### PR TITLE
Updated logic for renewals less than 1 year

### DIFF
--- a/transform/snowflake-dbt/models/finance/arr_transactions.sql
+++ b/transform/snowflake-dbt/models/finance/arr_transactions.sql
@@ -214,7 +214,9 @@ union
       ,opportunity_id
       ,max(case when iswon = true then close_date else null end) as close_date
       ,max(lic_start_date) as license_start
-      ,max(lic_end_date) as license_end
+      --min logic takes into account that some renewals are made for less than a year
+      ,min(lic_end_date) as license_end
+      --,max(lic_end_date) as license_end
       ,max(iswon) as is_won
       ,max(case when iswon = true then 'Renewal' else 'Expired' end) as opp_type
       ,max(case when iswon = true then term else 0 end) as term


### PR DESCRIPTION
Revised license end date logic to take into account that renewals can be as short as 1 month and not 12 months. 
Use case found for NASA  in August 2022.

https://mattermost.lightning.force.com/lightning/r/Opportunity/0063p00000z8nCjAAI/view









