### PR TITLE
MM-47922: add tests for releases import job

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ different set of environment variables. The following table describes the requir
         <td>PERMISSION_BOT_WAREHOUSE</td>
         <td>Warehouse to store transformed data to</td>
     </tr>
+    <tr>
+      <td>RELEASE_LOCATION</td>
+      <td>Location to load release data from</td>
+    </tr>
   </tbody>
 </table>
 

--- a/tests/extract/s3_extract/conftest.py
+++ b/tests/extract/s3_extract/conftest.py
@@ -26,6 +26,7 @@ def mock_environment(mocker):
         'GITHUB_TOKEN': 'token',
         'DIAGNOSTIC_LOCATION_ONE': 'location-one',
         'DIAGNOSTIC_LOCATION_TWO': 'location-two',
+        'RELEASE_LOCATION': 'test-release-location',
         'AWS_ACCOUNT_ID': 'test-aws-account-id'
     }
     mocker.patch.dict(os.environ, mock_env_vars, clear=True)

--- a/tests/extract/s3_extract/test_stage_import.py
+++ b/tests/extract/s3_extract/test_stage_import.py
@@ -9,6 +9,7 @@ from extract.s3_extract.stage_import import (
     get_push_proxy_pattern,
     licenses_import,
     push_proxy_import,
+    releases_import,
 )
 
 
@@ -21,12 +22,16 @@ def test_extract_from_stage(mock_snowflake):
 
     # THEN: expect query to have been executed once
     mock_execute_query.assert_called_once()
-    assert _flatten_whitespaces(mock_execute_query.call_args_list[0][0][1]) == _flatten_whitespaces("""
+    assert _flatten_whitespaces(
+        mock_execute_query.call_args_list[0][0][1]
+    ) == _flatten_whitespaces(
+        """
         COPY INTO raw.test-schema.test-table
         FROM @dev/data/valuable
         PATTERN = '*.csv'
         ON_ERROR = 'CONTINUE';
-    """)
+    """
+    )
 
 
 def test_diagnostics_import(mocker, mock_environment):
@@ -39,43 +44,69 @@ def test_diagnostics_import(mocker, mock_environment):
 
     # THEN: expect extract to have been called once for each import
     assert mock_extract.call_count == 2
-    mock_extract.assert_has_calls([
-        call("log_entries", "diagnostics_stage", "diagnostics", "location-one", ".*location-one.2022-10-01.*",
-             mock_environment),
-        call("log_entries", "diagnostics_stage", "diagnostics", "location-two", ".*location-two.2022-10-01.*",
-             mock_environment)
-    ])
+    mock_extract.assert_has_calls(
+        [
+            call(
+                "log_entries",
+                "diagnostics_stage",
+                "diagnostics",
+                "location-one",
+                ".*location-one.2022-10-01.*",
+                mock_environment,
+            ),
+            call(
+                "log_entries",
+                "diagnostics_stage",
+                "diagnostics",
+                "location-two",
+                ".*location-two.2022-10-01.*",
+                mock_environment,
+            ),
+        ]
+    )
 
 
-@pytest.mark.parametrize("loc,import_date,pattern", [
-    ("location1", "2022-10-01", ".*location1.2022-10-01.*"),
-    ("location2", "2021-12-25", ".*location2.2021-12-25.*")
-])
+@pytest.mark.parametrize(
+    "loc,import_date,pattern",
+    [
+        ("location1", "2022-10-01", ".*location1.2022-10-01.*"),
+        ("location2", "2021-12-25", ".*location2.2021-12-25.*"),
+    ],
+)
 def test_get_diagnostics_pattern(loc, import_date, pattern):
     assert get_diagnostics_pattern(loc, import_date) == pattern
 
 
-@pytest.mark.parametrize("aws_account_id,az,expected", [
-    ("account-1", "az-1", "AWSLogs/account-1/elasticloadbalancing/az-1"),
-    ("account-2", "az-2", "AWSLogs/account-2/elasticloadbalancing/az-2"),
-])
+@pytest.mark.parametrize(
+    "aws_account_id,az,expected",
+    [
+        ("account-1", "az-1", "AWSLogs/account-1/elasticloadbalancing/az-1"),
+        ("account-2", "az-2", "AWSLogs/account-2/elasticloadbalancing/az-2"),
+    ],
+)
 def test_get_path(aws_account_id, az, expected):
     assert get_path(aws_account_id, az) == expected
 
 
