### PR TITLE
Iterating on mattermost.server_daily_detail table and creation of mattermost.server_fact table

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/schema.yml
+++ b/transform/snowflake-dbt/models/mattermost/schema.yml
@@ -21,4 +21,4 @@ models:
     description: NPS scores and feedback
 
   - name: server_fact
-    description: Production server attributes including the date server was first and last active, the all-time max active users logged on the server, and the last date the server recorded active users.
+    description: Production server attributes including the server's first active date (telemetry-enabled), last active date (telemetry-enabled), the all-time max active users logged on the server, and the last date the server logged active users.

--- a/transform/snowflake-dbt/models/mattermost/schema.yml
+++ b/transform/snowflake-dbt/models/mattermost/schema.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: server_daily_details
-    description: Server daily details
+    description: Production server daily details table. Derived from event.security. Only includes production servers defined in TEDAS logic.
     columns:
       - name: server_id
         tests:

--- a/transform/snowflake-dbt/models/mattermost/schema.yml
+++ b/transform/snowflake-dbt/models/mattermost/schema.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: server_daily_details
-    description: Production server daily details table. Derived from event.security. Only includes production servers defined in TEDAS logic.
+    description: Production server daily details table. Derived from events.security. Only includes production servers defined by TEDAS logic.
     columns:
       - name: server_id
         tests:
@@ -19,3 +19,6 @@ models:
   
   - name: nps_data
     description: NPS scores and feedback
+
+  - name: server_fact
+    description: Production server attributes including the date server was first and last active, the all-time max active users logged on the server, and the last date the server recorded active users.

--- a/transform/snowflake-dbt/models/mattermost/server_daily_details.sql
+++ b/transform/snowflake-dbt/models/mattermost/server_daily_details.sql
@@ -4,34 +4,108 @@
   })
 }}
 
-WITH server_security_details AS (
-    SELECT
-  		id,
-  		date AS day,
-		MAX(user_count) AS user_count,
-  		MAX(active_user_count) AS active_user_count
-	FROM {{ ref('security') }}
+WITH security AS (
+    SELECT 
+        sec.id,
+        sec.date,
+        sec.hour,
+        sec.grouping, 
+        sec.ip_address,
+        sec.location,
+        sec.active_user_count,
+        sec.user_count,
+        sec.version,
+        sec.dev_build,
+        sec.db_type,
+        sec.os_type,
+        sec.ran_tests
+    FROM {{ ref('security') }} sec
+             LEFT JOIN {{ ref('excludable_servers') }} es
+                       ON sec.id = es.server_id
+    WHERE es.server_id IS NULL
+      AND sec.dev_build = 0
+      AND sec.ran_tests = 0
+      AND sec.version LIKE '_.%._._.%._'
+      AND sec.ip_address <> '194.30.0.184'
+      AND sec.user_count >= sec.active_user_count
     {% if is_incremental() %}
 
         -- this filter will only be applied on an incremental run
-        WHERE date > (SELECT MAX(day) FROM {{ this }})
+        and date > (SELECT MAX(day) FROM {{ this }})
 
     {% endif %}
-
-	GROUP BY 1, 2
-), server_daily_details AS (
-    SELECT 
-        day, 
-        account_sfid, 
-        license_id, 
-        server.user_id AS server_id,
-        active_user_count
-    FROM {{ source('mattermost2', 'server') }}
-    LEFT JOIN {{ source('mattermost2', 'license') }} ON license.user_id = server.user_id
-    LEFT JOIN {{ ref('license_overview') }} ON license_overview.licenseid = license.license_id
-    LEFT JOIN server_security_details ON server_security_details.id = license.user_id
-    GROUP BY 1, 2, 3, 4, 5
-)
+      ),
+     max_users AS (
+         SELECT 
+            sec.date,
+            coalesce(nullif(sec.id, ''), sec.ip_address) AS id,
+            max(sec.active_user_count)                   AS max_active_users,
+            count(sec.id)                                AS occurrences
+         FROM security sec
+         GROUP BY 1, 2
+         ),
+    max_hour AS (
+         SELECT 
+            s.date,
+            coalesce(nullif(s.id, ''), s.ip_address) AS id,
+            m.max_active_users,
+            m.occurrences,
+            max(s.hour)                              AS max_hour,
+            max(ip_address)                          AS max_ip,
+            max(version)                             AS max_version
+         FROM security s
+                  JOIN max_users m
+                       ON coalesce(nullif(s.id, ''), s.ip_address) = m.id
+                           AND s.date = m.date
+                           AND s.active_user_count = m.max_active_users
+         GROUP BY 1, 2, 3, 4
+         ),
+    server_security_details AS (
+        SELECT 
+            s.id,
+            s.date,
+            s.hour,
+            s.grouping, 
+            s.ip_address,
+            s.location,
+            s.active_user_count,
+            s.user_count,
+            s.version,
+            s.dev_build,
+            s.db_type,
+            s.os_type,
+            s.ran_tests
+        FROM security s
+                JOIN max_hour m
+                    ON coalesce(nullif(s.id, ''), s.ip_address) = m.id
+                        AND s.date = m.date
+                        AND s.active_user_count = m.max_active_users
+                        AND s.hour = m.max_hour
+                        AND s.ip_address = m.max_ip
+        GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
+    ),
+    server_daily_details AS (
+        SELECT 
+            s.id,
+            s.date,
+            s.hour,
+            s.grouping, 
+            s.ip_address,
+            s.location,
+            s.active_user_count,
+            s.user_count,
+            s.version,
+            s.dev_build,
+            s.db_type,
+            s.os_type,
+            s.ran_tests 
+            license_overview.account_sfid, 
+            license.license_id
+        FROM server_security_details
+        LEFT JOIN {{ source('mattermost2', 'license') }} ON license.user_id = server.user_id
+        LEFT JOIN {{ ref('license_overview') }} ON license_overview.licenseid = license.license_id
+        GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+    )
 
 SELECT * FROM server_daily_details
 

