### PR TITLE
Remove community members (contributors & customers) from exclusion list

### DIFF
--- a/transform/snowflake-dbt/data/staff_github_usernames.csv
+++ b/transform/snowflake-dbt/data/staff_github_usernames.csv
@@ -23,7 +23,6 @@ flexo3001
 srkgupta
 coreyhulen
 cpoile
-rvillablanca
 Willyfrog
 agnivade
 ashishbhate
@@ -33,7 +32,6 @@ matthewbirtch
 isacikgoz
 iomodo
 jwilander
-wget
 crspeller
 fmunshi
 migbot
@@ -58,8 +56,6 @@ jfrerich
 corey-robinson
 lfbrock
 jaydeland
-csduarte
-cometkim
 metanerd
 mattermost-build
 asaadmahmood
@@ -83,7 +79,6 @@ rbradleyhaas
 angeloskyratzakos
 ali-farooq0
 lindalumitchell
-avasconcelos114
 amyblais
 michaelgamble
 DHaussermann
@@ -103,7 +98,6 @@ ccbrown
 MusikPolice
 stephenkiers
 rgarmsen2295
-yuya-oc
 DavidLu1997
 thekiiingbob
 atti1a
@@ -148,7 +142,6 @@ ccbrown
 MusikPolice
 stephenkiers
 rgarmsen2295
-yuya-oc
 DavidLu1997
 thekiiingbob
 atti1a


### PR DESCRIPTION
They are core committers and hence part of the Mattermost org, but not employees

@rbradleyhaas 