### PR TITLE
MM-47921: test push proxy import job

### DIFF
--- a/tests/extract/s3_extract/conftest.py
+++ b/tests/extract/s3_extract/conftest.py
@@ -24,7 +24,8 @@ def mock_environment(mocker):
     mock_env_vars = {
         'GITHUB_TOKEN': 'token',
         'DIAGNOSTIC_LOCATION_ONE': 'location-one',
-        'DIAGNOSTIC_LOCATION_TWO': 'location-two'
+        'DIAGNOSTIC_LOCATION_TWO': 'location-two',
+        'AWS_ACCOUNT_ID': 'test-aws-account-id'
     }
     mocker.patch.dict(os.environ, mock_env_vars, clear=True)
     mock_env_copy = mocker.patch('os.environ.copy')

--- a/tests/extract/s3_extract/test_stage_import.py
+++ b/tests/extract/s3_extract/test_stage_import.py
@@ -1,6 +1,7 @@
 import pytest
 from mock import call
-from extract.s3_extract.stage_import import extract_from_stage, diagnostics_import, get_diagnostics_pattern
+from extract.s3_extract.stage_import import extract_from_stage, diagnostics_import, get_diagnostics_pattern, \
+    push_proxy_import, get_path, get_push_proxy_pattern
 
 
 def test_extract_from_stage(mock_snowflake):
@@ -31,8 +32,10 @@ def test_diagnostics_import(mocker, mock_environment):
     # THEN: expect extract to have been called once for each import
     assert mock_extract.call_count == 2
     mock_extract.assert_has_calls([
-        call("log_entries", "diagnostics_stage", "diagnostics", "location-one", ".*location-one.2022-10-01.*", mock_environment),
-        call("log_entries", "diagnostics_stage", "diagnostics", "location-two", ".*location-two.2022-10-01.*", mock_environment)
+        call("log_entries", "diagnostics_stage", "diagnostics", "location-one", ".*location-one.2022-10-01.*",
+             mock_environment),
+        call("log_entries", "diagnostics_stage", "diagnostics", "location-two", ".*location-two.2022-10-01.*",
+             mock_environment)
     ])
 
 
@@ -42,6 +45,39 @@ def test_diagnostics_import(mocker, mock_environment):
 ])
 def test_get_diagnostics_pattern(loc, import_date, pattern):
     assert get_diagnostics_pattern(loc, import_date) == pattern
+
+
+@pytest.mark.parametrize("aws_account_id,az,expected", [
+    ("account-1", "az-1", "AWSLogs/account-1/elasticloadbalancing/az-1"),
+    ("account-2", "az-2", "AWSLogs/account-2/elasticloadbalancing/az-2"),
+])
+def test_get_path(aws_account_id, az, expected):
+    assert get_path(aws_account_id, az) == expected
+
+
+@pytest.mark.parametrize("import_date,expected", [
+    ("2022-10-01", ".*2022-10-01\\/.*"),
+    ("2022/10/01", ".*2022\\/10\\/01\\/.*"),
+])
+def test_get_push_proxy_pattern(import_date, expected):
+    assert get_push_proxy_pattern(import_date) == expected
+
+
+@pytest.mark.parametrize("location,table,stage,zone", [
+    ("US", "logs", "push_proxy_stage", "us-east-1"),
+    ("DE", "de_logs", "push_proxy_de_stage", "eu-central-1"),
+    ("TEST", "test_logs", "push_proxy_test_stage", "us-east-1"),
+])
+def test_push_proxy_import(mocker, mock_environment, location, table, stage, zone):
+    # GIVEN: environment configured for handling push proxy import
+    # GIVEN: calls to extract from stage are captured
+    mock_extract = mocker.patch("extract.s3_extract.stage_import.extract_from_stage")
+
+    # WHEN: push proxy job is triggered for a specific location and date
+    push_proxy_import(location, "2022/10/01")
+
+    # THEN: expect extract to have been called once
+    mock_extract.assert_called_once_with(table, stage, "push_proxy", f"AWSLogs/test-aws-account-id/elasticloadbalancing/{zone}", ".*2022\\/10\\/01\\/.*", mock_environment)
 
 
 def _flatten_whitespaces(text):


### PR DESCRIPTION
#### Summary


Test the job that imports push proxy logs from S3. The job is nothing more than a trigger to Snowflake to copy data from an S3 stage. Copying stage has already been tested in https://github.com/mattermost/mattermost-data-warehouse/pull/1030, so all this PR needs to do is that the expected parameters are passed to the trigger. 

There's also some additional tests for helper functions that build S3 paths and patterns to import.