### PR TITLE
Preserve the pod after it finishes running

### DIFF
--- a/dags/billing/nightly_test.py
+++ b/dags/billing/nightly_test.py
@@ -50,4 +50,5 @@ run_nightly_billing = KubernetesPodOperator(
     env_vars=env_vars,
     arguments=[run_nightly_billing_cmd],
     dag=dag,
+    is_delete_operator_pod=False,
 )


### PR DESCRIPTION

#### Summary
Having issues debugging this because the pod is deleted immediately. This should preserve it for poking around.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

