### PR TITLE
Add more names to the staff list

### DIFF
--- a/transform/snowflake-dbt/data/staff_github_usernames.csv
+++ b/transform/snowflake-dbt/data/staff_github_usernames.csv
@@ -154,3 +154,7 @@ JustinReynolds-MM
 dependabot
 GoldUniform
 jasonlanderson
+lynn915
+dependabot-preview
+comharris
+joewaitye


### PR DESCRIPTION
Wondering if we need to sync against Bamboo at some point to ensure all past and future staff are included in this list?
