### PR TITLE
Hotfix: rename duplicated dag

### DIFF
--- a/dags/extract/licenses_new.py
+++ b/dags/extract/licenses_new.py
@@ -24,7 +24,7 @@ default_args = {
 }
 
 # Create the DAG
-dag = DAG("licenses", default_args=default_args, schedule_interval="0 3 * * *")
+dag = DAG("licenses-new", default_args=default_args, schedule_interval="0 3 * * *")
 
 KubernetesPodOperator(
     **pod_defaults,


### PR DESCRIPTION
#### Summary

- [x] Rename duplicated dag to distinguish from original.