### PR TITLE
Adding created field to Stripe Invoices

### DIFF
--- a/transform/snowflake-dbt/models/stripe/invoices.sql
+++ b/transform/snowflake-dbt/models/stripe/invoices.sql
@@ -16,6 +16,7 @@ WITH invoices AS (
         ,invoices.billing_reason
         ,invoices.charge
         ,invoices.closed
+        ,invoices.created
         ,invoices.currency
         ,invoices.customer
         ,invoices.date


### PR DESCRIPTION
Impact: Adding created from Stripe Raw Invoices into Stripe Invoices table, to calculate MRR based off invoice created date.

Testing: Changes were fully tested locally.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

