### PR TITLE
Hotfix: deduplicate-server-security-details

### DIFF
--- a/transform/snowflake-dbt/models/staging/server_security_details.sql
+++ b/transform/snowflake-dbt/models/staging/server_security_details.sql
@@ -37,7 +37,7 @@ WITH security                AS (
     {% if is_incremental() %}
 
         -- this filter will only be applied on an incremental run
-        AND date >= (SELECT MAX(date) FROM {{ this }})
+        AND date > (SELECT MAX(date) FROM {{ this }})
 
     {% endif %}
 ),
@@ -162,7 +162,7 @@ WITH security                AS (
         {% if is_incremental() %}
 
         -- this filter will only be applied on an incremental run
-        AND s.date >= (SELECT MAX(date) FROM {{ this }})
+        AND s.date > (SELECT MAX(date) FROM {{ this }})
 
          {% endif %}
          GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 19, 20, 21, 22


### PR DESCRIPTION
#### Summary

Incremental loading logic is using a `>=` statement for checking latest date. If the latest date happened to be the duplicate, then the new data would be created.

Since incremental loading requires newer data, it makes sense to include all records with timestamp greater (instead of greater or equal) than the max timestamp. 