### PR TITLE
Updating community in excludable servers

### DIFF
--- a/transform/snowflake-dbt/seeds/excludable_servers_seed.csv
+++ b/transform/snowflake-dbt/seeds/excludable_servers_seed.csv
@@ -79,7 +79,7 @@ test_server,at6oam3ostnnfr93t5yty6w9oc
 test_server,96to1trfbigjidhxguirj1hhgc
 test_server,xha8c3iwz3f47rxep9qbtebwia
 test_server,a5pg6ik77ifq8xsrsom89y1qeo
-test_server,93mykbogbjfrbbdqphx3zhze5c
+community,93mykbogbjfrbbdqphx3zhze5c
 test_server,c7cyss7uji8cdxoe9c53d7octc
 test_server,75q84tcgn7rtibgyhbrj3m6ycr
 test_server,y3768xtapfyq5czzfgg6yuuaqh


### PR DESCRIPTION
Impact: Updating community in excludable servers so we can add only community along with other prod servers in various Analyses.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

