### PR TITLE
MM-49001: drop extra clearbit fields

### DIFF
--- a/tests/utils/fixtures/clearbit/cloud/expectations/person-company.json
+++ b/tests/utils/fixtures/clearbit/cloud/expectations/person-company.json
@@ -128,8 +128,7 @@
     "person": null,
     "company": null,
     "server_id": "server-0010",
-    "company_geo_streetaddress": null,
-    "company_metrics_trafficrank": null
+    "company_geo_streetaddress": null
   },
   {
     "column_name": null,
@@ -260,7 +259,6 @@
     "person": null,
     "company": null,
     "server_id": "server-0011",
-    "company_geo_streetaddress": null,
-    "company_metrics_trafficrank": "medium"
+    "company_geo_streetaddress": null
   }
 ]

--- a/utils/cloud_clearbit.py
+++ b/utils/cloud_clearbit.py
@@ -167,6 +167,10 @@ def cloud_clearbit():
             # CONVERT COLUMN NAMES TO LOWERCASE FOR LOADING PURPOSES
             clearbit_df2.columns = clearbit_df2.columns.str.lower()
 
+            # If the list of columns is known (table already exists), then don't add new columns.
+            if clearbit_cols:
+                clearbit_df2 = clearbit_df2[clearbit_cols]
+
             engine = snowflake_engine_factory(os.environ, "TRANSFORMER", "util")
             with engine.connect() as connection:
 


### PR DESCRIPTION
#### Summary

Clearbit introduced a new field (`trafficrank`). This field cannot be inserted without adding an extra column in the database. Ignoring for now.