### PR TITLE
Add previous staff to GitHub contributor exclusion list

### DIFF
--- a/transform/snowflake-dbt/data/staff_github_usernames.csv
+++ b/transform/snowflake-dbt/data/staff_github_usernames.csv
@@ -185,3 +185,8 @@ HilaryClarke
 faase
 jwayman
 weblate
+fmunshi
+ali-farooq0
+michaelschiffmm
+chuttam
+imisshtml


### PR DESCRIPTION
@rbradleyhaas I wonder if we can include this in our offboarding process, since they are affecting community stats?