### PR TITLE
MM-48977: add DAG for running data quality checks daily

### DIFF
--- a/dags/transformation/data_quality.py
+++ b/dags/transformation/data_quality.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+
+from dags.airflow_utils import MATTERMOST_DATAWAREHOUSE_IMAGE, pod_defaults, pod_env_vars, send_alert
+from dags.kube_secrets import (
+    DBT_CLOUD_API_ACCOUNT_ID,
+    DBT_CLOUD_API_KEY,
+    SNOWFLAKE_ACCOUNT,
+    SNOWFLAKE_PASSWORD,
+    SNOWFLAKE_TRANSFORM_ROLE,
+    SNOWFLAKE_TRANSFORM_SCHEMA,
+    SNOWFLAKE_TRANSFORM_WAREHOUSE,
+    SNOWFLAKE_USER,
+    SSH_KEY,
+)
+
+# Load the env vars into a dict and set Secrets
+env_vars = {**pod_env_vars, **{}}
+
+# Default arguments for the DAG
+default_args = {
+    "depends_on_past": False,
+    "owner": "airflow",
+    "on_failure_callback": send_alert,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=1),
+    "sla": timedelta(hours=8),
+    "start_date": datetime(2019, 1, 1, 0, 0, 0),
+}
+
+doc_md = """
+### Data Quality DBT dag
+
+#### Purpose
+This DAG triggers data quality checks by running dbt tests. It is used to check expectations and assumptions
+on raw data.
+
+#### Notes
+- DAG is expected to be failing as there are known issues with the quality of the data.
+"""
+
+# Create the DAG
+dag = DAG(
+    "data_quality",
+    default_args=default_args,
+    schedule_interval="0 8 * * *",
+    catchup=False,
+    max_active_runs=1,  # Don't allow multiple concurrent dag executions
+    doc_md=doc_md,
+)
+
+data_quality_daily_run = KubernetesPodOperator(
+    **pod_defaults,
+    image=MATTERMOST_DATAWAREHOUSE_IMAGE,  # Uses latest build from master
+    task_id="data-quality-daily-run",
+    name="data-quality-daily-run",
+    secrets=[
+        DBT_CLOUD_API_ACCOUNT_ID,
+        DBT_CLOUD_API_KEY,
+        SNOWFLAKE_ACCOUNT,
+        SNOWFLAKE_USER,
+        SNOWFLAKE_PASSWORD,
+        SNOWFLAKE_TRANSFORM_ROLE,
+        SNOWFLAKE_TRANSFORM_WAREHOUSE,
+        SNOWFLAKE_TRANSFORM_SCHEMA,
+        SSH_KEY,
+    ],
+    env_vars={**env_vars, "DBT_JOB_TIMEOUT": "300"},
+    arguments=["python -m utils.run_dbt_cloud_job 182308 \"Airflow dbt nightly\""],
+    dag=dag,
+)


### PR DESCRIPTION
#### Summary

- [x] Run daily check on data quality.
- [x] Failed DAG executions will be reported to alerts channel.
- [x] Schedule after nightly DAG execution.

Note that this DAG contains a single task. An alternative approach would be to add the task after nightly build. However, as data quality tests are currently being added, there might be some hiccups. Keeping the two DAGs separate for the time being will help understand where the issue is.