### PR TITLE
MM-47901: add tests for github contributors

### DIFF
--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -1,5 +1,7 @@
 from pathlib import Path
-
+import os
+import pandas as pd
+import json
 import pytest
 
 from responses import Response
@@ -11,18 +13,62 @@ def mock_settings_env_vars(mocker):
     Mock any environment variables loaded to global variables.
     TODO: Load configuration using factory pattern.
     """
+    # Mock items loaded from environment on module initialization
     mocker.patch("utils.run_dbt_cloud_job.token", "test-dbt-key")
     mocker.patch("utils.run_dbt_cloud_job.account_id", "1001")
     mocker.patch("utils.run_dbt_cloud_job.timeout", 35)
 
+    # Mock items loaded using os.environ in method calls
+    mock_env_vars = {
+        'GITHUB_TOKEN': 'token'
+    }
+    mocker.patch.dict(os.environ, mock_env_vars, clear=True)
+
 
 @pytest.fixture()
-def given_request_to(responses):
+def given_request_to(request, responses):
+    """
+    Loads test data from fixture directory. Defaults can be modified on the module level by defining a dict with name
+    __MOCK_REQUEST_DEFAULTS. The dict may contains the following keys:
+
+    'dir': a string with the directory under fixtures/ to use for loading the data from.
+    'headers': a dictionary with any default headers to expect.
+    """
+
     def _given_request_to(url, response_file, method="GET", status=200):
-        with open(Path(__file__).parent / 'fixtures' / 'dbt' / response_file) as fp:
+        config = getattr(request.module, '__MOCK_REQUEST_DEFAULTS') or {}
+        target = Path(__file__).parent / 'fixtures' / config.get('dir') / response_file if config.get('dir') \
+            else Path(__file__).parent / 'fixtures' / response_file
+        with open(target) as fp:
             rsp = Response(method=method, url=url,
-                           status=status, headers={"Authorization": f"Token test-dbt-key", "Content-Type": "application/json"},
+                           status=status, headers=config.get('headers', {}),
                            body=fp.read())
             responses.add(rsp)
 
     return _given_request_to
+
+
+@pytest.fixture()
+def mock_snowflake(mocker):
+    def _mock_snowflake(module_name):
+        mock_engine_factory = mocker.patch(f"{module_name}.snowflake_engine_factory")
+        mock_engine = mocker.MagicMock()
+        mock_engine_factory.return_value = mock_engine
+        mock_connection = mocker.MagicMock()
+        mock_engine.connect.return_value = mock_connection
+        mock_execute_query = mocker.patch(f"{module_name}.execute_query")
+
+        # Mock pandas' to_sql
+        mock_to_sql = mocker.patch("pandas.io.sql.to_sql")
+        return mock_engine, mock_connection, mock_execute_query, mock_to_sql
+
+    return _mock_snowflake
+
+
+@pytest.fixture()
+def load_dataset():
+    def _load_dataset(filename):
+        with open(Path(__file__).parent / 'fixtures' / filename) as fp:
+            return pd.DataFrame(json.load(fp))
+
+    return _load_dataset

--- a/tests/utils/fixtures/github/auth.error.json
+++ b/tests/utils/fixtures/github/auth.error.json
@@ -1,0 +1,4 @@
+{
+  "message": "This endpoint requires you to be authenticated.",
+  "documentation_url": "https://docs.github.com/graphql/guides/forming-calls-with-graphql#authenticating-with-graphql"
+}

--- a/tests/utils/fixtures/github/dataset.json
+++ b/tests/utils/fixtures/github/dataset.json
@@ -1,0 +1,62 @@
+[
+  {
+    "PR_NUMBER": 1,
+    "MERGED_AT": "2015-06-15T18:01:11Z",
+    "AUTHOR": "user-a",
+    "REPO": "mattermost-server"
+  },
+  {
+    "PR_NUMBER": 2,
+    "MERGED_AT": "2015-06-15T18:01:37Z",
+    "AUTHOR": "user-a",
+    "REPO": "mattermost-server"
+  },
+  {
+    "PR_NUMBER": 3,
+    "MERGED_AT": "2015-06-15T18:02:24Z",
+    "AUTHOR": "user-b",
+    "REPO": "mattermost-server"
+  },
+  {
+    "PR_NUMBER": 4,
+    "MERGED_AT": "2015-07-07T12:44:29Z",
+    "AUTHOR": "user-a",
+    "REPO": "mattermost-server"
+  },
+  {
+    "PR_NUMBER": 5,
+    "MERGED_AT": "2015-07-07T19:51:03Z",
+    "AUTHOR": "user-c",
+    "REPO": "mattermost-server"
+  },
+  {
+    "PR_NUMBER": 6,
+    "MERGED_AT": "2015-07-08T07:12:08Z",
+    "AUTHOR": "user-d",
+    "REPO": "mattermost-server"
+  },
+  {
+    "PR_NUMBER": 1,
+    "MERGED_AT": "2015-06-15T18:01:11Z",
+    "AUTHOR": "user-a",
+    "REPO": "docs"
+  },
+  {
+    "PR_NUMBER": 2,
+    "MERGED_AT": "2015-06-15T18:01:37Z",
+    "AUTHOR": "user-k",
+    "REPO": "docs"
+  },
+  {
+    "PR_NUMBER": 1,
+    "MERGED_AT": "2015-06-15T18:01:11Z",
+    "AUTHOR": "user-b",
+    "REPO": "focalboard"
+  },
+  {
+    "PR_NUMBER": 2,
+    "MERGED_AT": "2015-06-15T18:01:37Z",
+    "AUTHOR": "user-q",
+    "REPO": "focalboard"
+  }
+]

--- a/tests/utils/fixtures/github/docs.page.1.json
+++ b/tests/utils/fixtures/github/docs.page.1.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "repository": {
+      "name": "docs",
+      "pullRequests": {
+        "pageInfo": {
+          "endCursor": "mattermost-server-cursor",
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "number": 1,
+            "mergedAt": "2015-06-15T18:01:11Z",
+            "author": {
+              "login": "user-a"
+            }
+          },
+          {
+            "number": 2,
+            "mergedAt": "2015-06-15T18:01:37Z",
+            "author": {
+              "login": "user-k"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/utils/fixtures/github/focalboard.page.1.json
+++ b/tests/utils/fixtures/github/focalboard.page.1.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "repository": {
+      "name": "focalboard",
+      "pullRequests": {
+        "pageInfo": {
+          "endCursor": "focalboard-cursor",
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "number": 1,
+            "mergedAt": "2015-06-15T18:01:11Z",
+            "author": {
+              "login": "user-b"
+            }
+          },
+          {
+            "number": 2,
+            "mergedAt": "2015-06-15T18:01:37Z",
+            "author": {
+              "login": "user-q"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/utils/fixtures/github/mattermost-server.page.1.json
+++ b/tests/utils/fixtures/github/mattermost-server.page.1.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "repository": {
+      "name": "mattermost-server",
+      "pullRequests": {
+        "pageInfo": {
+          "endCursor": "mattermost-server-cursor",
+          "hasNextPage": true
+        },
+        "nodes": [
+          {
+            "number": 1,
+            "mergedAt": "2015-06-15T18:01:11Z",
+            "author": {
+              "login": "user-a"
+            }
+          },
+          {
+            "number": 2,
+            "mergedAt": "2015-06-15T18:01:37Z",
+            "author": {
+              "login": "user-a"
+            }
+          },
+          {
+            "number": 3,
+            "mergedAt": "2015-06-15T18:02:24Z",
+            "author": {
+              "login": "user-b"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/utils/fixtures/github/mattermost-server.page.2.json
+++ b/tests/utils/fixtures/github/mattermost-server.page.2.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "repository": {
+      "name": "mattermost-server",
+      "pullRequests": {
+        "pageInfo": {
+          "endCursor": "mattermost-server-cursor",
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "number": 4,
+            "mergedAt": "2015-07-07T12:44:29Z",
+            "author": {
+              "login": "user-a"
+            }
+          },
+          {
+            "number": 5,
+            "mergedAt": "2015-07-07T19:51:03Z",
+            "author": {
+              "login": "user-c"
+            }
+          },
+          {
+            "number": 6,
+            "mergedAt": "2015-07-08T07:12:08Z",
+            "author": {
+              "login": "user-d"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/utils/fixtures/github/repo.page.1.json
+++ b/tests/utils/fixtures/github/repo.page.1.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "organization": {
+      "repositories": {
+        "pageInfo": {
+          "endCursor": "cursor-value",
+          "hasNextPage": true
+        },
+        "nodes": [
+          {
+            "name": "mattermost-server"
+          },
+          {
+            "name": "docs"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/utils/fixtures/github/repo.page.2.json
+++ b/tests/utils/fixtures/github/repo.page.2.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "organization": {
+      "repositories": {
+        "pageInfo": {
+          "endCursor": "cursor-value",
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "name": "focalboard"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/utils/test_github_contributors.py
+++ b/tests/utils/test_github_contributors.py
@@ -1,0 +1,83 @@
+import pandas as pd
+from utils.github_contributors import contributors
+
+# Customize defaults for given_request_to
+__MOCK_REQUEST_DEFAULTS = {
+    "dir": "github",
+    "headers": {"Authorization": "Bearer token"}
+}
+
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+
+
+def test_contributors(responses, given_request_to, mock_snowflake, load_dataset):
+    # GIVEN: repo query returns two pages of results
+    given_request_to(GITHUB_GRAPHQL_URL, "repo.page.1.json", method="POST")
+    given_request_to(GITHUB_GRAPHQL_URL, "repo.page.2.json", method="POST")
+    given_request_to(GITHUB_GRAPHQL_URL, "mattermost-server.page.1.json", method="POST")
+    given_request_to(GITHUB_GRAPHQL_URL, "mattermost-server.page.2.json", method="POST")
+    given_request_to(GITHUB_GRAPHQL_URL, "docs.page.1.json", method="POST")
+    given_request_to(GITHUB_GRAPHQL_URL, "focalboard.page.1.json", method="POST")
+
+    # GIVEN: mock snowflake connection
+    _, mock_connection, _, mock_to_sql = mock_snowflake("utils.github_contributors")
+
+    # WHEN: request to load contributors
+    contributors()
+
+    # THEN: expect github's graphql url to have been called for getting repos
+    responses.assert_call_count(GITHUB_GRAPHQL_URL, 6)
+
+    # THEN: expect request to delete existing contributors table
+    mock_connection.execute.assert_called_once_with("DELETE FROM staging.github_contributions_all")
+
+    # THEN: expect proper data to be loaded to snowflake table
+    mock_to_sql.assert_called_once()
+    pd.testing.assert_frame_equal(
+        mock_to_sql.call_args_list[0][0][0],
+        pd.DataFrame(data=load_dataset('github/dataset.json'))
+    )
+
+    # THEN: expect connection to snowflake to be closed
+    mock_connection.close.assert_called_once()
+
+
+def test_contributors_fail_to_get_repos(responses, given_request_to, mock_snowflake, load_dataset):
+    # GIVEN: repo query fails due to authentication error
+    given_request_to(GITHUB_GRAPHQL_URL, "auth.error.json", method="POST", status=401)
+
+    # GIVEN: mock snowflake connection
+    _, mock_connection, _, mock_to_sql = mock_snowflake("utils.github_contributors")
+
+    # WHEN: request to load contributors
+    contributors()
+
+    # THEN: expect github's graphql url to have been called just for the first time
+    responses.assert_call_count(GITHUB_GRAPHQL_URL, 1)
+
+    # THEN: no interactions with database
+    mock_connection.execute.assert_not_called()
+    mock_to_sql.assert_not_called()
+    mock_connection.close.assert_not_called()
+
+
+def test_contributors_fail_to_get_repo_details(responses, given_request_to, mock_snowflake, load_dataset):
+    # GIVEN: repo query returns two pages of results
+    given_request_to(GITHUB_GRAPHQL_URL, "repo.page.1.json", method="POST")
+    given_request_to(GITHUB_GRAPHQL_URL, "repo.page.2.json", method="POST")
+    # GIVEN: error to get list of contributors
+    given_request_to(GITHUB_GRAPHQL_URL, "auth.error.json", method="POST", status=401)
+
+    # GIVEN: mock snowflake connection
+    _, mock_connection, _, mock_to_sql = mock_snowflake("utils.github_contributors")
+
+    # WHEN: request to load contributors
+    contributors()
+
+    # THEN: expect github's graphql url to have been called just for the first repo
+    responses.assert_call_count(GITHUB_GRAPHQL_URL, 3)
+
+    # THEN: no interactions with database
+    mock_connection.execute.assert_not_called()
+    mock_to_sql.assert_not_called()
+    mock_connection.close.assert_not_called()

--- a/tests/utils/test_run_dbt_cloud_job.py
+++ b/tests/utils/test_run_dbt_cloud_job.py
@@ -7,6 +7,12 @@ from utils.run_dbt_cloud_job import trigger_dbt_run, poll_dbt_run
 EXPECTED_RUN_TRIGGER_URL = "https://cloud.getdbt.com/api/v2/accounts/1001/jobs/101/run/"
 EXPECTED_RUN_POLL_URL = "https://cloud.getdbt.com/api/v2/accounts/1001/runs/42/"
 
+# Customize defaults for given_request_to
+__MOCK_REQUEST_DEFAULTS = {
+    'dir': 'dbt',
+    'headers': {"Authorization": f"Token test-dbt-key", "Content-Type": "application/json"}
+}
+
 
 def test_should_trigger_run(responses, given_request_to):
     # GIVEN: DBT cloud ready to accept job

--- a/utils/github_contributors.py
+++ b/utils/github_contributors.py
@@ -138,8 +138,9 @@ def contributors():
         )
     except Exception as e:
         print(e)
-        connection.close()
         return
+    finally:
+        connection.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary

Test code for getting github contributors. Mocks connections to snowflake and github and focuses on data extraction and transformation logic.

Note that in order to make handling of responses reusable, a few changes were required in `test_run_dbt_cloud_job.py`.