### PR TITLE
MM-48977:  Introduce missing data check

### DIFF
--- a/transform/snowflake-dbt/models/data_quality_layer/raw/rudderstack/dq_daily_activity.sql
+++ b/transform/snowflake-dbt/models/data_quality_layer/raw/rudderstack/dq_daily_activity.sql
@@ -1,0 +1,63 @@
+{{config({
+    "materialized": 'table',
+    "schema": "data_quality",
+    "tags":'data-quality'
+  })
+}}
+
+-- Number of days to keep activity data for monitoring
+{% set retention = 90 %}
+
+WITH server_activities AS (
+    -- Find the dates where a server has been sending activity data
+    SELECT
+        USER_ID AS server_id,
+        TIMESTAMP::DATE AS date,
+        COUNT(*) AS cnt_activities
+    FROM
+        {{ source('mm_telemetry_prod', 'activity') }}
+    WHERE
+        TIMESTAMP BETWEEN DATEADD('day', -{{ retention }}, CURRENT_TIMESTAMP) AND CURRENT_TIMESTAMP
+    GROUP BY 1, 2
+),
+server_activity_range AS (
+    -- Find the date range where each server has been sending data
+    SELECT
+        server_id,
+        MIN(date) AS start_date,
+        MAX(date) AS end_date
+    FROM
+        server_activities
+    GROUP BY 1
+),
+dates AS (
+    -- Find all dates between start and today
+    SELECT
+        DISTINCT(TIMESTAMP::DATE) AS date
+    FROM
+        {{ source('mm_telemetry_prod', 'activity') }}
+    WHERE
+        TIMESTAMP BETWEEN DATEADD('day', -{{ retention }}, CURRENT_TIMESTAMP) AND CURRENT_TIMESTAMP
+),
+expected_dates AS (
+    -- Find all dates with expected activity data for a given server
+    SELECT
+        sar.server_id, date
+    FROM
+        server_activity_range sar
+        CROSS JOIN dates d
+    WHERE
+        d.date BETWEEN sar.start_date AND sar.end_date
+)
+SELECT
+    {{ dbt_utils.surrogate_key(['sd.server_id', 'sd.date']) }} as daily_activity_id,
+    sd.server_id,
+    sd.date,
+    COALESCE(sa.cnt_activities, 0) AS cnt_activities,
+    CASE WHEN sa.server_id IS NULL THEN true ELSE false END AS is_missing,
+    CASE WHEN sf.INSTALLATION_ID IS NOT NULL THEN true ELSE false END AS is_cloud
+FROM
+    expected_dates sd
+    LEFT JOIN server_activities sa ON sd.server_id = sa.server_id AND sd.date = sa.date
+    LEFT JOIN {{ ref('server_fact') }} sf ON sd.server_id = sf.server_id
+

--- a/transform/snowflake-dbt/models/data_quality_layer/raw/rudderstack/schema.yml
+++ b/transform/snowflake-dbt/models/data_quality_layer/raw/rudderstack/schema.yml
@@ -1,0 +1,38 @@
+version: 2
+
+models:
+  - name: dq_daily_activity
+    description: Daily information about activity data from Rudderstack.
+
+    columns:
+      - name: daily_activity_id
+        description: Primary key for server activity
+        tests:
+          - not_null
+          - unique
+
+      - name: server_id
+        description: The id of the server
+        tests:
+          - not_null
+
+      - name: date
+        description: The date of the activity
+        tests:
+          - not_null
+
+      - name: cnt_activities
+        description: The total number of activities for the given server and date
+        tests:
+          - not_null
+
+      - name: is_missing
+        description: Whether there's missing activity data for the given server and date
+        tests:
+          - not_null
+
+      - name: is_cloud
+        description: True if it's a cloud server
+        tests:
+          - not_null
+

--- a/transform/snowflake-dbt/tests/data_quality/raw/rudderstack/test_daily_activity.sql
+++ b/transform/snowflake-dbt/tests/data_quality/raw/rudderstack/test_daily_activity.sql
@@ -1,0 +1,39 @@
+{{
+    config(
+        tags=['data-quality']
+    )
+}}
+
+-- Thresholds for cloud, on prem and total missing data
+{%- set min_pct_missing_cloud = 0.01 -%}
+{%- set min_pct_missing_onprem = 0.01 -%}
+{%- set min_pct_missing = 0.01 -%}
+
+-- Checks if yesterday's missing activity data are above given threshold
+WITH activity_stats AS (
+    SELECT
+        date,
+        SUM(CASE WHEN is_missing AND is_cloud THEN 1 ELSE 0 END) AS cnt_missing_cloud,
+        SUM(CASE WHEN is_missing AND is_cloud THEN 0 ELSE 1 END) AS cnt_existing_cloud,
+        SUM(CASE WHEN is_missing AND not is_cloud THEN 1 ELSE 0 END) AS cnt_missing_onprem,
+        SUM(CASE WHEN is_missing AND not is_cloud THEN 0 ELSE 1 END) AS cnt_existing_onprem,
+        cnt_missing_cloud*1.0 / (cnt_missing_cloud + cnt_existing_cloud) AS pct_missing_cloud,
+        cnt_missing_onprem*1.0 / (cnt_missing_onprem + cnt_existing_onprem) AS pct_missing_onprem,
+        (cnt_missing_cloud + cnt_missing_onprem)*1.0 / (cnt_missing_cloud + cnt_missing_onprem + cnt_existing_cloud + cnt_existing_onprem) AS pct_missing,
+        cnt_missing_cloud + cnt_missing_onprem + cnt_existing_cloud + cnt_existing_onprem AS total
+    FROM
+        {{ ref('dq_daily_activity') }}
+    GROUP BY 1
+    ORDER BY 1
+)
+SELECT
+    *
+FROM
+    activity_stats
+WHERE
+    date > DATEADD('day', -7, CURRENT_DATE)
+    AND (
+        pct_missing_cloud > {{ min_pct_missing_cloud }}
+        OR pct_missing_onprem > {{ min_pct_missing_onprem }}
+        OR pct_missing > {{ min_pct_missing }}
+    )


### PR DESCRIPTION
#### Summary

Introduces a new model for testing for missing activity data. This PR contains the following items:
- [x] DBT model for figuring out missing activity data per date. Last 90 days are used as "retention" period in order to save disk space.
- [x] DBT test checking the percentage of missing data for the past week against a configured threshold. 
- [x] Use a separate `data-quality` tag both for model and tests. This way data quality models and tests can be isolated and run independently of other models.

Note that thresholds can (and should) be changed. 

If you want to run the examples, you can try the following commands:
```bash
# Create model with historical missing data
dbt run --select tag:data-quality -t prod

# Run the test - requires the previous command
dbt test --select tag:data-quality -t prod
```

You can preview the output by checking `analytics.data_quality.dq_daily_activity` table.

Next step would be to run the tests daily, ideally after the daily DBT job has completed. 