### PR TITLE
Adding Distinct to remove duplicates from the user_retention table

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/hourly/user_retention.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/user_retention.sql
@@ -32,7 +32,7 @@ WITH first_active AS (
     {% endif %}
     GROUP BY 1, 2, 3, 4, 5
 )
-SELECT
+SELECT DISTINCT 
       first_active.first_active_timestamp
   ,   first_active.server_id
   ,   first_active.user_actual_id AS user_id


### PR DESCRIPTION
Impact: Without distinct there are a lot of duplicate rows in the table, which is added processing for Looker.

Testing: The table has been cleaned up using the new code.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

