### PR TITLE
Updated models for campaignmember status

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/freemium/cloud_starter/cs_signup_campaign.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/cloud_starter/cs_signup_campaign.sql
@@ -65,19 +65,17 @@ select
     lead.sfid as lead_sfid,
     contact.sfid as contact_sfid,
     case
-        when facts.dns is not null then 'Completed Signup'
-        when facts.completed_signup_at is not null then 'Completed Signup'
-        when facts.workspace_provisioning_started_at is not null then 'Created Workspace'
-        when facts.entered_company_name_at is not null then 'Entered Company Name'
-        when facts.verified_email_at is not null then 'Verified Email'
-        when facts.submitted_form_at is not null then 'Submitted Form'
+        when facts.dns is not null then 'Workspace Created'
+        when facts.account_created_at is not null then 'Account Created'
+        when facts.verified_email_at is not null then 'Email Verified'
+        when facts.workspace_created_at is not null then 'Workspace Created'
     end as campaign_status,
     coalesce(
-        facts.completed_signup_at,
-        facts.workspace_provisioning_started_at,
-        facts.entered_company_name_at,
+        facts.account_created_at,
         facts.verified_email_at,
-        facts.submitted_form_at) as last_action_date
+        facts.workspace_created_at,
+        facts.workspace_provisioning_started_at
+        ) as last_action_date
 from
     {{ ref('cs_signup_campaign_facts') }} facts
     left join existing_members as campaignmember

--- a/transform/snowflake-dbt/models/hightouch/freemium/cloud_starter/cs_sso_campaignmember_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/cloud_starter/cs_sso_campaignmember_insert.sql
@@ -5,7 +5,7 @@
 }}
 
 with campaignmembers_to_insert as (
-    select * from {{ ref('cs_signup_campaign') }}
+    select * from {{ ref('cs_sso_facts') }}
     where campaignmember_sfid is null and lead_exists
 )
 select * from campaignmembers_to_insert


### PR DESCRIPTION
Fixed stripe edition error and campaignmember status.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
TL;DR
1. Updated campaignmember status with accepted values.
2. Updated the filter returning cloud starter leads.
3. Added lead_source and lead_source fields in sso lead model.

BREAKING
1. Campaignmember status had some values that were not accepted from salesforce, causing models to fail.
2. Stripe field "edition" was coming as null for some records, causing filter on it to return less number of rows.

#### Ticket Link
N/A

