### PR TITLE
Chore: update tests/utils code according to lint rules

### DIFF
--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -19,10 +19,7 @@ def mock_settings_env_vars(mocker):
     mocker.patch("utils.run_dbt_cloud_job.timeout", 35)
 
     # Mock items loaded using os.environ in method calls
-    mock_env_vars = {
-        'GITHUB_TOKEN': 'token',
-        'CLEARBIT_KEY': 'clearbit-test-key'
-    }
+    mock_env_vars = {'GITHUB_TOKEN': 'token', 'CLEARBIT_KEY': 'clearbit-test-key'}
     mocker.patch.dict(os.environ, mock_env_vars, clear=True)
 
 
@@ -37,13 +34,14 @@ def given_request_to(request, responses):
     """
 
     def _given_request_to(url, response_file, method="GET", status=200):
-        config = getattr(request.module, '__MOCK_REQUEST_DEFAULTS') or {}
-        target = Path(__file__).parent / 'fixtures' / config.get('dir') / response_file if config.get('dir') \
+        config = getattr(request.module, '__MOCK_REQUEST_DEFAULTS', {})
+        target = (
+            Path(__file__).parent / 'fixtures' / config.get('dir') / response_file
+            if config.get('dir')
             else Path(__file__).parent / 'fixtures' / response_file
+        )
         with open(target) as fp:
-            rsp = Response(method=method, url=url,
-                           status=status, headers=config.get('headers', {}),
-                           body=fp.read())
+            rsp = Response(method=method, url=url, status=status, headers=config.get('headers', {}), body=fp.read())
             responses.add(rsp)
 
     return _given_request_to
@@ -51,7 +49,6 @@ def given_request_to(request, responses):
 
 @pytest.fixture()
 def mock_snowflake(mocker):
-
     def _mock_snowflake(module_name):
         mock_engine_factory = mocker.patch(f"{module_name}.snowflake_engine_factory")
         mock_engine = mocker.MagicMock()
@@ -102,10 +99,10 @@ def user_agent_input():
     with open(Path(__file__).parent / 'fixtures' / 'user_agent' / 'agents.txt') as fp:
         return fp.read().splitlines()
 
+
 @pytest.fixture()
 def mock_clearbit(mocker):
     def _mock_clearbit(module_name):
-        count = 0
         # Mock clearbit client
         mock_clearbit = mocker.patch(f"{module_name}.clearbit")
         return mock_clearbit
@@ -127,6 +124,7 @@ def _mock_clearbit_factory(api):
     """
     Creates a loader for returning responses from provided clearbit {api}.
     """
+
     def _load_responses(*args):
         """
         Lazily loads each file defined as args. The files are loaded from fixture/{api}.
@@ -166,7 +164,6 @@ def expect_data():
 
 @pytest.fixture
 def mock_snowflake_connector(mocker):
-
     def _mock_snowflake_connector(module_name):
         snowflake_connector_factory = mocker.patch(f"{module_name}.snowflake.connector.connect")
         mock_connection = mocker.Mock()
@@ -179,18 +176,25 @@ def mock_snowflake_connector(mocker):
         mock_cursor.fetchall.return_value = mock_fetchall
 
         return mock_cursor, mock_connection, mock_execute, mock_fetchall
-    
+
     return _mock_snowflake_connector
+
 
 @pytest.fixture
 def post_nps_ok(responses):
-    response = Response(method="POST", url="https://mattermost.example.com/hooks/hookid", status=200, content_type='application/json')
+    response = Response(
+        method="POST", url="https://mattermost.example.com/hooks/hookid", status=200, content_type='application/json'
+    )
     responses.add(response)
+
 
 @pytest.fixture
 def post_nps_error(responses):
-    response = Response(method="POST", url="https://mattermost.example.com/hooks/hookid", status=401, content_type='application/json')
+    response = Response(
+        method="POST", url="https://mattermost.example.com/hooks/hookid", status=401, content_type='application/json'
+    )
     responses.add(response)
+
 
 @pytest.fixture
 def config_nps(monkeypatch, mocker):

--- a/tests/utils/test_cloud_clearbit.py
+++ b/tests/utils/test_cloud_clearbit.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import pandas as pd
 import pytest
 import sqlalchemy
-from sqlalchemy.exc import ProgrammingError
 
 from utils.cloud_clearbit import cloud_clearbit
 
