### PR TITLE
adding logic for null license id

### DIFF
--- a/transform/snowflake-dbt/models/finance/arr_transactions.sql
+++ b/transform/snowflake-dbt/models/finance/arr_transactions.sql
@@ -53,7 +53,7 @@ with mrr as (
     WHERE opp.iswon in (true,false)
         and opp.isclosed = true
         and opp.isdeleted = false
-        and opp.license_key__c not in (select distinct license_id from mrr)
+        and coalesce(opp.license_key__c,'null') not in (select distinct license_id from mrr)
     group by 1
     having arr >=1
     order by 1


### PR DESCRIPTION
Noticed that license ids can be null on opportunity table given that synching between license portal and sfdc was reported to be down by Jim Ketaily.
Null license ids inadvertently gets excluded from arr report.  Created null logic to avoid understatement of ARR.  Use case witnessed on Boxel deal

