### PR TITLE
MM-41868 Added license_id to surrogate key to fix dbt nightly job

### DIFF
--- a/transform/snowflake-dbt/models/staging/server/server_license_details.sql
+++ b/transform/snowflake-dbt/models/staging/server/server_license_details.sql
@@ -104,7 +104,7 @@ WITH license_daily_details as (
            , MAX(feature_saml)                        AS feature_saml
            , MAX(issued_date)                         AS issued_date
            , MAX(users)                               AS users
-           , {{ dbt_utils.surrogate_key(['d.date','d.server_id'])}} AS id
+           , {{ dbt_utils.surrogate_key(['d.date','license_id','d.server_id'])}} AS id
            , MAX(installation_id)                     AS installation_id
            , MAX(feature_advanced_logging)            AS feature_advanced_logging
            , MAX(feature_cloud)                       AS feature_cloud


### PR DESCRIPTION
1) Impact: The dbt nightly job is failing as there is a conflict between an E10 and E20 Trial license, which were issued on the same day. Adding license_id to the surrogate key will fix the issue and dbt nightly job will no longer fail.
2) Testing: Changes have been fully tested in a local environment.

More information in the Jira Ticket. 

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

