### PR TITLE
MM - 43454 Fixing server_fact and adding a server to excludable_server_seed

### DIFF
--- a/transform/snowflake-dbt/data/excludable_servers_seed.csv
+++ b/transform/snowflake-dbt/data/excludable_servers_seed.csv
@@ -337,3 +337,4 @@ test_server,rzwpox355f8h3du3ko95ojnq1a
 test_server,uqngy3ti5fftbxmtzm3u16budw
 test_server,qqztsmoh43b78bfron8kb31c1o
 test_server,etu71c5z5tdj8fuwkyib9i4cha
+test_server,hbk7k4yhqprw7rc4k3nqpcb3uh


### PR DESCRIPTION
Impact: Server_fact table which uses server_daily_details as source, is dropping new servers. I observed this when I did a full refresh of the server_fact table and all the plots got updated with this new server data. Adding a not exists clause fixes this issue and server_fact wouldn't drop any rows. Also adding an exclusion server to excludable server seed file.

Testing: Changes have been tested locally and this PR works as expected.

![image](https://user-images.githubusercontent.com/96433562/164344420-48efc984-a6b2-4b11-a5bf-7507a6ffad8d.png)
![image](https://user-images.githubusercontent.com/96433562/164344452-b7843735-3ce1-4c5b-b4aa-ff1e0b68691f.png)


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

