### PR TITLE
Fix first_active_date in server_fact

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/hourly/server_daily_details.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/server_daily_details.sql
@@ -137,7 +137,7 @@ dates as (
       , CASE WHEN s1.server_id IS NULL AND s2.server_id IS NULL THEN TRUE ELSE FALSE END AS tracking_disabled
       , CASE WHEN s1.occurrences > 1 OR s2.occurrences > 1 THEN TRUE ELSE FALSE END      AS has_dupes
       , CASE WHEN coalesce(s1.ip_count, NULL) > 1 THEN TRUE ELSE FALSE END               AS has_multi_ips
-      , coalesce(s2.timestamp, s1.timestamp)                                                     AS timestamp
+      , coalesce(s1.timestamp, s2.timestamp)                                                     AS timestamp
       , {{ dbt_utils.surrogate_key(['d.date', 'd.server_id']) }}                           AS id
       , CASE WHEN COALESCE(s2.database_version, NULL) IS NULL THEN
           MAX(COALESCE(s2.database_version, NULL)) OVER (PARTITION BY d.server_id ORDER BY d.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)


### PR DESCRIPTION
Impact: first_active_date is being fetched from telemetry instead of diagnostics log entries, which is causing some issues in retention calculation.

Testing: Changes have been fully tested locally.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

