### PR TITLE
Fix - Airflow base url

### DIFF
--- a/.github/workflows/ci-airflow.yml
+++ b/.github/workflows/ci-airflow.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   tests:
     name: Testing Plugins and DAGs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
 
@@ -39,11 +39,8 @@ jobs:
       - name: Install dependencies
         run: pip install -r build/requirements-airflow-dev.txt
 
-      # - name: Run plugin tests
-      #   run: pytest plugins
-
-      - name: Run dag tests
-        run: pytest dags
+      # - name: Run tests
+      - name: Run plugin tests
+        run: pytest plugins dags
         env:
-          # DAGs require plugins package
           PYTHONPATH: .

--- a/dags/airflow_utils.py
+++ b/dags/airflow_utils.py
@@ -148,7 +148,7 @@ def create_alert_body(context):
     """
     Creates post body to be sent to mattermost channel.
     """
-    base_url = os.getenv("AIRFLOW_BASE_URL")
+    base_url = "https://airflow.internal.mattermost.com"
     execution_date = context["ts"]
     dag_context = context["dag"]
     dag_name = dag_context.dag_id

--- a/dags/tests/conftest.py
+++ b/dags/tests/conftest.py
@@ -11,7 +11,6 @@ def config_utils(monkeypatch):
 
         # patching environment variables used in airflow_utils
         monkeypatch.setenv("NAMESPACE", "test_namespace")
-        monkeypatch.setenv("AIRFLOW_BASE_URL", "https://test.airflow.mattermost.com")
 
 @pytest.fixture
 def config_alert_context(mocker):

--- a/dags/tests/test_airflow_utils.py
+++ b/dags/tests/test_airflow_utils.py
@@ -3,8 +3,8 @@ def test_create_alert_body(config_alert_context):
     from airflow_utils import create_alert_body
     body = create_alert_body(config_alert_context)
     assert ':red_circle: Test Exception message' in body
-    assert '**Dag**: [test_utils_dag](https://test.airflow.mattermost.com/tree?dag_id=test_utils_dag)' in body
-    assert '**Task**: [test_task](https://test.airflow.mattermost.com/task?dag_id=test_utils_dag&task_id=test_task&execution_date=2022-11-15T00%3A00%3A00%2B00%3A00)' in body
+    assert '**Dag**: [test_utils_dag](https://airflow.internal.mattermost.com/tree?dag_id=test_utils_dag)' in body
+    assert '**Task**: [test_task](https://airflow.internal.mattermost.com/task?dag_id=test_utils_dag&task_id=test_task&execution_date=2022-11-15T00%3A00%3A00%2B00%3A00)' in body
         
 def test_send_alert(config_alert_context, mocker):
 

--- a/plugins/tests/hooks/test_mattermost_webhook.py
+++ b/plugins/tests/hooks/test_mattermost_webhook.py
@@ -3,7 +3,7 @@ import pytest
 from airflow import AirflowException
 from airflow.models import Connection
 
-from hooks.mattermost_webhook_hook import MattermostWebhookHook
+from plugins.hooks.mattermost_webhook_hook import MattermostWebhookHook
 
 def test_execute_simple_message(responses, ok_response, mock_connection):
     hook = MattermostWebhookHook(mattermost_conn_id='some_conn_id', text='Test message')

--- a/plugins/tests/operators/test_mattermost_operator.py
+++ b/plugins/tests/operators/test_mattermost_operator.py
@@ -1,4 +1,4 @@
-from operators.mattermost_operator import MattermostOperator
+from plugins.operators.mattermost_operator import MattermostOperator
 
 def test_create_full_config(dag, full_config):
     op = MattermostOperator(task_id="mattermost_task", dag=dag, **full_config)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Airflow utils unable to get variable "airflow_base_url" from the env.
Hardcoded the value for temp fix.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
N/A