-@pytest.mark.parametrize("import_date,expected", [
-    ("2022-10-01", ".*2022-10-01\\/.*"),
-    ("2022/10/01", ".*2022\\/10\\/01\\/.*"),
-])
+@pytest.mark.parametrize(
+    "import_date,expected",
+    [
+        ("2022-10-01", ".*2022-10-01\\/.*"),
+        ("2022/10/01", ".*2022\\/10\\/01\\/.*"),
+    ],
+)
 def test_get_push_proxy_pattern(import_date, expected):
     assert get_push_proxy_pattern(import_date) == expected
 
 
-@pytest.mark.parametrize("location,table,stage,zone", [
-    ("US", "logs", "push_proxy_stage", "us-east-1"),
-    ("DE", "de_logs", "push_proxy_de_stage", "eu-central-1"),
-    ("TEST", "test_logs", "push_proxy_test_stage", "us-east-1"),
-])
+@pytest.mark.parametrize(
+    "location,table,stage,zone",
+    [
+        ("US", "logs", "push_proxy_stage", "us-east-1"),
+        ("DE", "de_logs", "push_proxy_de_stage", "eu-central-1"),
+        ("TEST", "test_logs", "push_proxy_test_stage", "us-east-1"),
+    ],
+)
 def test_push_proxy_import(mocker, mock_environment, location, table, stage, zone):
     # GIVEN: environment configured for handling push proxy import
     # GIVEN: calls to extract from stage are captured
@@ -85,7 +116,14 @@ def test_push_proxy_import(mocker, mock_environment, location, table, stage, zon
     push_proxy_import(location, "2022/10/01")
 
     # THEN: expect extract to have been called once
-    mock_extract.assert_called_once_with(table, stage, "push_proxy", f"AWSLogs/test-aws-account-id/elasticloadbalancing/{zone}", ".*2022\\/10\\/01\\/.*", mock_environment)
+    mock_extract.assert_called_once_with(
+        table,
+        stage,
+        "push_proxy",
+        f"AWSLogs/test-aws-account-id/elasticloadbalancing/{zone}",
+        ".*2022\\/10\\/01\\/.*",
+        mock_environment,
+    )
 
 
 def test_licenses_import(mocker, mock_environment):
@@ -97,7 +135,33 @@ def test_licenses_import(mocker, mock_environment):
     licenses_import("2022-10-01")
 
     # THEN: expect extract to have been called once
-    mock_extract.assert_called_once_with("licenses", "licenses_stage", "licenses", "2022-10-01", ".*2022-10-01.csv", mock_environment)
+    mock_extract.assert_called_once_with(
+        "licenses",
+        "licenses_stage",
+        "licenses",
+        "2022-10-01",
+        ".*2022-10-01.csv",
+        mock_environment,
+    )
+
+
+def test_releases_import(mocker, mock_environment):
+    # GIVEN: environment configured for handling releases import -- see mock_environment
+    # GIVEN: calls to extract from stage are captured
+    mock_extract = mocker.patch("extract.s3_extract.stage_import.extract_from_stage")
+
+    # WHEN: license job is triggered for a specific date
+    releases_import("2022-10-01")
+
+    # THEN: expect extract to have been called once
+    mock_extract.assert_called_once_with(
+        "log_entries",
+        "releases_stage",
+        "releases",
+        "releases.mattermost.com-cloudfront/test-release-location",
+        ".*test-release-location.2022-10-01.*",
+        mock_environment,
+    )
 
 
 def _flatten_whitespaces(text):


### PR DESCRIPTION
#### Summary

Test job that imports releases data from S3. The job is nothing more than a trigger to Snowflake to copy data from an S3 stage. Copying stage has already been tested in https://github.com/mattermost/mattermost-data-warehouse/pull/1030, so all this PR needs to do is that the expected parameters are passed to the trigger.