### PR TITLE
Revert last pr breaking license table

### DIFF
--- a/transform/snowflake-dbt/models/blp/license_server_fact.sql
+++ b/transform/snowflake-dbt/models/blp/license_server_fact.sql
@@ -464,7 +464,7 @@ SELECT
           ELSE FALSE END) AS customer_license_users
 FROM license_server_fact l
 LEFT JOIN server_activity activity
-    ON l.server_id = activity.server_id
+    ON l.server_id = activity.server_id 
 
 {% if is_incremental() %}
 
@@ -474,3 +474,5 @@ WHERE
   last_active_date::date >= (SELECT MAX(last_active_date::date) - INTERVAL '1 DAY' FROM {{this}})
 
 {% endif %}
+QUALIFY ROW_NUMBER() OVER (PARTITION BY L.id ORDER BY ISSUED_DATE) = 1
+

--- a/transform/snowflake-dbt/models/blp/license_server_fact.sql
+++ b/transform/snowflake-dbt/models/blp/license_server_fact.sql
@@ -12,14 +12,75 @@
 
 {% endif %}
 
-with license_union as (
-  SELECT *
-  FROM {{ ref('licensed_servers') }}
-  
+with licensed_servers as (
+SELECT
+    {{ dbt_utils.surrogate_key(['l.license_id', 'l.server_id']) }} as id
+  , l.server_id
+  , l.license_id
+  , MAX(trim(COALESCE(am.company, l.company, s.company))) AS company
+  , MAX(COALESCE(am.edition, l.edition)) AS edition
+  , MAX(l.users)   AS users
+  , l.trial
+  , MIN(l.issued_date::date) AS issued_date
+  , MIN(l.start_date::date) AS start_date
+  , MAX(l.expire_date::date) AS expire_date
+  , MAX(trim(lower(l.license_email))) AS license_email
+  , MAX(COALESCE(am.contact_sfid, l.contact_sfid)) AS contact_sfid
+  , MAX(COALESCE(am.account_sfid, l.account_sfid, s.account_sfid)) AS account_sfid
+  , MAX(COALESCE(am.account_name, l.account_name, s.account_name)) AS account_name
+  , MAX(am.opportunity_sfid) AS opportunity_sfid
+  , l.stripeid
+  , l.customer_id
+  , MIN(l.license_activation_date) AS license_activation_date
+  , MAX(l.timestamp)  AS last_active_date
+  , MIN(s.first_active_date) AS server_activation_date
+FROM {{ ref('licenses') }} l
+LEFT JOIN {{ ref('server_fact') }} s
+  ON l.server_id = s.server_id
+LEFT JOIN  {{ ref('account_mapping') }} am
+  ON l.license_id = am.license_id
+WHERE l.server_id IS NOT NULL
+AND l.license_id <> '16tfkttgktgdmb5m8xakqncx3c'
+AND l.issued_date::DATE <= CURRENT_DATE
+GROUP BY 1, 2, 3, 7, 16, 17
+), 
+nonactivated_licenses as (
+  SELECT
+    {{ dbt_utils.surrogate_key(['l.license_id', 'l.server_id']) }} as id
+  , l.server_id
+  , l.license_id
+  , MAX(trim(coalesce(am.company, l.company))) AS company
+  , MAX(COALESCE(am.edition, l.edition)) AS edition
+  , MAX(l.users)   AS users
+  , l.trial
+  , MIN(l.issued_date::date) AS issued_date
+  , MIN(l.start_date::date) AS start_date
+  , MAX(l.expire_date::date) AS expire_date
+  , MAX(trim(lower(l.license_email))) AS license_email
+  , MAX(COALESCE(am.contact_sfid, l.contact_sfid)) AS contact_sfid
+  , MAX(COALESCE(am.account_sfid, l.account_sfid)) AS account_sfid
+  , MAX(COALESCE(am.account_name, l.account_name)) AS account_name
+  , MAX(am.opportunity_sfid) AS opportunity_sfid
+  , l.stripeid
+  , l.customer_id
+  , MIN(l.license_activation_date) AS license_activation_date
+  , MAX(l.timestamp)  AS last_active_date
+  , MIN(NULL) AS server_activation_date
+  FROM {{ ref('licenses') }} l
+  LEFT JOIN licensed_servers s
+    ON l.license_id = s.license_id
+  LEFT JOIN {{ ref('account_mapping') }} am
+    ON l.license_id = am.license_id       
+  WHERE s.license_id is null
+  AND l.license_id <> '16tfkttgktgdmb5m8xakqncx3c'
+  AND l.issued_date::DATE <= CURRENT_DATE
+  GROUP BY 1, 2, 3, 7, 16, 17
+)
+, license_union as (
+  SELECT *  FROM licensed_servers
   UNION ALL
+  select * from nonactivated_licenses
 
-  SELECT *
-  FROM {{ ref('nonactivated_licenses') }}
 ),
 
 last_server_telemetry as (
@@ -38,6 +99,71 @@ server_activity AS (
        ON a1.server_id = a2.server_id
        AND a1.date = a2.max_date
 ),
+max_sku AS (
+  SELECT DISTINCT
+      s1.subscription
+    , MAX(s1.plan_name) AS plan_name
+  FROM {{ ref('subscription_items')}} s1
+  JOIN (
+    SELECT
+        subscription
+      , MAX(plan_amount) as max_amount
+    FROM {{ ref('subscription_items')}}
+    GROUP BY 1
+  ) s2
+      ON s1.subscription = s2.subscription
+      AND s1.plan_amount = s2.max_amount
+  GROUP BY 1
+),
+
+cloud_subscriptions AS (
+  SELECT 
+      {{ dbt_utils.surrogate_key(['s.cws_installation', 'coalesce(sf.server_id, server.user_id)'])}}               AS id
+    , COALESCE(sf.server_id, server.user_id)                       AS server_id
+    , s.cws_installation                                           AS license_id
+    , COALESCE(am.account_sfid, c.cws_customer)                                               AS customer_id
+    , COALESCE(am.account_name, INITCAP(SPLIT_PART(replace(s.cws_dns, '-', ' '), '.', 1)))    AS customer_name
+    , INITCAP(SPLIT_PART(replace(s.cws_dns, '-', ' '), '.', 1))    AS company
+    , COALESCE(am.edition, ms.plan_name, 'Mattermost Cloud')       AS edition
+    , s.quantity                                                   AS users
+    , FALSE                                                        AS trial
+    , MIN(s.created::DATE)                                         AS issued_date
+    , COALESCE(MIN(sf.first_active_date::date), 
+               MIN(server.timestamp::date), 
+               MIN(s.current_period_start::DATE))                  AS start_date
+    , MAX(s.current_period_end::DATE)                              AS expire_date
+    , c.email                                                      AS license_email
+    , MAX(COALESCE(am.contact_sfid, NULL))                                                         AS contact_sfid
+    , MAX(COALESCE(am.account_sfid, NULL))                                                         AS account_sfid
+    , MAX(COALESCE(am.account_name, NULL))                                                        AS account_name
+    , MAX(COALESCE(am.opportunity_sfid, NULL))                                                     AS opportunity_sfid
+    , c.id                                                         AS stripeid
+    , c.cws_customer                                               AS license_customer_id
+    , s.created::TIMESTAMP                                         AS license_activation_date
+    , COALESCE(MAX(sf.last_active_date::TIMESTAMP), 
+        MAX(server.timestamp::TIMESTAMP))                          AS last_active_date
+    , COALESCE(MIN(sf.first_active_date::DATE),
+        MIN(server.timestamp::DATE))                               AS server_activation_date
+    , 1                                                            AS license_rank
+    , 1                                                            AS license_priority_rank
+    , s.current_period_end::DATE                                   AS license_retired_date
+  FROM {{ ref('subscriptions') }}             s
+        LEFT JOIN {{ ref('customers') }}       c
+                  ON s.customer = c.id
+        LEFT JOIN {{ ref('server_fact') }} sf
+                  ON s.cws_installation = sf.installation_id
+        LEFT JOIN {{ source('mm_telemetry_prod', 'server') }} server
+                  ON s.cws_installation = server.context_traits_installationid
+                      AND server.context_traits_installationid IS NOT NULL
+        LEFT JOIN max_sku ms
+                  ON s.id = ms.subscription
+        LEFT JOIN {{ ref('account_mapping') }} am
+                  ON s.cws_installation = am.license_id
+  WHERE s.cws_installation IS NOT NULL
+  AND s.created::DATE <= CURRENT_DATE
+  GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 13, 18, 19, 20
+  , 23, 24, 25
+) ,
 license_server_fact as (
 SELECT 
         id
@@ -168,7 +294,7 @@ FROM license_union
 UNION ALL
 
 SELECT *
-FROM {{ ref('cloud_subscriptions_blp') }}
+FROM cloud_subscriptions
 WHERE license_id NOT IN (select license_id from license_union group by 1)
 )
 
@@ -339,6 +465,7 @@ SELECT
 FROM license_server_fact l
 LEFT JOIN server_activity activity
     ON l.server_id = activity.server_id
+
 {% if is_incremental() %}
 
 WHERE 


### PR DESCRIPTION
1) The last PR didn't fix the issue, as more duplicate rows kept coming in with the same dbt generated ID (a combination of server_id and license_id). To fix the issue, we are adding a Qualify statement to pick the original row, so the dbt job stops failing and we can investigate the new data later.

2) The change has been tested locally in production.

![image](https://user-images.githubusercontent.com/96433562/151588601-117144c8-41ac-4e1b-b779-4ca29b8eb819.png)


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

