### PR TITLE
MM 42449 Adding salesforce ids for reference

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_campaignmember_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_campaignmember_insert.sql
@@ -29,7 +29,8 @@ with existing_members as (
     from {{ ref('contact') }}
 ), campaignmembers_to_sync as (
     SELECT
-        existing_leads.sfid,
+        existing_leads.sfid as lead_sfid,
+        existing_contacts.sfid as contact_sfid,
         customers_with_free_subs.email,
         customers_with_free_subs.company_name,
         COALESCE(

--- a/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_contact_update.sql
@@ -16,6 +16,7 @@ WITH existing_lead AS (
 ), freemium_contacts_to_sync as (
     SELECT
         UUID_STRING('78157189-82de-4f4d-9db3-88c601fbc22e', customers_with_free_subs.email ) AS campaignmember_external_id,
+        contact.id as contact_sfid,
         customers_with_free_subs.email,
         customers_with_free_subs.domain,
         customers_with_free_subs.last_name,

--- a/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_lead_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_lead_update.sql
@@ -16,6 +16,7 @@ WITH existing_lead AS (
 ), freemium_leads_to_sync as (
     SELECT
         UUID_STRING('78157189-82de-4f4d-9db3-88c601fbc22e', customers_with_free_subs.email ) AS campaignmember_external_id,
+        existing_lead.id as lead_sfid,
         customers_with_free_subs.email,
         customers_with_free_subs.domain,
         customers_with_free_subs.last_name,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Salesforce Ids are required to identify existing objects in salesforce. Generally required for update syncs.
TL;DR
Adding missing salesforce ids that are required by hightouch sync.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

