### PR TITLE
MM-41737 Adding community MM data from mm_telemetry_rc to performance_events

### DIFF
--- a/transform/snowflake-dbt/models/events/nightly/performance_events.sql
+++ b/transform/snowflake-dbt/models/events/nightly/performance_events.sql
@@ -6,6 +6,7 @@
   })
 }}
 
-{% set rudder_relations = get_rudder_relations(schema=["mm_telemetry_prod"], database='RAW', 
+{% set rudder_relations = get_rudder_relations(schema=["mm_telemetry_prod","mm_telemetry_rc"], database='RAW', 
                           table_inclusions="'event'") %}
 {{ union_relations(relations = rudder_relations[0], tgt_relation = rudder_relations[1]) }}
+


### PR DESCRIPTION
1) Impact: `EVENTS.PERFORMANCE_EVENTS` is only looking at production data. Community Mattermost is sending data to `MM_TELEMETRY_RC`, this PR apends Community Mattermost data from `MM_TELEMETRY_RC ` to Production data. 
The source of the data which is `MM_TELEMETRY_RC` can be derived from `_dbt_source_relation` column, so there is a clear distinguish between `prod `and `rc`. There is no impact to production data, as we are only adding new data.
2) Testing: The changes have been tested fully in my local environment. 

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

