### PR TITLE
Chore: move airflow's docker compose under build

### DIFF
--- a/build/docker-compose-airflow.yml
+++ b/build/docker-compose-airflow.yml
@@ -31,8 +31,8 @@ services:
       - NAMESPACE=airflow
     volumes:
       - airflow_scheduler_data:/bitnami
-      - ./dags:/opt/bitnami/airflow/dags/dags
-      - ./plugins:/opt/bitnami/airflow/plugins
+      - ../dags:/opt/bitnami/airflow/dags/dags
+      - ../plugins:/opt/bitnami/airflow/dags/plugins
 
   airflow-worker:
     depends_on:
@@ -48,8 +48,8 @@ services:
       - NAMESPACE=airflow
     volumes:
       - airflow_worker_data:/bitnami
-      - ./dags:/opt/bitnami/airflow/dags/dags
-      - ./plugins:/opt/bitnami/airflow/plugins
+      - ../dags:/opt/bitnami/airflow/dags/dags
+      - ../plugins:/opt/bitnami/airflow/dags/plugins
 
   airflow:
     depends_on:
@@ -67,8 +67,8 @@ services:
       - '8080:8080'
     volumes:
       - airflow_data:/bitnami
-      - ./dags:/opt/bitnami/airflow/dags/dags
-      - ./plugins:/opt/bitnami/airflow/plugins
+      - ../dags:/opt/bitnami/airflow/dags/dags
+      - ../plugins:/opt/bitnami/airflow/dags/plugins
 
 volumes:
   airflow_scheduler_data:

--- a/docs/Airflow.md
+++ b/docs/Airflow.md
@@ -19,7 +19,7 @@ restart!).
 At the root of the project run 
 
 ```bash
-docker compose -f docker-compose-airflow.yml up
+docker compose -f build/docker-compose-airflow.yml up
 ```
 
 After a while you can access airflow at [http://localhost:8080](http://localhost:8080), with username/password `user`/`bitnami`.


### PR DESCRIPTION
#### Summary

-[x] Move `docker-compose-airflow.yml` under `build/` directory to be consistent with the rest of the project.
-[x] Minor fix for importing `plugins`.
-[x] Updated docs.
