### PR TITLE
Server Upgrades Model

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/nightly/server_upgrades.sql
+++ b/transform/snowflake-dbt/models/mattermost/nightly/server_upgrades.sql
@@ -10,16 +10,27 @@ WITH upgrade         AS (
       , server_id
       , lag(version) OVER (PARTITION BY server_id ORDER BY date) AS prev_version
       , version                                                  AS current_version
+      , edition                                                  AS current_edition
+      , lag(edition) OVER (PARTITION BY server_id ORDER BY date) AS prev_edition
     FROM {{ ref('server_daily_details') }}
     WHERE NOT tracking_disabled
                         ),
      server_upgrades AS (
-         SELECT *
+         SELECT
+             date
+           , server_id
+           , substr(prev_version, 0, length(current_version)) AS prev_version
+           , substr(current_version, 0, length(prev_version)) AS current_version
+           , prev_edition
+           , current_edition
          FROM upgrade
-         WHERE substr(current_version, 0, length(prev_version)) > substr(prev_version, 0, length(current_version))
+         WHERE (substr(current_version, 0, length(prev_version)) >
+                coalesce(substr(prev_version, 0, length(current_version)),
+                         substr(current_version, 0, length(prev_version)))
+             OR (current_edition = 'true' AND coalesce(prev_edition, 'true') <> current_edition))
          {% if is_incremental() %}
-
-         AND date > (SELECT MAX(date) FROM {{this}})
+         
+         AND date > (SELECT MAX(date) FROM {{this}} )
 
          {% endif %}
      )

--- a/transform/snowflake-dbt/models/mattermost/nightly/server_upgrades.sql
+++ b/transform/snowflake-dbt/models/mattermost/nightly/server_upgrades.sql
@@ -1,0 +1,23 @@
+{{config({
+    "materialized": 'incremental',
+    "schema": "mattermost"
+  })
+}}
+
+WITH server_upgrades AS (
+    SELECT
+        date
+      , server_id
+      , lag(version) OVER (PARTITION BY server_id ORDER BY date) AS prev_version
+      , version                                                  AS current_version
+    FROM {{ ref('server_daily_details') }}
+    WHERE NOT tracking_disabled
+                )
+SELECT *
+FROM server_upgrades
+WHERE substr(current_version, 0, length(prev_version)) > substr(prev_version, 0, length(current_version))
+{% if is_incremental %}
+
+AND date > (SELECT MAX(date) FROM {{this}})
+
+{% endif %}

--- a/transform/snowflake-dbt/models/mattermost/nightly/server_upgrades.sql
+++ b/transform/snowflake-dbt/models/mattermost/nightly/server_upgrades.sql
@@ -24,4 +24,4 @@ WITH upgrade         AS (
          {% endif %}
      )
 SELECT *
-FROM server_upgrades;
+FROM server_upgrades

--- a/transform/snowflake-dbt/models/mattermost/schema.yml
+++ b/transform/snowflake-dbt/models/mattermost/schema.yml
@@ -37,3 +37,6 @@ models:
 
   - name: user_daily_details
     description: Contains a daily snapshot of a users state and all time usage/activity up to that date including activity, events, nps, server/account/license details.
+
+  - name: server_upgrades
+    description: Contains each instance a server upgraded from one version to a different, greater version.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Building model to track server upgrades by version and from TE -> EE. Model will be in mattermost schema (mattermost.server_upgrades). It will contain every instance where a server changes from an older server version to a newer or switches from edition = false to edition = true. These changes are tracked via the server_daily_details model and a window function partitioned by the server_id and ordered by date is used to identify upgrades.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

