### PR TITLE
MM - 44105 Add ldap and custom user groups to server_daily_details_ext

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/nightly/server_daily_details_ext.sql
+++ b/transform/snowflake-dbt/models/mattermost/nightly/server_daily_details_ext.sql
@@ -607,6 +607,8 @@ WITH server_daily_details_ext AS (
       , sc.group_count
       , sc.group_synced_channel_count
       , sc.group_count_with_allow_reference
+      , sc.ldap_group_count
+      , sc.custom_group_count
       , sc.enable_legacy_sidebar
       , sc.managed_resource_paths
       , sc.openid_google

--- a/transform/snowflake-dbt/models/staging/server/server_config_details.sql
+++ b/transform/snowflake-dbt/models/staging/server/server_config_details.sql
@@ -588,6 +588,8 @@ SELECT
   , sgroup.group_count
   , sgroup.group_synced_channel_count
   , sgroup.group_count_with_allow_reference
+  , sgroup.ldap_group_count
+  , sgroup.custom_group_count
   , sservice.enable_legacy_sidebar
   , sservice.managed_resource_paths
   , soauth.openid_google

--- a/transform/snowflake-dbt/models/staging/server/server_group_details.sql
+++ b/transform/snowflake-dbt/models/staging/server/server_group_details.sql
@@ -64,6 +64,8 @@ max_rudder_timestamp       AS (
             , MAX(COALESCE(r.CONTEXT_TRAITS_INSTALLATIONID,  NULL)) AS context_traits_installationid
             , MAX(COALESCE(r.CONTEXT_REQUEST_IP,  NULL)) AS context_request_ip
             , MAX(COALESCE(r.CONTEXT_TRAITS_INSTALLATION_ID,  NULL)) AS context_traits_installation_id
+            , MAX(COALESCE(r.LDAP_GROUP_COUNT,  NULL)) AS ldap_group_count
+            , MAX(COALESCE(r.CUSTOM_GROUP_COUNT,  NULL)) AS custom_group_count
             , {{ dbt_utils.surrogate_key(['COALESCE(s.timestamp::DATE, r.timestamp::date)', 'COALESCE(s.user_id, r.user_id)']) }} AS id
          FROM 
             (


### PR DESCRIPTION
Impact: Adding the new fields ldap_group_count and custom_group_count from telemetry into server_daily_details_ext table.

Testing: Changes have been tested fully locally and work as expected.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

