### PR TITLE
Hotfix: fix cli argument

### DIFF
--- a/dags/extract/licenses_new.py
+++ b/dags/extract/licenses_new.py
@@ -39,6 +39,6 @@ KubernetesPodOperator(
         SNOWFLAKE_LOAD_WAREHOUSE,
     ],
     env_vars={},
-    arguments=["extract.s3_extract.licenses_job {{{{ next_ds }}}}"],
+    arguments=["extract.s3_extract.licenses_job {{ next_ds }}"],
     dag=dag,
 )


### PR DESCRIPTION
#### Summary

Original argument was passed as an `f-string`, adjusting for normal string.