### PR TITLE
Fix onprem renewals

### DIFF
--- a/transform/snowflake-dbt/models/blapi/customers_with_onprem_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_onprem_subs.sql
@@ -95,7 +95,7 @@ WITH latest_credit_card_address AS (
         JOIN {{ source('blapi', 'products') }} ON onprem_subscriptions.sku = products.sku
         LEFT JOIN {{ ref('subscriptions') }} renewed_from_subscription
             ON subscriptions.renewed_from_sub_id = renewed_from_subscription.id
-        LEFT JOIN {{ ref('onprem_subscriptions') }} renewed_from_blapi_subscription ON subscriptions.id = renewed_from_blapi_subscription.stripe_id
+        LEFT JOIN {{ ref('onprem_subscriptions') }} renewed_from_blapi_subscription ON subscriptions.renewed_from_sub_id = renewed_from_blapi_subscription.stripe_id
         LEFT JOIN {{ ref('invoices') }} ON onprem_subscriptions.stripe_invoice_number = invoices.number
         JOIN latest_credit_card_address
             ON customers.id = latest_credit_card_address.customer_id

--- a/transform/snowflake-dbt/models/blapi/customers_with_onprem_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_onprem_subs.sql
@@ -152,7 +152,8 @@ WITH latest_credit_card_address AS (
         customers_with_onprem_subs.subscription_id, 
         customers_with_onprem_subs.previous_subscription_version_id,
         opportunity.sfid as previous_opportunity_sfid,
-        opportunity.amount as up_for_renewal_arr
+        opportunity.amount as up_for_renewal_arr,
+        ROW_NUMBER() OVER (PARTITION BY customers_with_onprem_subs.stripe_charge_id ORDER BY opportunity.lastmodifieddate DESC) as row_num
     FROM customers_with_onprem_subs
     JOIN {{ ref('opportunity') }}
         ON  UUID_STRING(
@@ -208,3 +209,4 @@ JOIN customers_oli
     AND customers_oli.row_num = 1
 LEFT JOIN customers_previous_opportunity
     ON customers_with_onprem_subs.subscription_id = customers_previous_opportunity.subscription_id
+    AND customers_previous_opportunity.row_num = 1


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Onprem subscription opportunity is not syncing due to
1. Incorrect renewed_from_subscription_id coming from stripe, that does not match with data coming from blapi. 
2. Since blapi data is used for previous subscriptions, salesforce_id of those opportunities could not be identified by current model.

Updates - 
1. Updated join for previous subscriptions.
2. Getting previous subscriptions from current model in case of mismatch of renewed from subscription id.

Tested changes with row_count, confirmed no change in data for other columns.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

