### PR TITLE
Hotfix: prepend python

### DIFF
--- a/dags/extract/licenses_new.py
+++ b/dags/extract/licenses_new.py
@@ -39,6 +39,6 @@ KubernetesPodOperator(
         SNOWFLAKE_LOAD_WAREHOUSE,
     ],
     env_vars={},
-    arguments=["extract.s3_extract.licenses_job {{ next_ds }}"],
+    arguments=["python -m extract.s3_extract.licenses_job {{ next_ds }}"],
     dag=dag,
 )


### PR DESCRIPTION
#### Summary

Add `python -m` as `entrypoint` seems to be overriden.