### PR TITLE
Hotfix: reenable plugin tests

### DIFF
--- a/.github/workflows/ci-airflow.yml
+++ b/.github/workflows/ci-airflow.yml
@@ -34,16 +34,14 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.6.12'   # This is the python version in the airflow docker image currently used
+          architecture: x64          # See https://github.com/actions/setup-python/issues/162
           cache: 'pip'               # caching pip dependencies
 
       - name: Install dependencies
         run: pip install -r build/requirements-airflow-dev.txt
 
-      # - name: Run plugin tests
-      #   run: pytest plugins
-
-      - name: Run dag tests
-        run: pytest dags
+      # - name: Run tests
+      - name: Run plugin tests
+        run: pytest plugins dags
         env:
-          # DAGs require plugins package
           PYTHONPATH: .

--- a/.github/workflows/ci-airflow.yml
+++ b/.github/workflows/ci-airflow.yml
@@ -34,7 +34,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.6.12'   # This is the python version in the airflow docker image currently used
-          architecture: 'x64'        # See https://github.com/actions/setup-python/issues/162
           cache: 'pip'               # caching pip dependencies
 
       - name: Install dependencies

--- a/.github/workflows/ci-airflow.yml
+++ b/.github/workflows/ci-airflow.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   tests:
     name: Testing Plugins and DAGs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
 
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.6.12'   # This is the python version in the airflow docker image currently used
-          architecture: x64          # See https://github.com/actions/setup-python/issues/162
+          architecture: 'x64'        # See https://github.com/actions/setup-python/issues/162
           cache: 'pip'               # caching pip dependencies
 
       - name: Install dependencies

--- a/plugins/tests/hooks/test_mattermost_webhook.py
+++ b/plugins/tests/hooks/test_mattermost_webhook.py
@@ -3,7 +3,7 @@ import pytest
 from airflow import AirflowException
 from airflow.models import Connection
 
-from hooks.mattermost_webhook_hook import MattermostWebhookHook
+from plugins.hooks.mattermost_webhook_hook import MattermostWebhookHook
 
 def test_execute_simple_message(responses, ok_response, mock_connection):
     hook = MattermostWebhookHook(mattermost_conn_id='some_conn_id', text='Test message')

--- a/plugins/tests/operators/test_mattermost_operator.py
+++ b/plugins/tests/operators/test_mattermost_operator.py
@@ -1,4 +1,4 @@
-from operators.mattermost_operator import MattermostOperator
+from plugins.operators.mattermost_operator import MattermostOperator
 
 def test_create_full_config(dag, full_config):
     op = MattermostOperator(task_id="mattermost_task", dag=dag, **full_config)


### PR DESCRIPTION
#### Summary

- [x] Re-enable plugin tests
- [x] Fix references to plugins in tests
- [x] Pin ubuntu version to 20.04. `ubuntu-latest` was rolled from 20.04 to 22.04. 22.04 will have issues with python 3.6.