### PR TITLE
MM-42708 Adding dbt_source_relation and fixed context_user_agent field

### DIFF
--- a/transform/snowflake-dbt/models/events/nightly/user_events_by_date.sql
+++ b/transform/snowflake-dbt/models/events/nightly/user_events_by_date.sql
@@ -299,7 +299,6 @@ mobile_events2 AS (
           WHERE e.max_timestamp > (SELECT MAX(max_timestamp) from {{this}} )
 
          {% endif %}
-         where e.max_timestamp::date > '2020-12-31'
          GROUP BY 1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 19
      ),
 

--- a/transform/snowflake-dbt/models/events/nightly/user_events_by_date.sql
+++ b/transform/snowflake-dbt/models/events/nightly/user_events_by_date.sql
@@ -294,11 +294,7 @@ mobile_events2 AS (
               LEFT JOIN {{ ref('events_registry') }} r
                    ON e.event_name = r.event_name
                    AND e.category = r.event_category
-         {% if is_incremental() %}
 
-          WHERE e.max_timestamp > (SELECT MAX(max_timestamp) from {{this}} )
-
-         {% endif %}
          GROUP BY 1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 19
      ),
 


### PR DESCRIPTION
Impact: 
1) The code for incremental is looking for the  `MAX(max_timestamp) from {{this}}`, which would be incorrect and dropping some rows everytime the code runs, since the max `MAX(max_timestamp) from {{this}}`, might not be the same for all the sources, as we are pulling data from multiple sources (mobile and desktop in this table). By adding the name of the source, and fetching the `MAX(max_timestamp) from {{this}} where source_relation = source_name` for the individual source would be the correct incremental implementation, without dropping any data.
2) For the desktop, we collected data in the field `context_useragent`, this has changed on April 16th 2021 to `context_user_agent`. Adding `coalesce(context_useragent, context_user_agent)` for the Desktop source, fixes this issue. 

Testing: Changes have been tested locally and the dashboard has been fixed. Data has been updated only from 2021 onwards, since the RAW events table is huge, and the query is resource consuming.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

