### PR TITLE
Add DAG for running the nightly billing in the BLAPI test environment

### DIFF
--- a/dags/billing/nightly_test.py
+++ b/dags/billing/nightly_test.py
@@ -1,0 +1,53 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from dags.airflow_utils import (
+    DATA_IMAGE,
+    clone_and_setup_extraction_cmd,
+    mm_failed_task,
+    pod_defaults,
+    pod_env_vars,
+    xs_warehouse,
+)
+from dags.kube_secrets import BLAPI_TEST_DATABASE_URL, BLAPI_TEST_TOKEN, BLAPI_TEST_URL
+
+# Load the env vars into a dict and set Secrets
+env = os.environ.copy()
+env_vars = {**pod_env_vars, **{}}
+
+# Default arguments for the DAG
+default_args = {
+    "catchup": False,
+    "depends_on_past": False,
+    "owner": "airflow",
+    "on_failure_callback": mm_failed_task,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=1),
+    "sla": timedelta(hours=8),
+    "start_date": datetime(2020, 10, 16, 0, 0, 0),
+}
+
+# We purposely don't run this job on the first day of the month, because stripe will
+# create the draft invoices for the previous month and we handle that in blapi directly
+dag = DAG(
+    "test_env_nightly_billing", default_args=default_args, schedule_interval="0 1 2-31 * *"
+)
+
+
+run_nightly_billing_cmd = f"""
+    {clone_and_setup_extraction_cmd} &&
+    python billing/run_nightly_billing.py
+"""
+
+run_nightly_billing = KubernetesPodOperator(
+    **pod_defaults,
+    image=DATA_IMAGE,
+    task_id="test-env-run-nightly-billing",
+    name="test-env-run-nightly-billing",
+    secrets=[BLAPI_TEST_DATABASE_URL, BLAPI_TEST_TOKEN, BLAPI_TEST_URL],
+    env_vars=env_vars,
+    arguments=[run_nightly_billing_cmd],
+    dag=dag,
+)

--- a/dags/kube_secrets.py
+++ b/dags/kube_secrets.py
@@ -15,6 +15,10 @@ BLAPI_DATABASE_URL = Secret(
 BLAPI_TOKEN = Secret("env", "BLAPI_TOKEN", "airflow", "BLAPI_TOKEN")
 BLAPI_URL = Secret("env", "BLAPI_URL", "airflow", "BLAPI_URL")
 
+BLAPI_TEST_URL = Secret("env", "BLAPI_TEST_URL", "airflow", "BLAPI_TEST_URL")
+BLAPI_TEST_TOKEN = Secret("env", "BLAPI_TEST_TOKEN", "airflow", "BLAPI_TEST_TOKEN")
+BLAPI_TEST_DATABASE_URL = Secret("env", "BLAPI_TEST_DATABASE_URL", "airflow", "BLAPI_TEST_DATABASE_URL")
+
 # dbt Cloud
 DBT_CLOUD_API_KEY = Secret("env", "DBT_CLOUD_API_KEY", "airflow", "DBT_CLOUD_API_KEY")
 DBT_CLOUD_API_ACCOUNT_ID = Secret(


### PR DESCRIPTION
#### Summary
We want to be able to see the nightly billing calculations throughout the month on the test environment, in order to help us catch issues earlier, as well as help test future BLAPI changes. 

This PR adds a DAG to run the nightly billing, along with 3 new secrets to point this particular DAG at the BLAPI Test environment rather than production.

#### Ticket Link
n/a

