### PR TITLE
MM 45103 incorrect arr amounts fix

### DIFF
--- a/transform/snowflake-dbt/models/blapi/onprem_subscriptions.sql
+++ b/transform/snowflake-dbt/models/blapi/onprem_subscriptions.sql
@@ -10,6 +10,7 @@ WITH latest_payment AS (
         payments.stripe_charge_id,
         payments.subscription_id,
         'ONL' || payments.invoice_number AS invoice_number,
+        payments.invoice_number as stripe_invoice_number,
         ROW_NUMBER() OVER (PARTITION BY payments.subscription_id ORDER BY payments.created_at DESC) as row_num
     FROM {{ ref('payments') }}
 ), subscriptions AS (
@@ -18,6 +19,7 @@ WITH latest_payment AS (
         p.sku,
         latest_payment.stripe_charge_id,
         latest_payment.invoice_number,
+        latest_payment.stripe_invoice_number,
         ROW_NUMBER() OVER (PARTITION BY s.id ORDER BY s.transaction_id DESC) as row_num
     FROM {{ source('blapi', 'subscriptions_version') }} s
     JOIN {{ source('blapi', 'products') }} p ON s.product_id = p.id


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Issue - Amount field coming from blapi does not have the amount paid by the customer, instead it contains the subscription price. Incorrect amount was getting synced to salesforce due to discount not getting considered.

Updates - 
1. Added a reference field "stripe_invoice_number" in source view for join to invoices.
2. Updated correct amount fields for arr subscriptions.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

