### PR TITLE
License activation signal

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/operations/lead_update_trial_activation.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/lead_update_trial_activation.sql
@@ -5,7 +5,7 @@
 }}
 
 with lead_update_trial_activation as (
-  select l.Id, l.Email, l.Trial_License_Id__c, lsf.LICENSE_ACTIVATION_DATE as Activation_Date
+  select l.Id, l.Trial_License_Id__c, lsf.LICENSE_ACTIVATION_DATE as Activation_Date
   from {{ ref('lead') }} l 
   left join {{ ref('license_server_fact') }} lsf on lsf.LICENSE_ID = l.Trial_License_Id__c -- on lsf.LICENSE_EMAIL = l.Email
   where lsf.LICENSE_ACTIVATION_DATE is not null and 

--- a/transform/snowflake-dbt/models/hightouch/operations/lead_update_trial_activation.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/lead_update_trial_activation.sql
@@ -10,8 +10,7 @@ with lead_update_trial_activation as (
   left join {{ ref('license_server_fact') }} lsf on lsf.LICENSE_ID = l.Trial_License_Id__c -- on lsf.LICENSE_EMAIL = l.Email
   where lsf.LICENSE_ACTIVATION_DATE is not null and 
   l.Trial_License_Id__c is not null and
-  l.Trial_Activation_Date__c is null and
-  DATEDIFF(day, lsf.START_DATE, current_timestamp) < 14
+  l.Trial_Activation_Date__c is null
 )
 
-select Id, Trial_License_Id__c, Activation_Date from lead_update_trial_activation
+select distinct Id, Trial_License_Id__c, Activation_Date from lead_update_trial_activation

--- a/transform/snowflake-dbt/models/hightouch/operations/lead_update_trial_activation.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/lead_update_trial_activation.sql
@@ -1,0 +1,15 @@
+{{config({
+    "materialized": 'table',
+    "schema": "hightouch"
+  })
+}}
+
+with lead_update_trial_activation as (
+  select l.Id, l.Email, l.Trial_License_Id__c, lsf.LICENSE_ACTIVATION_DATE as Trial_Activation_Date__c
+  from {{ ref('lead') }} l 
+  left join {{ ref('license_server_fact') }} lsf on lsf.LICENSE_EMAIL = l.Email -- on lsf.LICENSE_ID = l.Trial_License_Id__c
+  where lsf.LICENSE_ACTIVATION_DATE is not null and 
+  l.Trial_License_Id__c is not null
+)
+
+select Id, Trial_Activation_Date__c from lead_update_trial_activation

--- a/transform/snowflake-dbt/models/hightouch/operations/lead_update_trial_activation.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/lead_update_trial_activation.sql
@@ -5,11 +5,12 @@
 }}
 
 with lead_update_trial_activation as (
-  select l.Id, l.Email, l.Trial_License_Id__c, lsf.LICENSE_ACTIVATION_DATE as Trial_Activation_Date__c
+  select l.Id, l.Email, l.Trial_License_Id__c, lsf.LICENSE_ACTIVATION_DATE as Activation_Date
   from {{ ref('lead') }} l 
   left join {{ ref('license_server_fact') }} lsf on lsf.LICENSE_EMAIL = l.Email -- on lsf.LICENSE_ID = l.Trial_License_Id__c
   where lsf.LICENSE_ACTIVATION_DATE is not null and 
-  l.Trial_License_Id__c is not null
+  l.Trial_License_Id__c is not null and
+  l.Trial_Activation_Date__c is null
 )
 
-select Id, Trial_Activation_Date__c from lead_update_trial_activation
+select Id, Activation_Date from lead_update_trial_activation

--- a/transform/snowflake-dbt/models/hightouch/operations/lead_update_trial_activation.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/lead_update_trial_activation.sql
@@ -7,10 +7,11 @@
 with lead_update_trial_activation as (
   select l.Id, l.Email, l.Trial_License_Id__c, lsf.LICENSE_ACTIVATION_DATE as Activation_Date
   from {{ ref('lead') }} l 
-  left join {{ ref('license_server_fact') }} lsf on lsf.LICENSE_EMAIL = l.Email -- on lsf.LICENSE_ID = l.Trial_License_Id__c
+  left join {{ ref('license_server_fact') }} lsf on lsf.LICENSE_ID = l.Trial_License_Id__c -- on lsf.LICENSE_EMAIL = l.Email
   where lsf.LICENSE_ACTIVATION_DATE is not null and 
   l.Trial_License_Id__c is not null and
-  l.Trial_Activation_Date__c is null
+  l.Trial_Activation_Date__c is null and
+  DATEDIFF(day, lsf.START_DATE, current_timestamp) < 14
 )
 
-select Id, Activation_Date from lead_update_trial_activation
+select Id, Trial_License_Id__c, Activation_Date from lead_update_trial_activation


### PR DESCRIPTION


#### Summary
Adds a hightouch model that joins the salesforce lead table with the license server fact table on license id, and returns rows when the lsf table has an activation date and the lead table doesn't
