### PR TITLE
Hotfix: provide default value for DBT_PROFILE_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,29 +132,25 @@ airflow-test: $(VIRTUALENV_AIRFLOW)  ## to run airflow tests
 .PHONY: dbt-docs
 dbt-docs: ## to generate and serve dbt docs
 	$(AT)$(INFO) Generating docs and spinning up the a webserver on port 8081...
-	$(AT)export DBT_PROFILE_PATH=".";\
-	$(DOCKER) compose run -d -p "8081:8081" dbt_image bash -c "dbt deps && dbt docs generate -t prod && dbt docs serve --port 8081"  || ${FAIL}
+	$(AT)$(DOCKER) compose run -d -p "8081:8081" dbt_image bash -c "dbt deps && dbt docs generate -t prod && dbt docs serve --port 8081"  || ${FAIL}
 	$(AT)$(OK) Server started, visit http://localhost:8081 to view the docs
 
 .PHONY: dbt-generate-docs
 dbt-generate-docs: ## to generate dbt docs
 	$(AT)$(INFO) Generating docs...
-	$(AT)export DBT_PROFILE_PATH=".";\
-	$(DOCKER) compose run dbt_image bash -c "dbt deps && dbt docs generate -t prod" } || ${FAIL}
+	$(AT)$(DOCKER) compose run dbt_image bash -c "dbt deps && dbt docs generate -t prod" } || ${FAIL}
 	$(AT)$(OK) Generated docs
 
 .PHONY: dbt-bash
 dbt-bash: ## to start a bash shell with DBT
 	$(AT)$(INFO) Running bash with dbt...
-	$(AT)export DBT_PROFILE_PATH=".";\
-	$(DOCKER) compose -f ${DOCKER_COMPOSE_DBT_FILE} run dbt_image bash -c "dbt deps && /bin/bash" || ${FAIL}
+	$(AT)$(DOCKER) compose -f ${DOCKER_COMPOSE_DBT_FILE} run dbt_image bash -c "dbt deps && /bin/bash" || ${FAIL}
 	$(AT)$(OK) Exited dbt bash
 
 .PHONY: data-image
 data-image: ## to start a bash shell on the data image
 	$(AT)$(INFO) Attaching to data-image and mounting repo...
-	$(AT)export DBT_PROFILE_PATH=".";\
-	$(DOCKER) compose -f ${DOCKER_COMPOSE_DBT_FILE} run data_image bash || ${FAIL}
+	$(AT)$(DOCKER) compose -f ${DOCKER_COMPOSE_DBT_FILE} run data_image bash || ${FAIL}
 	$(AT)$(OK) Exited data-image
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Copy `.dbt.env.example` to `.dbt.env`. Edit the file and replace placeholder wit
 At the home of the repo run:
 
 ```bash
-DBT_PROFILE_PATH=./transform/snowflake-dbt/profile make dbt-bash
+make dbt-bash
 ```
 
 This command creates a container with `dbt` pre-installed and connects you to the bash shell.
@@ -126,10 +126,22 @@ then the setup is working.
 At the home of the repo run:
 
 ```bash
-DBT_PROFILE_PATH=./transform/snowflake-dbt/profile make dbt-docs
+make dbt-docs
 ```
 
 This command will generate the docs and serve them at [http://localhost:8081](http://localhost:8081).
+
+### Overriding profile
+
+All dbt commands that are part of the `Makefile` use by default profiles under [transform/snowflake-dbt/profile](transform/snowflake-dbt/profile).
+This directory can be overriden by setting `DBT_PROFILE_PATH` environment variable:
+
+```bash
+DBT_PROFILE_PATH=/path/to/profile make dbt-bash
+```
+
+> Note that `DBT_PROFILE_PATH` can use either absolute or relative paths. For relative paths, the base is the [build](build) 
+> directory of this project.
 
 ## Developing
 
@@ -153,7 +165,6 @@ Additional dependencies can be specified at `pyproject.toml`. [Poetry's document
 provides examples. Please prefer using `poetry` CLI, as it also updates `poetry.lock` file and "pins" any new dependencies.
 
 > Note that currently there's a `requirements.txt` file. This file will be deprecated.
-
 
 ## Configuration
 

--- a/build/docker-compose.dbt.yml
+++ b/build/docker-compose.dbt.yml
@@ -19,7 +19,7 @@ services:
           source: ../transform/snowflake-dbt/
           target: /usr/app
         - type: bind
-          source: ${DBT_PROFILE_PATH}
+          source: ${DBT_PROFILE_PATH:-../transform/snowflake-dbt/profile}
           target: /usr/local/dbt_profiles/
           read_only: True
 
@@ -38,7 +38,7 @@ services:
     permifrost:
       image: docker.io/adovenmm/permifrost:latest
       env_file:
-        - ../.env
+        - ../.dbt.env
       restart: always
       command: /bin/bash -c "permifrost grant roles.yaml"
       volumes:


### PR DESCRIPTION
Hotfix: provide default value for DBT_PROFILE_PATH

#### Summary
- [x] Fix `make dbt-bash` target.
- [x] Use profile under `transform/snowflake-dbt/profile` as default.
- [x] Allow overriding profile path.
- [x] Update readme