### PR TITLE
Hotfix: airflow stitch alerts

### DIFF
--- a/dags/general/_helpers.py
+++ b/dags/general/_helpers.py
@@ -79,7 +79,7 @@ def resolve_stitch(ti=None, **kwargs):
         task_logger.info('There are no failed loads or extractions')
     else:
         status = ':red_circle:'
-        message = f"**STITCH**: {status}\nFailed extractions: " "{failed_extractions}\nFailed loads: {failed_loads}"
+        message = f"**STITCH**: {status}\nFailed extractions:{failed_extractions}\nFailed loads: {failed_loads}"
         MattermostOperator(mattermost_conn_id='mattermost', text=message, task_id='resolve_stitch_message').execute(
             None
         )

--- a/dags/general/monitoring.py
+++ b/dags/general/monitoring.py
@@ -35,7 +35,7 @@ with DAG(
     start_date=datetime(2017, 3, 20),
     schedule_interval='@hourly',
     catchup=False,
-) as dag:
+):
     check_stitch_extractions = SimpleHttpOperator(
         task_id="check_stitch_extractions",
         # TODO add to airflow variables

--- a/dags/general/monitoring.py
+++ b/dags/general/monitoring.py
@@ -35,7 +35,7 @@ with DAG(
     start_date=datetime(2017, 3, 20),
     schedule_interval='@hourly',
     catchup=False,
-):
+) as dag:
     check_stitch_extractions = SimpleHttpOperator(
         task_id="check_stitch_extractions",
         # TODO add to airflow variables


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Stitch alerts are not showing failed extractions and loads.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

