### PR TITLE
MM - 43494 Adding inactive servers reference into Analytics

### DIFF
--- a/transform/snowflake-dbt/models/events/hourly/rudder_webapp_events.sql
+++ b/transform/snowflake-dbt/models/events/hourly/rudder_webapp_events.sql
@@ -7,7 +7,7 @@
 }}
 
 {% set rudder_relations = get_rudder_relations(schema=["mm_telemetry_prod"], database='RAW', 
-                          table_inclusions="'event'") %}
+                          table_inclusions="'event','inactive_server','inactive_server_emails_sent'") %}
 {{ union_relations(relations = rudder_relations[0], tgt_relation = rudder_relations[1]) }}
 
 


### PR DESCRIPTION
Impact: This change is going to add all the data from Inactive servers telemetry into Analytics db, following which I will work on building the chart for MM - 43494.

Testing: This was tested locally and it works as expected.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

