### PR TITLE
Update to server_fact fix from the last PR #905

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
@@ -30,7 +30,7 @@ WITH sdd AS (
             , MAX(CASE WHEN in_mm2_server THEN timestamp ELSE NULL END)                           AS last_mm2_telemetry_date
             FROM {{ ref('server_daily_details') }} SDD
             WHERE timestamp <= CURRENT_TIMESTAMP 
-            OR NOT EXISTS (SELECT 1 FROM {{this}} SF WHERE SF.SERVER_ID = SDD.SERVER_ID)
+            OR NOT EXISTS (SELECT 1 FROM {{this}} SF WHERE SF.SERVER_ID = SDD.SERVER_ID AND SDD.timestamp <= CURRENT_TIMESTAMP)
             GROUP BY 1
             {% if is_incremental() %}
             HAVING MAX(CASE WHEN in_security OR in_mm2_server THEN timestamp ELSE NULL END) > (SELECT MAX(last_active_date) - INTERVAL '2 HOURS' FROM {{this}})

--- a/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
@@ -29,12 +29,12 @@ WITH sdd AS (
             , MIN(CASE WHEN in_mm2_server THEN timestamp ELSE NULL END)                           AS first_mm2_telemetry_date
             , MAX(CASE WHEN in_mm2_server THEN timestamp ELSE NULL END)                           AS last_mm2_telemetry_date
             FROM {{ ref('server_daily_details') }} SDD
-            WHERE timestamp <= CURRENT_TIMESTAMP
-            {% if is_incremental() %}
-            AND (CASE WHEN in_security OR in_mm2_server THEN timestamp ELSE NULL END) > (SELECT MAX(last_active_date) - INTERVAL '2 HOURS' FROM {{this}})
-            {% endif %}
+            WHERE timestamp <= CURRENT_TIMESTAMP 
+            OR NOT EXISTS (SELECT 1 FROM {{this}} SF WHERE SF.SERVER_ID = SDD.SERVER_ID)
             GROUP BY 1
-
+            {% if is_incremental() %}
+            HAVING MAX(CASE WHEN in_security OR in_mm2_server THEN timestamp ELSE NULL END) > (SELECT MAX(last_active_date) - INTERVAL '2 HOURS' FROM {{this}})
+            {% endif %}
           ),
 
     server_details AS (

--- a/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
@@ -31,9 +31,7 @@ WITH sdd AS (
             FROM {{ ref('server_daily_details') }} SDD
             WHERE timestamp <= CURRENT_TIMESTAMP
             {% if is_incremental() %}
-            AND ((CASE WHEN in_security OR in_mm2_server THEN timestamp ELSE NULL END) > (SELECT MAX(last_active_date) - INTERVAL '2 HOURS' FROM {{this}})
-            OR NOT EXISTS (select 1 FROM {{this}} SF WHERE SF.SERVER_ID = SDD.SERVER_ID)
-            )
+            AND (CASE WHEN in_security OR in_mm2_server THEN timestamp ELSE NULL END) > (SELECT MAX(last_active_date) - INTERVAL '2 HOURS' FROM {{this}})
             {% endif %}
             GROUP BY 1
 


### PR DESCRIPTION
Impact: There was an unforeseen issue which made its way in, in the last PR merge. The missing new servers from the 24 hour telemetry job got fixed and the servers are getting added, but the job is setting the first active date to the current date to a lot of servers, which is causing a spike in the charts. 
I will have to re-think my solution to fix the missing new servers.

Testing: This change reverts the job to the way it was before.

Update: Added the missing servers condition to the WHERE clause and reverted to the original HAVING condition. 

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

