### PR TITLE
Adding max_original_timestamp to focalboard_user_retention

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/hourly/focalboard_user_retention.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/focalboard_user_retention.sql
@@ -36,6 +36,7 @@ SELECT DISTINCT
   WHEN (MAX(fet2.ORIGINAL_TIMESTAMP::DATE) - first_active.first_active_timestamp::DATE) >=7 
   AND (MAX(fet2.ORIGINAL_TIMESTAMP::DATE) - first_active.first_active_timestamp::DATE) < 28 THEN 'AGE 7 - 27'
   WHEN (MAX(fet2.ORIGINAL_TIMESTAMP::DATE) - first_active.first_active_timestamp::DATE) >= 28 THEN 'AGE 28+' END as AGE
+   , MAX(fet2.ORIGINAL_TIMESTAMP::DATE) as MAX_ORIGINAL_TIMESTAMP
 FROM first_active
      LEFT JOIN {{ ref('focalboard_event_telemetry') }} fet2
           ON fet2.user_actual_id = first_active.user_actual_id


### PR DESCRIPTION
Impact: Adding max_original_timestamp to focalboard_user_retention, for Focalboard Cohort analysis.

Testing: Changes have been tested and Looker changes also merged, the plot is failing to update because this field is missing.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

