### PR TITLE
MM-49037: reenable automatic deployments for python code

### DIFF
--- a/dags/airflow_utils.py
+++ b/dags/airflow_utils.py
@@ -102,7 +102,7 @@ pod_resources = Resources(request_memory="500Mi", request_cpu="500m")
 # Default settings for all DAGs
 pod_defaults = dict(
     get_logs=True,
-    image_pull_policy="Always",
+    image_pull_policy="IfNotPresent",
     in_cluster=True,
     is_delete_operator_pod=True,
     namespace=os.environ["NAMESPACE"],

--- a/dags/airflow_utils.py
+++ b/dags/airflow_utils.py
@@ -8,13 +8,12 @@ from typing import List
 from airflow.contrib.kubernetes.pod import Resources
 
 from plugins.operators.mattermost_operator import MattermostOperator
-from airflow.models import Variable
 
-DATA_IMAGE = "docker.io/adovenmm/data-image:v1.23.1"
-DBT_IMAGE = "docker.io/adovenmm/dbt-image:v0.18.1"
 PERMIFROST_IMAGE = "docker.io/adovenmm/permifrost-image:latest"
 PSQL_IMAGE = "docker.io/adovenmm/data-warehouse-psql:latest"
 PIPELINEWISE_IMAGE = "docker.io/adovenmm/pipelinewise:latest"
+
+MATTERMOST_DATAWAREHOUSE_IMAGE = "mattermost/mattermost-data-warehouse:master"
 
 mm_webhook_url = os.getenv("MATTERMOST_WEBHOOK_URL")
 
@@ -103,7 +102,7 @@ pod_resources = Resources(request_memory="500Mi", request_cpu="500m")
 # Default settings for all DAGs
 pod_defaults = dict(
     get_logs=True,
-    image_pull_policy="IfNotPresent",
+    image_pull_policy="Always",
     in_cluster=True,
     is_delete_operator_pod=True,
     namespace=os.environ["NAMESPACE"],

--- a/dags/extract/diagnostics.py
+++ b/dags/extract/diagnostics.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from airflow import DAG
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 
-from dags.airflow_utils import pod_defaults, send_alert
+from dags.airflow_utils import MATTERMOST_DATAWAREHOUSE_IMAGE, pod_defaults, send_alert
 from dags.kube_secrets import (
     DIAGNOSTIC_LOCATION_ONE,
     DIAGNOSTIC_LOCATION_TWO,
@@ -16,7 +16,6 @@ from dags.kube_secrets import (
 
 # Default arguments for the DAG
 default_args = {
-    "catchup": False,
     "depends_on_past": False,
     "on_failure_callback": send_alert,
     "owner": "airflow",
@@ -26,11 +25,17 @@ default_args = {
 }
 
 # Create the DAG
-dag = DAG("diagnostics", default_args=default_args, schedule_interval="0 3 * * *")
+dag = DAG(
+    "diagnostics",
+    default_args=default_args,
+    schedule_interval="0 3 * * *",
+    catchup=False,
+    max_active_runs=1,  # Don't allow multiple concurrent dag executions
+)
 
 KubernetesPodOperator(
     **pod_defaults,
-    image="mattermost/mattermost-data-warehouse:master",
+    image=MATTERMOST_DATAWAREHOUSE_IMAGE,
     task_id="diagnostics",
     name="diagnostics",
     secrets=[

--- a/dags/extract/releases.py
+++ b/dags/extract/releases.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from airflow import DAG
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 
-from dags.airflow_utils import pod_defaults, send_alert
+from dags.airflow_utils import MATTERMOST_DATAWAREHOUSE_IMAGE, pod_defaults, send_alert
 from dags.kube_secrets import (
     RELEASE_LOCATION,
     SNOWFLAKE_ACCOUNT,
@@ -19,7 +19,6 @@ env = os.environ.copy()
 
 # Default arguments for the DAG
 default_args = {
-    "catchup": False,
     "depends_on_past": False,
     "on_failure_callback": send_alert,
     "owner": "airflow",
@@ -29,11 +28,17 @@ default_args = {
 }
 
 # Create the DAG
-dag = DAG("releases", default_args=default_args, schedule_interval="0 3 * * *")
+dag = DAG(
+    "releases",
+    default_args=default_args,
+    schedule_interval="0 3 * * *",
+    catchup=False,
+    max_active_runs=1,  # Don't allow multiple concurrent dag executions
+)
 
 KubernetesPodOperator(
     **pod_defaults,
-    image="mattermost/mattermost-data-warehouse:master",  # Uses latest build from master
+    image=MATTERMOST_DATAWAREHOUSE_IMAGE,  # Uses latest build from master
     task_id="release",
     name="release",
     secrets=[

--- a/dags/general/weekly_job.py
+++ b/dags/general/weekly_job.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from airflow import DAG
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 
-from dags.airflow_utils import pod_defaults, send_alert
+from dags.airflow_utils import MATTERMOST_DATAWAREHOUSE_IMAGE, pod_defaults, send_alert
 from dags.kube_secrets import (
     DOCS_WEBHOOK_URL,
     SNOWFLAKE_ACCOUNT,
@@ -17,7 +17,6 @@ from dags.kube_secrets import (
 
 # Default arguments for the DAG
 default_args = {
-    "catchup": False,
     "depends_on_past": False,
     "owner": "airflow",
     "on_failure_callback": send_alert,
@@ -28,11 +27,17 @@ default_args = {
 }
 
 # Create the DAG
-dag = DAG("weekly_job", default_args=default_args, schedule_interval="0 12 * * 1")
+dag = DAG(
+    "weekly_job",
+    default_args=default_args,
+    schedule_interval="0 12 * * 1",
+    catchup=False,
+    max_active_runs=1,  # Don't allow multiple concurrent dag executions
+)
 
 post_docs_feedback = KubernetesPodOperator(
     **pod_defaults,
-    image="mattermost/mattermost-data-warehouse:master",  # Uses latest build from master
+    image=MATTERMOST_DATAWAREHOUSE_IMAGE,  # Uses latest build from master
     task_id="post-docs-feedback",
     name="post-docs-feedback",
     secrets=[

--- a/dags/helpers/__init__.py
+++ b/dags/helpers/__init__.py
@@ -1,0 +1,3 @@
+"""
+DAGs not related to ETLs but helping maintain the system.
+"""

--- a/dags/helpers/cicd.py
+++ b/dags/helpers/cicd.py
@@ -22,9 +22,9 @@ doc_md = """
 
 #### Purpose
 
-This DAG attempts to load the latest `master` version of the image on each run. 
+This DAG attempts to load the latest `master` version of the image on each run.
 
-> This is a workaround in order to reduce the load from pulling new images. The trick is that this is the only 
+> This is a workaround in order to reduce the load from pulling new images. The trick is that this is the only
 > DAG that will `Always` try to download the new image.
  """
 

--- a/dags/helpers/cicd.py
+++ b/dags/helpers/cicd.py
@@ -1,0 +1,54 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+
+from dags.airflow_utils import MATTERMOST_DATAWAREHOUSE_IMAGE, send_alert
+
+# Default arguments for the DAG
+default_args = {
+    "depends_on_past": False,
+    "owner": "airflow",
+    "on_failure_callback": send_alert,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=1),
+    "sla": timedelta(hours=8),
+    "start_date": datetime(2019, 1, 1, 0, 0, 0),
+}
+
+doc_md = """
+### CI/CD DAG
+
+#### Purpose
+
+This DAG attempts to load the latest `master` version of the image on each run. 
+
+> This is a workaround in order to reduce the load from pulling new images. The trick is that this is the only 
+> DAG that will `Always` try to download the new image.
+ """
+
+# Create the DAG
+dag = DAG(
+    "cicd",
+    default_args=default_args,
+    schedule_interval="*/5 * * * *",
+    catchup=False,
+    max_active_runs=1,  # Don't allow multiple concurrent dag executions
+    doc_md=doc_md,
+)
+
+# Dummy task that just runs a random command.
+dummy = KubernetesPodOperator(
+    get_logs=True,
+    image_pull_policy="Always",
+    in_cluster=True,
+    is_delete_operator_pod=True,
+    namespace=os.environ["NAMESPACE"],
+    cmds=["/bin/bash", "-c"],
+    image=MATTERMOST_DATAWAREHOUSE_IMAGE,  # Uses latest build from master
+    task_id="download-image",
+    name="download-image",
+    arguments=["date"],
+    dag=dag,
+)


### PR DESCRIPTION
#### Summary

- [x] Created a new DAG with `image_pull_policy` to `Always`. This DAG will pull the latest image with `master` tag (if any) every 5 minutes. 
- [x] Make sure tasks do not start if previous have not completed.
  - [x] Set DAG `max_active_runs` to `1` for all DAGs that use the `mattermost-data-warehouse` image.
  - [x] Moved image definition to `airflow_utils.py` so that it's defined on a single place.
  - [x] Properly moved `catchup` configuration as an argument to DAG's constructor rather than in `default_args`. [Airflow API](https://airflow.apache.org/docs/apache-airflow/1.10.12/_api/airflow/models/index.html?highlight=baseoperator#airflow.models.DAG) defines it this way.
- [x] Minor removals of dead code.