@@ -13,124 +12,199 @@ with open(Path(__file__).parent / "fixtures" / "clearbit" / "cloud" / "setup" / 
     CLEARBIT_COLUMNS = [line.strip() for line in fp.readlines()]
 
 
-@pytest.mark.parametrize("column_names,table_data,items_to_update,clearbit_responses,expected", [
-    pytest.param(
-        # GIVEN: table exists
-        pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
-        # GIVEN: table contains some data
-        pd.DataFrame(),
-        # GIVEN: one item to update
-        pd.DataFrame.from_dict([
-            {"LICENSE_EMAIL": "test@example.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0009",
-             "INSTALLATION_ID": "installation-1042", "FIRST_ACTIVE_DATE": "2022-11-01",
-             "LAST_UP_ADDRESS": "42.42.42.42"},
-        ]),
-        # GIVEN: clearbit returns data for response
-        ["example.json"],
-        # THEN: expect one item to have been updated
-        "example.json",
-        id="table exists - contains data - one item to be updated - clearbit returns data"
-    ),
-    pytest.param(
-        # GIVEN: table exists
-        pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
-        # GIVEN: table contains some data
-        pd.DataFrame(),
-        # GIVEN: two items to update
-        pd.DataFrame.from_dict([
-            {"LICENSE_EMAIL": "alex@alexmaccaw.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0001",
-             "INSTALLATION_ID": "installation-1001", "FIRST_ACTIVE_DATE": "2022-10-01",
-             "LAST_UP_ADDRESS": "123.123.123.123"},
-            {"LICENSE_EMAIL": "test@example.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0009",
-             "INSTALLATION_ID": "installation-1042", "FIRST_ACTIVE_DATE": "2022-11-01",
-             "LAST_UP_ADDRESS": "42.42.42.42"},
-        ]),
-        # GIVEN: clearbit returns data for both responses
-        ["clearbit.json", "example.json"],
-        # THEN: expect two items to have been updated
-        "all.json",
-        id="table exists - contains data - two items to be updated - clearbit returns both"
-    ),
-    pytest.param(
-        # GIVEN: table exists
-        pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
-        # GIVEN: table contains some data
-        pd.DataFrame(),
-        # GIVEN: two items to update
-        pd.DataFrame.from_dict([
-            {"LICENSE_EMAIL": "alex@alexmaccaw.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0001",
-             "INSTALLATION_ID": "installation-1001", "FIRST_ACTIVE_DATE": "2022-10-01",
-             "LAST_UP_ADDRESS": "123.123.123.123"},
-            {"LICENSE_EMAIL": "test@example.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0009",
-             "INSTALLATION_ID": "installation-1042", "FIRST_ACTIVE_DATE": "2022-11-01",
-             "LAST_UP_ADDRESS": "42.42.42.42"},
-        ]),
-        # GIVEN: clearbit fails on first item but returns for the second
-        [None, "example.json"],
-        # THEN: expect one item to have been updated
-        "all-with-failure.json",
-        id="table exists - contains data - two items to be updated - clearbit returns one"
-    ),
-    pytest.param(
-        # GIVEN: table exists
-        pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
-        # GIVEN: table doesn't contain data
-        None,
-        # GIVEN: two items to update
-        pd.DataFrame.from_dict([
-            {"LICENSE_EMAIL": "alex@alexmaccaw.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0001",
-             "INSTALLATION_ID": "installation-1001", "FIRST_ACTIVE_DATE": "2022-10-01",
-             "LAST_UP_ADDRESS": "123.123.123.123"},
-            {"LICENSE_EMAIL": "test@example.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0009",
-             "INSTALLATION_ID": "installation-1042", "FIRST_ACTIVE_DATE": "2022-11-01",
-             "LAST_UP_ADDRESS": "42.42.42.42"},
-        ]),
-        # GIVEN: clearbit returns data only for one of the two items
-        ["clearbit.json", "example.json"],
-        # THEN: expect two items to have been updated
-        "all.json",
-        id="table exists - no data - two items to be updated - clearbit returns both"
-    ),
-    pytest.param(
-        # GIVEN: table doesn't exist
-        sqlalchemy.exc.ProgrammingError("SELECT 1", {}, None),
-        # GIVEN: table doesn't contain data
-        sqlalchemy.exc.ProgrammingError("SELECT 1", {}, None),
-        # GIVEN: one item to update
-        pd.DataFrame.from_dict([
-            {"LICENSE_EMAIL": "test@example.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0009",
-             "INSTALLATION_ID": "installation-1042", "FIRST_ACTIVE_DATE": "2022-11-01",
-             "LAST_UP_ADDRESS": "42.42.42.42"},
-        ]),
-        # GIVEN: clearbit returns data for single responses
-        ["example.json"],
-        # THEN: expect one item to have been updated
-        "example-new-table.json",
-        id="table doesn't exist - no data - one item to be updated - clearbit returns one"
-    ),
-    pytest.param(
-        # GIVEN: table exists
-        pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
-        # GIVEN: table contains some data
-        pd.DataFrame(),
-        # GIVEN: two items to update
-        pd.DataFrame.from_dict([
-            {"LICENSE_EMAIL": "test1@example.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0010",
-             "INSTALLATION_ID": "installation-1042", "FIRST_ACTIVE_DATE": "2022-11-01",
-             "LAST_UP_ADDRESS": "42.42.42.42"},
-            {"LICENSE_EMAIL": "test2@example.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0011",
-             "INSTALLATION_ID": "installation-1042", "FIRST_ACTIVE_DATE": "2022-11-01",
-             "LAST_UP_ADDRESS": "42.42.42.42"},
-        ]),
-        # GIVEN: clearbit returns data for both responses, first response doesn't contain company info
-        ["person-only.json", "company-only.json"],
-        # THEN: expect two items to have been updated
-        "person-company.json",
-        id="table exists - contains data - three items to be updated - clearbit returns all"
-    ),
-])
-def test_cloud_clearbit(mock_snowflake, mock_snowflake_pandas, mock_clearbit, mock_clearbit_enrichments, expect_data,
-                        column_names, table_data, items_to_update, clearbit_responses, expected):
+@pytest.mark.parametrize(
+    "column_names,table_data,items_to_update,clearbit_responses,expected",
+    [
+        pytest.param(
+            # GIVEN: table exists
+            pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
+            # GIVEN: table contains some data
+            pd.DataFrame(),
+            # GIVEN: one item to update
+            pd.DataFrame.from_dict(
+                [
+                    {
+                        "LICENSE_EMAIL": "test@example.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0009",
+                        "INSTALLATION_ID": "installation-1042",
+                        "FIRST_ACTIVE_DATE": "2022-11-01",
+                        "LAST_UP_ADDRESS": "42.42.42.42",
+                    },
+                ]
+            ),
+            # GIVEN: clearbit returns data for response
+            ["example.json"],
+            # THEN: expect one item to have been updated
+            "example.json",
+            id="table exists - contains data - one item to be updated - clearbit returns data",
+        ),
+        pytest.param(
+            # GIVEN: table exists
+            pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
+            # GIVEN: table contains some data
+            pd.DataFrame(),
+            # GIVEN: two items to update
+            pd.DataFrame.from_dict(
+                [
+                    {
+                        "LICENSE_EMAIL": "alex@alexmaccaw.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0001",
+                        "INSTALLATION_ID": "installation-1001",
+                        "FIRST_ACTIVE_DATE": "2022-10-01",
+                        "LAST_UP_ADDRESS": "123.123.123.123",
+                    },
+                    {
+                        "LICENSE_EMAIL": "test@example.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0009",
+                        "INSTALLATION_ID": "installation-1042",
+                        "FIRST_ACTIVE_DATE": "2022-11-01",
+                        "LAST_UP_ADDRESS": "42.42.42.42",
+                    },
+                ]
+            ),
+            # GIVEN: clearbit returns data for both responses
+            ["clearbit.json", "example.json"],
+            # THEN: expect two items to have been updated
+            "all.json",
+            id="table exists - contains data - two items to be updated - clearbit returns both",
+        ),
+        pytest.param(
+            # GIVEN: table exists
+            pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
+            # GIVEN: table contains some data
+            pd.DataFrame(),
+            # GIVEN: two items to update
+            pd.DataFrame.from_dict(
+                [
+                    {
+                        "LICENSE_EMAIL": "alex@alexmaccaw.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0001",
+                        "INSTALLATION_ID": "installation-1001",
+                        "FIRST_ACTIVE_DATE": "2022-10-01",
+                        "LAST_UP_ADDRESS": "123.123.123.123",
+                    },
+                    {
+                        "LICENSE_EMAIL": "test@example.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0009",
+                        "INSTALLATION_ID": "installation-1042",
+                        "FIRST_ACTIVE_DATE": "2022-11-01",
+                        "LAST_UP_ADDRESS": "42.42.42.42",
+                    },
+                ]
+            ),
+            # GIVEN: clearbit fails on first item but returns for the second
+            [None, "example.json"],
+            # THEN: expect one item to have been updated
+            "all-with-failure.json",
+            id="table exists - contains data - two items to be updated - clearbit returns one",
+        ),
+        pytest.param(
+            # GIVEN: table exists
+            pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
+            # GIVEN: table doesn't contain data
+            None,
+            # GIVEN: two items to update
+            pd.DataFrame.from_dict(
+                [
+                    {
+                        "LICENSE_EMAIL": "alex@alexmaccaw.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0001",
+                        "INSTALLATION_ID": "installation-1001",
+                        "FIRST_ACTIVE_DATE": "2022-10-01",
+                        "LAST_UP_ADDRESS": "123.123.123.123",
+                    },
+                    {
+                        "LICENSE_EMAIL": "test@example.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0009",
+                        "INSTALLATION_ID": "installation-1042",
+                        "FIRST_ACTIVE_DATE": "2022-11-01",
+                        "LAST_UP_ADDRESS": "42.42.42.42",
+                    },
+                ]
+            ),
+            # GIVEN: clearbit returns data only for one of the two items
+            ["clearbit.json", "example.json"],
+            # THEN: expect two items to have been updated
+            "all.json",
+            id="table exists - no data - two items to be updated - clearbit returns both",
+        ),
+        pytest.param(
+            # GIVEN: table doesn't exist
+            sqlalchemy.exc.ProgrammingError("SELECT 1", {}, None),
+            # GIVEN: table doesn't contain data
+            sqlalchemy.exc.ProgrammingError("SELECT 1", {}, None),
+            # GIVEN: one item to update
+            pd.DataFrame.from_dict(
+                [
+                    {
+                        "LICENSE_EMAIL": "test@example.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0009",
+                        "INSTALLATION_ID": "installation-1042",
+                        "FIRST_ACTIVE_DATE": "2022-11-01",
+                        "LAST_UP_ADDRESS": "42.42.42.42",
+                    },
+                ]
+            ),
+            # GIVEN: clearbit returns data for single responses
+            ["example.json"],
+            # THEN: expect one item to have been updated
+            "example-new-table.json",
+            id="table doesn't exist - no data - one item to be updated - clearbit returns one",
+        ),
+        pytest.param(
+            # GIVEN: table exists
+            pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
+            # GIVEN: table contains some data
+            pd.DataFrame(),
+            # GIVEN: two items to update
+            pd.DataFrame.from_dict(
+                [
+                    {
+                        "LICENSE_EMAIL": "test1@example.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0010",
+                        "INSTALLATION_ID": "installation-1042",
+                        "FIRST_ACTIVE_DATE": "2022-11-01",
+                        "LAST_UP_ADDRESS": "42.42.42.42",
+                    },
+                    {
+                        "LICENSE_EMAIL": "test2@example.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0011",
+                        "INSTALLATION_ID": "installation-1042",
+                        "FIRST_ACTIVE_DATE": "2022-11-01",
+                        "LAST_UP_ADDRESS": "42.42.42.42",
+                    },
+                ]
+            ),
+            # GIVEN: clearbit returns data for both responses, first response doesn't contain company info
+            ["person-only.json", "company-only.json"],
+            # THEN: expect two items to have been updated
+            "person-company.json",
+            id="table exists - contains data - three items to be updated - clearbit returns all",
+        ),
+    ],
+)
+def test_cloud_clearbit(
+    mock_snowflake,
+    mock_snowflake_pandas,
+    mock_clearbit,
+    mock_clearbit_enrichments,
+    expect_data,
+    column_names,
+    table_data,
+    items_to_update,
+    clearbit_responses,
+    expected,
+):
     # GIVEN: snowflake engine and connection are mocked
     mock_snowflake("utils.cloud_clearbit")
     # GIVEN: snowflake pandas interactions are mocked
@@ -144,7 +218,7 @@ def test_cloud_clearbit(mock_snowflake, mock_snowflake_pandas, mock_clearbit, mo
         # GIVEN: clearbit table contains data? (second request to load dataframe)
         table_data,
         # GIVEN: items to update
-        items_to_update
+        items_to_update,
     ]
     # GIVEN: clearbit returns two enrichments
     mock_clearbit.Enrichment.find.side_effect = mock_clearbit_enrichments(*clearbit_responses)
@@ -157,48 +231,70 @@ def test_cloud_clearbit(mock_snowflake, mock_snowflake_pandas, mock_clearbit, mo
     pd.testing.assert_frame_equal(
         mock_to_sql.call_args_list[0][0][0].sort_index(axis=1),
         expect_data(expected).sort_index(axis=1),
-        check_dtype=False
+        check_dtype=False,
     )
     # THEN: expect calls to clearbit to be equal to number of items to update
     assert mock_clearbit.Enrichment.find.call_count == len(items_to_update)
 
 
-@pytest.mark.parametrize("column_names,table_data,items_to_update,clearbit_responses", [
-    pytest.param(
-        # GIVEN: table exists
-        pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
-        # GIVEN: table contains some data
-        pd.DataFrame(),
-        # GIVEN: one item to update
-        pd.DataFrame.from_dict([
-            {"LICENSE_EMAIL": "alex@alexmaccaw.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0001",
-             "INSTALLATION_ID": "installation-1001", "FIRST_ACTIVE_DATE": "2022-10-01",
-             "LAST_UP_ADDRESS": "123.123.123.123"},
-            {"LICENSE_EMAIL": "test@example.com", "EMAIL_DOMAIN": "example.com", "SERVER_ID": "server-0009",
-             "INSTALLATION_ID": "installation-1042", "FIRST_ACTIVE_DATE": "2022-11-01",
-             "LAST_UP_ADDRESS": "42.42.42.42"},
-        ]),
-        # GIVEN: clearbit doesn't return data
-        [None, None],
-        # THEN: expect no items to be updated
-        id="table exists - has data - one item to be updated - clearbit doesn't return data"
-    ),
-    pytest.param(
-        # GIVEN: table exists
-        pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
-        # GIVEN: table contains some data
-        pd.DataFrame(),
-        # GIVEN: no items to update
-        pd.DataFrame(),
-        # GIVEN: clearbit doesn't return data
-        [],
-        # THEN: expect no items to be updated
-        id="table exists - has data - no items to be updated - clearbit doesn't return data"
-    ),
-])
-def test_cloud_clearbit_nothing_to_store(mock_snowflake, mock_snowflake_pandas, mock_clearbit,
-                                         mock_clearbit_enrichments,
-                                         column_names, table_data, items_to_update, clearbit_responses):
+@pytest.mark.parametrize(
+    "column_names,table_data,items_to_update,clearbit_responses",
+    [
+        pytest.param(
+            # GIVEN: table exists
+            pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
+            # GIVEN: table contains some data
+            pd.DataFrame(),
+            # GIVEN: one item to update
+            pd.DataFrame.from_dict(
+                [
+                    {
+                        "LICENSE_EMAIL": "alex@alexmaccaw.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0001",
+                        "INSTALLATION_ID": "installation-1001",
+                        "FIRST_ACTIVE_DATE": "2022-10-01",
+                        "LAST_UP_ADDRESS": "123.123.123.123",
+                    },
+                    {
+                        "LICENSE_EMAIL": "test@example.com",
+                        "EMAIL_DOMAIN": "example.com",
+                        "SERVER_ID": "server-0009",
+                        "INSTALLATION_ID": "installation-1042",
+                        "FIRST_ACTIVE_DATE": "2022-11-01",
+                        "LAST_UP_ADDRESS": "42.42.42.42",
+                    },
+                ]
+            ),
+            # GIVEN: clearbit doesn't return data
+            [None, None],
+            # THEN: expect no items to be updated
+            id="table exists - has data - one item to be updated - clearbit doesn't return data",
+        ),
+        pytest.param(
+            # GIVEN: table exists
+            pd.DataFrame.from_dict({"COLUMN_NAME": CLEARBIT_COLUMNS}),
+            # GIVEN: table contains some data
+            pd.DataFrame(),
+            # GIVEN: no items to update
+            pd.DataFrame(),
+            # GIVEN: clearbit doesn't return data
+            [],
+            # THEN: expect no items to be updated
+            id="table exists - has data - no items to be updated - clearbit doesn't return data",
+        ),
+    ],
+)
+def test_cloud_clearbit_nothing_to_store(
+    mock_snowflake,
+    mock_snowflake_pandas,
+    mock_clearbit,
+    mock_clearbit_enrichments,
+    column_names,
+    table_data,
+    items_to_update,
+    clearbit_responses,
+):
     # GIVEN: snowflake engine and connection are mocked
     mock_snowflake("utils.cloud_clearbit")
     # GIVEN: snowflake pandas interactions are mocked
@@ -212,7 +308,7 @@ def test_cloud_clearbit_nothing_to_store(mock_snowflake, mock_snowflake_pandas, 
         # GIVEN: clearbit table contains data (second request to load dataframe)
         table_data,
         # GIVEN: there are two new items to be updated from clearbit
-        items_to_update
+        items_to_update,
     ]
     # GIVEN: clearbit returns no results
     mock_clearbit.Enrichment.find.side_effect = mock_clearbit_enrichments(*clearbit_responses)
@@ -229,5 +325,5 @@ def test_cloud_clearbit_nothing_to_store(mock_snowflake, mock_snowflake_pandas, 
 @pytest.fixture()
 def expect_data(expect_data):
     from functools import partial
-    return partial(expect_data, "cloud")
 
+    return partial(expect_data, "cloud")

--- a/tests/utils/test_github_contributors.py
+++ b/tests/utils/test_github_contributors.py
@@ -3,10 +3,7 @@ import pandas as pd
 from utils.github_contributors import contributors
 
 # Customize defaults for given_request_to
-__MOCK_REQUEST_DEFAULTS = {
-    "dir": "github",
-    "headers": {"Authorization": "Bearer token"}
-}
+__MOCK_REQUEST_DEFAULTS = {"dir": "github", "headers": {"Authorization": "Bearer token"}}
 
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 
@@ -36,15 +33,16 @@ def test_contributors(responses, given_request_to, mock_snowflake, mock_snowflak
     # THEN: expect proper data to be loaded to snowflake table
     mock_to_sql.assert_called_once()
     pd.testing.assert_frame_equal(
-        mock_to_sql.call_args_list[0][0][0],
-        pd.DataFrame(data=load_dataset('github/dataset.json'))
+        mock_to_sql.call_args_list[0][0][0], pd.DataFrame(data=load_dataset('github/dataset.json'))
     )
 
     # THEN: expect connection to snowflake to be closed
     mock_connection.close.assert_called_once()
 
 
-def test_contributors_fail_to_get_repos(responses, given_request_to, mock_snowflake, mock_snowflake_pandas, load_dataset):
+def test_contributors_fail_to_get_repos(
+    responses, given_request_to, mock_snowflake, mock_snowflake_pandas, load_dataset
+):
     # GIVEN: repo query fails due to authentication error
     given_request_to(GITHUB_GRAPHQL_URL, "auth.error.json", method="POST", status=401)
 
@@ -64,7 +62,9 @@ def test_contributors_fail_to_get_repos(responses, given_request_to, mock_snowfl
     mock_connection.close.assert_not_called()
 
 
-def test_contributors_fail_to_get_repo_details(responses, given_request_to, mock_snowflake, mock_snowflake_pandas, load_dataset):
+def test_contributors_fail_to_get_repo_details(
+    responses, given_request_to, mock_snowflake, mock_snowflake_pandas, load_dataset
+):
     # GIVEN: repo query returns two pages of results
     given_request_to(GITHUB_GRAPHQL_URL, "repo.page.1.json", method="POST")
     given_request_to(GITHUB_GRAPHQL_URL, "repo.page.2.json", method="POST")

--- a/tests/utils/test_onprem_clearbit.py
+++ b/tests/utils/test_onprem_clearbit.py
@@ -3,19 +3,11 @@ from pathlib import Path
 import pandas as pd
 import pytest
 import sqlalchemy
-from sqlalchemy.exc import ProgrammingError
 
 from utils.onprem_clearbit import onprem_clearbit
 
 # Load setup configuration
-with open(
-    Path(__file__).parent
-    / "fixtures"
-    / "clearbit"
-    / "onprem"
-    / "setup"
-    / "clearbit_columns.csv"
-) as fp:
+with open(Path(__file__).parent / "fixtures" / "clearbit" / "onprem" / "setup" / "clearbit_columns.csv") as fp:
     # List of columns in onprem_clearbit table
     CLEARBIT_COLUMNS = [line.strip() for line in fp.readlines()]
 
@@ -143,7 +135,7 @@ with open(
             "all-with-failures.json",
             # THEN: expect no exceptions,
             None,
-            id="table exists - contains data but not exceptions - two items to be updated - clearbit returns data on one",
+            id="table exists - contains data, no exceptions - two items to be updated - clearbit returns data on one",
         ),
         pytest.param(
             # GIVEN: table doesn't exist
@@ -170,9 +162,7 @@ with open(
             # THEN: expect no exceptions,
             None,
             id="table not exists - no data or exceptions - two items to be updated - clearbit returns data",
-            marks=pytest.mark.xfail(
-                reason="onprem expects column but it's not there - todo: fix"
-            ),
+            marks=pytest.mark.xfail(reason="onprem expects column but it's not there - todo: fix"),
         ),
         pytest.param(
             # GIVEN: table exists
@@ -306,7 +296,7 @@ def test_onprem_clearbit(
             None,
             # GIVEN: no items to update
             pd.DataFrame(),
-            # GIVEN: clearbit is not called
+            # GIVEN: clearbit is not called  # noqa: E800
             [],
             id="no items to be updated",
         ),

--- a/tests/utils/test_post_nps_data.py
+++ b/tests/utils/test_post_nps_data.py
@@ -1,46 +1,53 @@
-import os
-import importlib
 import pytest
 import snowflake.connector
+
 from utils import post_nps_data
-import responses
 
-class TestPostNpsJob():
 
-    @pytest.mark.parametrize("input_row, output_row",
-                                [
-                                    (('sample feedback 1',''),('sample feedback 1','')),
-                                    (('sample\nfeedback2',''),('sample feedback2','')),
-                                    (('sample\n\nfeedback ""3',''),('sample  feedback 3','')),
-                                    (('sample feedback""""\n""""4',''),('sample feedback 4','')),
-                                    (('sample feedback""""\n""""5','untouched string goes here\n\n""'),('sample feedback 5','untouched string goes here\n\n""'))
-                                ]
-                            )
+class TestPostNpsJob:
+    @pytest.mark.parametrize(
+        "input_row, output_row",
+        [
+            (('sample feedback 1', ''), ('sample feedback 1', '')),
+            (('sample\nfeedback2', ''), ('sample feedback2', '')),
+            (('sample\n\nfeedback ""3', ''), ('sample  feedback 3', '')),
+            (('sample feedback""""\n""""4', ''), ('sample feedback 4', '')),
+            (
+                ('sample feedback""""\n""""5', 'untouched string goes here\n\n""'),
+                ('sample feedback 5', 'untouched string goes here\n\n""'),
+            ),
+        ],
+    )
     def test_format_row(self, config_nps, input_row, output_row):
         # function returns output after removing newline and string quotes
         assert post_nps_data.format_row(input_row) == output_row
 
     def test_feedback_generate_success(self, config_nps, mock_snowflake_connector, mocker):
-
         mock_snowflake_connector('utils.post_nps_data')
         requests_mock = mocker.patch('utils.post_nps_data.requests.post')
         requests_mock.return_value = mocker.Mock()
         # Expected to give error since mock object methods cant be called
         with pytest.raises(ValueError):
             post_nps_data.post_nps()
-        data = b'{"text": "| Feedback            | Category            |\n|---------------------|---------------------|\n| test row 1 column 1 | test row 1 column 2 |\n| test row 2 column 1 | test row 2 column 2 |", "channel": "mattermost-nps-feedback"}'
-        # Validate post data sent to the mattermost webhook 
-        requests_mock.assert_called_once_with( "https://mattermost.example.com/hooks/hookid", data=data, headers={'Content-Type': 'application/json'})
+        data = (
+            b'{"text": "| Feedback            | Category            |\n'
+            b'|---------------------|---------------------|\n'
+            b'| test row 1 column 1 | test row 1 column 2 |\n'
+            b'| test row 2 column 1 | test row 2 column 2 |"'
+            b', "channel": "mattermost-nps-feedback"}'
+        )
+        # Validate post data sent to the mattermost webhook
+        requests_mock.assert_called_once_with(
+            "https://mattermost.example.com/hooks/hookid", data=data, headers={'Content-Type': 'application/json'}
+        )
 
     def test_post_to_channel_success(self, config_nps, responses, post_nps_ok, mock_snowflake_connector, mocker):
-
         mock_snowflake_connector('utils.post_nps_data')
         post_nps_data.post_nps()
         snowflake.connector.connect.assert_called_once()
         responses.assert_call_count("https://mattermost.example.com/hooks/hookid", 1)
 
     def test_post_to_channel_error(self, config_nps, responses, post_nps_error, mock_snowflake_connector):
-
         mock_snowflake_connector('utils.post_nps_data')
         with pytest.raises(ValueError) as error:
             post_nps_data.post_nps()

--- a/tests/utils/test_run_dbt_cloud_job.py
+++ b/tests/utils/test_run_dbt_cloud_job.py
@@ -10,7 +10,7 @@ EXPECTED_RUN_POLL_URL = "https://cloud.getdbt.com/api/v2/accounts/1001/runs/42/"
 # Customize defaults for given_request_to
 __MOCK_REQUEST_DEFAULTS = {
     'dir': 'dbt',
-    'headers': {"Authorization": f"Token test-dbt-key", "Content-Type": "application/json"}
+    'headers': {"Authorization": "Token test-dbt-key", "Content-Type": "application/json"},
 }
 
 
@@ -93,7 +93,7 @@ def test_poll_dbt_run_poll_timeout(responses, given_request_to):
 
 
 @pytest.mark.parametrize("status,content", [(400, 'run.400.json'), (404, 'run.404.json')])
-def test_should_handle_failure(responses, given_request_to, status, content):
+def test_should_handle_non_2xx_responses(responses, given_request_to, status, content):
     # GIVEN: DBT cloud returns a non-200 response
     given_request_to(EXPECTED_RUN_POLL_URL, content, status=status)
 
@@ -104,4 +104,3 @@ def test_should_handle_failure(responses, given_request_to, status, content):
 
     # THEN: expect request to have been sent
     responses.assert_call_count(EXPECTED_RUN_POLL_URL, 3)
-

--- a/tests/utils/test_run_snowflake_queries.py
+++ b/tests/utils/test_run_snowflake_queries.py
@@ -3,7 +3,7 @@ from unittest.mock import call
 
 import pytest
 
-from utils.run_snowflake_queries import run_queries, parser
+from utils.run_snowflake_queries import parser, run_queries
 
 ROLE = "TEST-ROLE"
 SCHEMA = "TEST-SCHEMA"
@@ -15,33 +15,30 @@ def test_parser():
     args = parser.parse_args(["test-file", ROLE, SCHEMA])
 
     # THEN: expect arguments to have been parsed
-    assert args.role is ROLE
-    assert args.schema is SCHEMA
-    assert args.sql_file is "test-file"
+    assert args.role == ROLE
+    assert args.schema == SCHEMA
+    assert args.sql_file == "test-file"
 
 
 @pytest.mark.parametrize(
-    "filename,expected_queries", [
-        pytest.param(
-            "single",
-            ["SELECT a, b FROM table", ""],
-            id="single statement"
-        ),
+    "filename,expected_queries",
+    [
+        pytest.param("single", ["SELECT a, b FROM table", ""], id="single statement"),
         pytest.param(
             "multiple",
             [
                 "update analytics.staging.ald_test set test = 'new' where id = 1",
                 "\n\nupdate analytics.staging.ald_test set test = 'old' where id = 2",
-                ""
+                "",
             ],
-            id="multiple statements"
+            id="multiple statements",
         ),
         pytest.param(
             "escape",
             ["SELECT user || ';' || age FROM users", "\nSELECT 1", ""],
-            id="multiple statements with escape char"
+            id="multiple statements with escape char",
         ),
-    ]
+    ],
 )
 def test_run_queries(mock_snowflake, filename, expected_queries):
     # GIVEN: connection to snowflake
@@ -54,8 +51,4 @@ def test_run_queries(mock_snowflake, filename, expected_queries):
     run_queries(args, base_path=FIXTURE_PATH)
 
     # THEN: Expect execute to have been called once for each query
-    mock_connection.execute.assert_has_calls([
-        call(q) for q in expected_queries
-    ])
-
-
+    mock_connection.execute.assert_has_calls([call(q) for q in expected_queries])

--- a/tests/utils/test_user_agent_parser.py
+++ b/tests/utils/test_user_agent_parser.py
@@ -12,9 +12,7 @@ def test_parse_user_agent(mocker, user_agent_input, user_agent_df):
     mock_engine.connect.return_value = mock_connection
     mock_execute_query = mocker.patch("utils.user_agent_parser.execute_query")
     mock_execute_df = mocker.patch("utils.user_agent_parser.execute_dataframe")
-    mock_execute_df.return_value = pd.DataFrame({
-        "CONTEXT_USERAGENT": user_agent_input
-    })
+    mock_execute_df.return_value = pd.DataFrame({"CONTEXT_USERAGENT": user_agent_input})
     # Capture calls to pandas' to_sql. This is a trick to capture the dataframe that is created internally.
     # TODO: separate processing and storing logic in user_agent_parser.py
     mock_to_sql = mocker.patch("pandas.io.sql.to_sql")
@@ -29,10 +27,7 @@ def test_parse_user_agent(mocker, user_agent_input, user_agent_df):
     # THEN: expect to have saved a single batch to database
     mock_to_sql.assert_called_once()
     # THEN: expect user agents have been parsed correctly - this is the most important check regarding data
-    pd.testing.assert_frame_equal(
-        mock_to_sql.call_args_list[0][0][0],
-        user_agent_df
-    )
+    pd.testing.assert_frame_equal(mock_to_sql.call_args_list[0][0][0], user_agent_df)
 
 
 def test_parse_user_agent_batching(mocker):
@@ -45,12 +40,17 @@ def test_parse_user_agent_batching(mocker):
     mock_execute_query = mocker.patch("utils.user_agent_parser.execute_query")
     mock_execute_df = mocker.patch("utils.user_agent_parser.execute_dataframe")
     # GIVEN: 32k user agents (enough for 2 batches)
-    mock_execute_df.return_value = pd.DataFrame({
-        "CONTEXT_USERAGENT": [
-            f"Mozilla/5.0 (Linux; Android {i}.0; Nexus 6 Build/NBD90Z) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36"
-            for i in range(1, 32_000)
-        ]
-    })
+    mock_execute_df.return_value = pd.DataFrame(
+        {
+            "CONTEXT_USERAGENT": [
+                "Mozilla/5.0 "
+                f"(Linux; Android {i}.0; Nexus 6 Build/NBD90Z) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/53.0.2785.124 Mobile Safari/537.36"
+                for i in range(1, 32_000)
+            ]
+        }
+    )
     mock_to_sql = mocker.patch("pandas.io.sql.to_sql")
 
     # WHEN: trigger user agent parsing


### PR DESCRIPTION
#### Summary

Fix linter errors under `tests/utils`. No change in the logic, mostly indentation and import order changes. Goal is to use single lint style for all code in order to improve readability.
