### PR TITLE
MM-42447 updated sso leads for cloud starter campaign

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/freemium/cloud_starter/cs_signup_campaign.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/cloud_starter/cs_signup_campaign.sql
@@ -49,19 +49,16 @@ select
     coalesce(lead.dwh_external_id__c, UUID_STRING('78157189-82de-4f4d-9db3-88c601fbc22e', facts.portal_customer_id || facts.email)) AS lead_external_id,
     '0051R00000GnvhhQAB' as lead_ownerid,
     'Cloud Starter Signup' as most_recent_action,
-    -- CASE is_sso then 'SSO' else 'Email' END as most_recent_action_detail,
-    'Email' as most_recent_action_detail,
+    CASE when sso_provider is not null then 'SSO' else 'Email' END as most_recent_action_detail,
     'Cloud Workspace Creation' as action_detail,
     coalesce(lead.LEAD_SOURCE_TEXT__C,'Referral') as lead_source,
     coalesce(lead.LEAD_SOURCE_DETAIL__C,'Mattermost Cloud') as lead_source_detail,
-    -- 'TBD' as signup_method,
     false as marketing_suspend,
     '7013p000001U28AAAS' as campaign_id,
     '7016u0000002Q5zAAE' as sandbox_campaign_id,
     campaignmember.sfid as campaignmember_sfid,
-    -- case when sso_provider is not null then true else false end as is_sso,
-    -- coalesce(sso_provider, 'Email') as signup_method,
-    'Email' as signup_method,
+    case when facts.sso_provider is not null then true else false end as is_sso,
+    coalesce(facts.sso_provider, 'Email') as signup_method,
     lead.sfid as lead_sfid,
     contact.sfid as contact_sfid,
     case
@@ -84,4 +81,3 @@ from
         on facts.email = lead.email and lead.row_num = 1
     left join existing_contacts as contact
         on facts.email = contact.email and contact.row_num = 1
-        where lower(facts.edition) = 'cloud starter'

--- a/transform/snowflake-dbt/models/hightouch/source.yml
+++ b/transform/snowflake-dbt/models/hightouch/source.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sources:
+  - name: raw
+    database: raw
+    schema: portal_prod
+
+    tables:
+    - name: identifies


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
TL;DR

1. Added sso leads from raw source 'identifies'
2. Added sso_provider and is_sso columns to model.
3. Fixed company_name[missing] and first_name[data value too large errors], since these errors were due to previously used sso models which is now depreciated.
4. Removed the cloud starter filter which was filtering out incomplete signups.

Previously we were getting sso leads from stripe, now we are getting it from portal and able to track the signup process for them.



#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

