### PR TITLE
Revert "Hotfix: always pull latest image (#1094)"

### DIFF
--- a/dags/airflow_utils.py
+++ b/dags/airflow_utils.py
@@ -103,7 +103,7 @@ pod_resources = Resources(request_memory="500Mi", request_cpu="500m")
 # Default settings for all DAGs
 pod_defaults = dict(
     get_logs=True,
-    image_pull_policy="Always",
+    image_pull_policy="IfNotPresent",
     in_cluster=True,
     is_delete_operator_pod=True,
     namespace=os.environ["NAMESPACE"],


### PR DESCRIPTION
This reverts commit 88fee8315d70441704a6d4bbb8157aab4009e8cb.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Reverting changes in PR -> https://github.com/mattermost/mattermost-data-warehouse/pull/1094
causing k8 pods to take long to load.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