--- a/transform/snowflake-dbt/models/mattermost/server_daily_details.sql
+++ b/transform/snowflake-dbt/models/mattermost/server_daily_details.sql
@@ -31,31 +31,31 @@ WITH security AS (
     {% if is_incremental() %}
 
         -- this filter will only be applied on an incremental run
-        and date > (SELECT MAX(day) FROM {{ this }})
+        AND date > (SELECT MAX(day) FROM {{ this }})
 
     {% endif %}
       ),
      max_users AS (
          SELECT 
             sec.date,
-            coalesce(nullif(sec.id, ''), sec.ip_address) AS id,
-            max(sec.active_user_count)                   AS max_active_users,
-            count(sec.id)                                AS occurrences
+            COALESCE(NULLIF(sec.id, ''), sec.ip_address) AS id,
+            MAX(sec.active_user_count)                   AS max_active_users,
+            COUNT(sec.id)                                AS occurrences
          FROM security sec
          GROUP BY 1, 2
          ),
     max_hour AS (
          SELECT 
             s.date,
-            coalesce(nullif(s.id, ''), s.ip_address) AS id,
+            COALESCE(NULLIF(s.id, ''), s.ip_address) AS id,
             m.max_active_users,
             m.occurrences,
-            max(s.hour)                              AS max_hour,
-            max(ip_address)                          AS max_ip,
-            max(version)                             AS max_version
+            MAX(s.hour)                              AS max_hour,
+            MAX(ip_address)                          AS max_ip,
+            MAX(version)                             AS max_version
          FROM security s
                   JOIN max_users m
-                       ON coalesce(nullif(s.id, ''), s.ip_address) = m.id
+                       ON COALESCE(NULLIF(s.id, ''), s.ip_address) = m.id
                            AND s.date = m.date
                            AND s.active_user_count = m.max_active_users
          GROUP BY 1, 2, 3, 4
@@ -77,7 +77,7 @@ WITH security AS (
             s.ran_tests
         FROM security s
                 JOIN max_hour m
-                    ON coalesce(nullif(s.id, ''), s.ip_address) = m.id
+                    ON COALESCE(NULLIF(s.id, ''), s.ip_address) = m.id
                         AND s.date = m.date
                         AND s.active_user_count = m.max_active_users
                         AND s.hour = m.max_hour
@@ -95,16 +95,14 @@ WITH security AS (
             s.active_user_count,
             s.user_count,
             s.version,
-            s.dev_build,
             s.db_type,
             s.os_type,
-            s.ran_tests 
             license_overview.account_sfid, 
             license.license_id
         FROM server_security_details
         LEFT JOIN {{ source('mattermost2', 'license') }} ON license.user_id = server.user_id
         LEFT JOIN {{ ref('license_overview') }} ON license_overview.licenseid = license.license_id
-        GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+        GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
     )
 
 SELECT * FROM server_daily_details

--- a/transform/snowflake-dbt/models/mattermost/server_fact.sql
+++ b/transform/snowflake-dbt/models/mattermost/server_fact.sql
@@ -1,0 +1,16 @@
+{{config({
+    "materialized": 'table',
+    "schema": "mattermost"
+  })
+}}
+
+SELECT
+    id AS server_id,
+    account_sfid,
+    license_id,
+    min(date) as first_active_date,
+    max(date) AS last_active_date,
+    max(active_user_count) AS max_active_user_count,
+    max(case when active_user_count > 0 then date else null end) AS last_active_user_date
+FROM {{ ref('server_daily_details') }}
+GROUP BY 1, 2, 3;

--- a/transform/snowflake-dbt/models/mattermost/server_fact.sql
+++ b/transform/snowflake-dbt/models/mattermost/server_fact.sql
@@ -5,17 +5,17 @@
 }}
 
 WITH server_fact AS (
-    SELECT *
+    SELECT
+        id AS server_id,
+        account_sfid,
+        license_id,
+        MIN(date) AS first_active_date,
+        MAX(date) AS last_active_date,
+        MAX(active_user_count) AS max_active_user_count,
+        MAX(CASE WHEN active_user_count > 0 THEN date ELSE null END) AS last_active_user_date
     FROM {{ ref('server_daily_details') }}
+    GROUP BY 1, 2, 3
 )
 
