### PR TITLE
MM-49348: Migrate local DBT dev image to DBT v1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,13 +267,13 @@ docker-login: ## to login to a container registry
 .PHONY: dbt-docs
 dbt-docs: ## to generate and serve dbt docs
 	$(AT)$(INFO) Generating docs and spinning up the a webserver on port 8081...
-	$(AT)$(DOCKER) compose run -d -p "8081:8081" dbt_image bash -c "dbt deps && dbt docs generate -t prod && dbt docs serve --port 8081"  || ${FAIL}
+	$(AT)$(DOCKER) compose -f ${DOCKER_COMPOSE_DBT_FILE} run -d -p "8081:8081" dbt_image bash -c "dbt deps && dbt docs generate -t prod && dbt docs serve --port 8081"  || ${FAIL}
 	$(AT)$(OK) Server started, visit http://localhost:8081 to view the docs
 
 .PHONY: dbt-generate-docs
 dbt-generate-docs: ## to generate dbt docs
 	$(AT)$(INFO) Generating docs...
-	$(AT)$(DOCKER) compose run dbt_image bash -c "dbt deps && dbt docs generate -t prod" } || ${FAIL}
+	$(AT)$(DOCKER) compose -f ${DOCKER_COMPOSE_DBT_FILE} run dbt_image bash -c "dbt deps && dbt docs generate -t prod" } || ${FAIL}
 	$(AT)$(OK) Generated docs
 
 .PHONY: dbt-bash

--- a/build/docker-compose.dbt.yml
+++ b/build/docker-compose.dbt.yml
@@ -2,17 +2,15 @@ version: '3.7'
 
 services:
     dbt_image:
-      image: fishtownanalytics/dbt:1.0.0
+      image: ghcr.io/dbt-labs/dbt-snowflake:1.1.0@sha256:26b63ed21a1d534439fa9cd2b107a873e14ae9021153dca2f13ec104fd518754
       env_file:
         - ../.dbt.env
       environment:
-        DBT_PROFILES_DIR: /usr/local/dbt_profiles/
         SNOWFLAKE_LOAD_DATABASE: "RAW"
         SNOWFLAKE_TRANSFORM_WAREHOUSE: "TRANSFORM_XS"
         SNOWFLAKE_TRANSFORM_DATABASE: "ANALYTICS"
       restart: always
       command: bash -c "/bin/bash"
-      #working_dir: /usr/local/analytics/transform/snowflake-dbt/
       entrypoint: [ "" ]
       volumes:
         - type: bind
@@ -20,7 +18,7 @@ services:
           target: /usr/app
         - type: bind
           source: ${DBT_PROFILE_PATH:-../transform/snowflake-dbt/profile}
-          target: /usr/local/dbt_profiles/
+          target: /root/.dbt/
           read_only: True
 
     data_image:


### PR DESCRIPTION
#### Summary

- [x] Change DBT docker image to v1.1.
- [x] Minor fixes to `Makefile`.

Tested by running `dbt compile -t prod` inside DBT container. Also tested by running `make dbt-generate-docs`.