### PR TITLE
Fix resp not being defined when blapi connection errors out

### DIFF
--- a/billing/run_nightly_billing.py
+++ b/billing/run_nightly_billing.py
@@ -59,6 +59,7 @@ def main():
             retries = 0
             url = f"{blapi_url}/api/v1/customer/{sub['customer_id']}/subscriptions/{sub['id']}/invoice/build"
 
+            resp = None
             while retries < 5:
                 try:
                     retries += 1
@@ -67,7 +68,7 @@ def main():
                 except requests.exceptions.ConnectionError:
                     pass
 
-            if resp.status_code != requests.codes.ok:
+            if resp and resp.status_code != requests.codes.ok:
                 message = f"Error building invoice for subscription {sub['id']} with dates {start_date}-{end_date}"
                 logging.error(message)
                 errors.append(message)


### PR DESCRIPTION
#### Summary
Resp variable isn't defined so it breaks because BLAPI is returning a non-200 for some subscriptions
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

