### PR TITLE
Adding new retention flag and user counts to server_fact

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
@@ -259,15 +259,22 @@ WITH sdd AS (
       , DATEDIFF(DAY, MIN(TIMESTAMP::DATE), CURRENT_DATE) - COUNT(DISTINCT TIMESTAMP::DATE) AS days_inactive
       , MIN(CASE WHEN COALESCE(type, event) IN ('ui_marketplace_download', 'api_install_marketplace_plugin') THEN timestamp::date ELSE NULL END) as first_plugin_install_date
       , COUNT(DISTINCT CASE WHEN COALESCE(type, event) IN ('ui_marketplace_download') THEN plugin_id ELSE NULL END) AS plugins_downloaded
-      , MAX(CASE WHEN user_events_telemetry.timestamp between sdd.first_active_date + INTERVAL '24 HOURS' AND sdd.first_active_date + INTERVAL '48 HOURS' 
+      , MAX(CASE WHEN user_events_telemetry.timestamp between sdd.first_active_date + INTERVAL '24 HOURS' AND sdd.first_active_date + INTERVAL '48 HOURS'
                     THEN TRUE ELSE FALSE END) AS retention_1day_flag
       , COUNT(DISTINCT CASE WHEN user_events_telemetry.timestamp between sdd.first_active_date + INTERVAL '24 HOURS' AND sdd.first_active_date + INTERVAL '48 HOURS' 
                     THEN user_events_telemetry.user_actual_id ELSE NULL END) AS retention_1day_users
+      , MAX(CASE WHEN user_events_telemetry.timestamp between sdd.first_active_date + INTERVAL '168 HOURS' AND sdd.first_active_date + INTERVAL '192 HOURS'  
+                    THEN TRUE ELSE FALSE END) AS retention_7day_flag
+      , COUNT(DISTINCT CASE WHEN user_events_telemetry.timestamp between sdd.first_active_date + INTERVAL '168 HOURS' AND sdd.first_active_date + INTERVAL '192 HOURS' 
+                    THEN user_events_telemetry.user_actual_id ELSE NULL END) AS retention_7day_users
+      , MAX(CASE WHEN user_events_telemetry.timestamp between sdd.first_active_date + INTERVAL '336 HOURS' AND sdd.first_active_date + INTERVAL '360 HOURS'  
+                    THEN TRUE ELSE FALSE END) AS retention_14day_flag
+      , COUNT(DISTINCT CASE WHEN user_events_telemetry.timestamp between sdd.first_active_date + INTERVAL '336 HOURS' AND sdd.first_active_date + INTERVAL '360 HOURS' 
+                    THEN user_events_telemetry.user_actual_id ELSE NULL END) AS retention_14day_users
       , MAX(CASE WHEN user_events_telemetry.timestamp between sdd.first_active_date + INTERVAL '672 HOURS' AND sdd.first_active_date + INTERVAL '696 HOURS' 
                     THEN TRUE ELSE FALSE END) AS retention_28day_flag
       , COUNT(DISTINCT CASE WHEN user_events_telemetry.timestamp between sdd.first_active_date + INTERVAL '672 HOURS' AND sdd.first_active_date + INTERVAL '696 HOURS' 
                     THEN user_events_telemetry.user_actual_id ELSE NULL END) AS retention_28day_users
-
       , COUNT(DISTINCT user_events_telemetry.user_actual_id) as active_users_alltime
     FROM sdd 
     JOIN {{ ref('user_events_telemetry') }}
@@ -402,6 +409,10 @@ WITH sdd AS (
         , MAX(server_details.last_active_user_date) AS last_active_user_date
         , MAX(lsd.retention_1day_flag) AS retention_1day_flag
         , MAX(lsd.retention_1day_users) AS retention_1day_users
+        , MAX(lsd.retention_7day_flag) AS retention_7day_flag
+        , MAX(lsd.retention_7day_users) AS retention_7day_users
+        , MAX(lsd.retention_14day_flag) AS retention_14day_flag
+        , MAX(lsd.retention_14day_users) AS retention_14day_users
         , MAX(lsd.retention_28day_flag) AS retention_28day_flag
         , MAX(lsd.retention_28day_users) AS retention_28day_users
         , MAX(COALESCE(nullif(TRIM(server_activity.last_ip_address), ''), NULLIF(fse.last_ip_address, ''))) AS last_ip_address


### PR DESCRIPTION
Impact: Adding new retention flag and user counts to server_fact to feed the requirement for Growth Scorecard.

Testing: Changes have been tested locally within Snowflake.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

