### PR TITLE
Hotfix: always pull latest image

### DIFF
--- a/dags/airflow_utils.py
+++ b/dags/airflow_utils.py
@@ -103,7 +103,7 @@ pod_resources = Resources(request_memory="500Mi", request_cpu="500m")
 # Default settings for all DAGs
 pod_defaults = dict(
     get_logs=True,
-    image_pull_policy="IfNotPresent",
+    image_pull_policy="Always",
     in_cluster=True,
     is_delete_operator_pod=True,
     namespace=os.environ["NAMESPACE"],


### PR DESCRIPTION
#### Summary

Image pull policy was set to `IfNotPresent`.  This resulted in the latest built image not being pulled. It has to be replaced with `Always` in order for latest changes to be visible.