### PR TITLE
Hotfix: fix failing tests

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           fetch-depth: 1
 
-
       - name: Install Poetry
         run: pipx install poetry
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,12 @@ authors = ["Munish Sharma <munish.sharma@mattermost.com>", "Ioannis Foukarakis <
 readme = "README.md"
 packages = [
     {include = "extract"},
-    {include = "transform"},
     {include = "utils"},
 ]
 exclude = [
-    ".",
     "dags",
-    "dags/billing/*"
+    "dags/billing/*",
+    "plugins",
 ]
 
 [tool.poetry.dependencies]
@@ -72,4 +71,4 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-addopts = "--ignore=dags"
+addopts = "--ignore=dags --ignore=plugins"


### PR DESCRIPTION
#### Summary

Fix failing tests due to introduction of `plugins` directory. This should be handled as a separate build process, ignoring from pytest for now.