### PR TITLE
Updated ARR_Reporting to avoid negative renewal amounts

### DIFF
--- a/transform/snowflake-dbt/models/finance/arr_reporting.sql
+++ b/transform/snowflake-dbt/models/finance/arr_reporting.sql
@@ -70,7 +70,7 @@ with a as (
         end as contracted
     ,iff(arr_delta - new <0 and acct_end_arr = 0,arr_delta-new-resurrected,0) as churned
     --on time renewals based on original renewal amount
-    ,iff(arr_renewed>0,(expire - churned -  contracted)*-1,0) as renewed
+    ,iff(arr_renewed>0 and expire <0,(expire - churned -  contracted)*-1,0) as renewed
     ,case 
         when gross_late_renewal > 0 and gross_late_renewal + previous_expire > 0
         then gross_late_renewal + previous_expire 

--- a/transform/snowflake-dbt/models/finance/arr_transactions.sql
+++ b/transform/snowflake-dbt/models/finance/arr_transactions.sql
@@ -127,7 +127,8 @@ with mrr as (
       --common to see license periods adjusted for co terminating deals
       ,round(datediff('day',license_start,license_end)/(365/12),0) as term
       ,opp.iswon
-      ,opp.type as opp_type
+      --logic for identifying renewals added as sales people do not necessarily tag opportunities correctly
+      ,iff(lower(opp.name) like '%renew%','Renewal',opp.type) as opp_type
       ,case when opp.new_logo__c is null then 'No' else opp.new_logo__c end as new_logo
       ,round(coalesce(opp.amount,2),0) as bill_amt
       ,case when term = 12 then bill_amt 


### PR DESCRIPTION
Updated logic to calculate renewed only when expiration occurs during the same month.  Logic became necessary when late renewals were split away from resurrections.