### PR TITLE
Fixing Boards join in server fact

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
@@ -169,7 +169,7 @@ WITH sdd AS (
         FROM {{ ref('focalboard_blocks') }} s1
         JOIN max_blocks_time s2
           ON s1.user_id = s2.user_id 
-          AND s1.timestamp = s2.max_time 
+          AND s1.logging_date = s2.max_date 
     ),
 
     server_activity as (


### PR DESCRIPTION
Impact: The boards join in server_fact was using timestamp, which wasn't returning any rows. Fixed the join to use date.


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