-SELECT
-    id AS server_id,
-    account_sfid,
-    license_id,
-    MIN(date) AS first_active_date,
-    MAX(date) AS last_active_date,
-    MAX(active_user_count) AS max_active_user_count,
-    MAX(CASE WHEN active_user_count > 0 THEN date ELSE null END) AS last_active_user_date
-FROM server_fact
-GROUP BY 1, 2, 3;
+SELECT *
+FROM server_fact;

--- a/transform/snowflake-dbt/models/mattermost/server_fact.sql
+++ b/transform/snowflake-dbt/models/mattermost/server_fact.sql
@@ -4,13 +4,18 @@
   })
 }}
 
+WITH server_fact AS (
+    SELECT *
+    FROM {{ ref('server_daily_details') }}
+)
+
 SELECT
     id AS server_id,
     account_sfid,
     license_id,
-    min(date) as first_active_date,
-    max(date) AS last_active_date,
-    max(active_user_count) AS max_active_user_count,
-    max(case when active_user_count > 0 then date else null end) AS last_active_user_date
-FROM {{ ref('server_daily_details') }}
+    MIN(date) AS first_active_date,
+    MAX(date) AS last_active_date,
+    MAX(active_user_count) AS max_active_user_count,
+    MAX(CASE WHEN active_user_count > 0 THEN date ELSE null END) AS last_active_user_date
+FROM server_fact
 GROUP BY 1, 2, 3;


### PR DESCRIPTION
#### Summary
This PR is an iteration of the mattermost.server_daily_details table and creation of a new table: mattermost.server_fact. The new code provides additional logic in the server_daily_details table that prevents fanning out, duplicate server id's, and a variety of other data inaccuracies/impossibilities. The records that do appear in mattermost.server_daily_details are (our best guess at) verified production servers. This table is then used to create an aggregate fact table (mattermost.server_fact) that provides max and min details logged throughout the lifetime of these production servers, including: 

1. Server's first active date (telemetry-enabled) -> first_active_date.
2. Server's last active date (telemetry-enabled) -> last_active_date
3. Max active users logged on the server in a single day (all time) -> max_active_user_count
4. Last date the server logged active users -> last_active_user_date

The mattermost.server_daily_details table is a derivative of the events.security table. This table has several noted data anomalies including duplicate server id's and ip addresses. These anomalies can be explained by custom builds, dev and test servers, NATS and server clustering (message-oriented middleware).  The duplication leads to inaccuracy and skew when using the table to calculate TEDAS & TEDAU metrics. Producing the need for "clean" tables consisting of only daily production server details and all-time facts about these production servers.

#### Ticket Link
<!--
N/A
-->

