### PR TITLE
MM-47583: run tests for airflow code

### DIFF
--- a/.github/workflows/ci-airflow.yml
+++ b/.github/workflows/ci-airflow.yml
@@ -1,0 +1,43 @@
+name: Aiflow Tests
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/ci-airflow.yml'
+      - 'dags/**'
+      - 'plugins/**'
+      - 'build/requirements-airflow-dev.txt'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/ci-airflow.yml'
+      - 'dags/**'
+      - 'plugins/**'
+      - 'build/requirements-airflow-dev.txt'
+
+jobs:
+  tests:
+    name: Testing Plugins and DAGs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+            fetch-depth: 1
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.6.12'   # This is the python version in the airflow docker image currently used
+          cache: 'pip'               # caching pip dependencies
+
+      - name: Install dependencies
+        run: pip install -r build/requirements-airflow-dev.txt
+
+      - name: Run tests
+        run: pytest dags plugins

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - '.github/**'
+      - '.github/workflows/ci-python.yml'
       - 'extract/**'
       - 'tests/**'
       - 'utils/**'
@@ -15,7 +15,7 @@ on:
     branches:
       - master
     paths:
-      - '.github/**'
+      - '.github/workflows/ci-python.yml'
       - 'extract/**'
       - 'tests/**'
       - 'utils/**'

--- a/airflow-requirements.txt
+++ b/airflow-requirements.txt
@@ -1,6 +1,0 @@
-markupsafe==2.0.1
-apache-airflow==1.10.12
-pytest==7.2.0
-pytest-mock==3.10.0
-pytest-responses==0.5.1
-responses==0.22.0

--- a/build/requirements-airflow-dev.txt
+++ b/build/requirements-airflow-dev.txt
@@ -1,0 +1,4 @@
+markupsafe==1.1.1
+apache-airflow==1.10.12
+pytest-mock==3.6.1
+pytest-responses==0.5.1


### PR DESCRIPTION
#### Summary

- [x] Run tests on airflow related code (dags and plugins) on PR and on merge on master.
- [x] Skip running python tests on airflow changes.
- [x] Move requirements for airflow under `build/` to be consistent.
- [x] Use same python version as the one deployed at production airflow (`3.6.12`).
- [x] Update dependencies to work with airflow's python version.
- [x] Add related tasks to Makefile.