### PR TITLE
MM-48848: Filtering airflow alerts

### DIFF
--- a/dags/general/_helpers.py
+++ b/dags/general/_helpers.py
@@ -28,7 +28,7 @@ def stitch_check_extractions(response):
         failed_extractions = {
             extraction['source_id']: extraction['tap_description']
             for extraction in extractions.get('data')
-            if extraction['tap_exit_status'] == 1 and time_filter(extraction['completion_time'], 1)
+            if extraction['tap_exit_status'] == 1 and time_filter(extraction['completion_time'], "%Y-%m-%dT%H:%M:%SZ", 1)
         }
     except KeyError as e:
         task_logger.error('Error in check extractions ...', exc_info=True)
@@ -54,7 +54,7 @@ def stitch_check_loads(response):
         failed_loads = {
             load['source_name']: load['error_state']['notification_data']['error']
             for load in loads.get('data')
-            if load['error_state'] is not None and time_filter(load['last_batch_loaded_at'], 1)
+            if load['error_state'] is not None and time_filter(load['last_batch_loaded_at'], "%Y-%m-%dT%H:%M:%SZ", 1)
         }
     except KeyError as e:
         task_logger.error('Error in check loads ...', exc_info=True)
@@ -86,5 +86,12 @@ def resolve_stitch(ti=None, **kwargs):
         )
 
 
-def time_filter(target_time=None, delta_hours=None):
-    return datetime.strptime(target_time, "%Y-%m-%dT%H:%M:%SZ") + timedelta(hours=delta_hours) <= datetime.utcnow()
+def time_filter(target_time, format, delta_hours):
+    """
+    This method returns True if target_time + delta_hours >= current time.
+    False otherwise.
+    :param target_time: The UTC datetime string of target.
+    :param format: Format of datetime string.
+    :param delta_hours: Number of hours to be added to target_time for comparison.
+    """
+    return datetime.strptime(target_time, format) + timedelta(hours=delta_hours) >= datetime.utcnow()

--- a/dags/tests/general/test_monitoring.py
+++ b/dags/tests/general/test_monitoring.py
@@ -1,6 +1,9 @@
+from datetime import datetime
+
 import pytest
 
-from dags.general._helpers import stitch_check_extractions, stitch_check_loads
+from dags.general._helpers import stitch_check_extractions, stitch_check_loads, time_filter
+
 
 def test_stitch_check_extractions_pass(load_data):
 
@@ -13,8 +16,8 @@ def test_stitch_check_extractions_pass(load_data):
 def test_stitch_check_extractions_fail(load_data):
     response = load_data('monitoring/extractions_fail.json')
     failed_extractions = stitch_check_extractions(response)
-    # Expected to return dict containing failed extractions
-    assert failed_extractions == {99999: 'Terminated'}
+    # Expected to return dict containing failed extractions, returning empty dict due to date filter
+    assert failed_extractions == {}
 
 
 def test_stitch_check_extractions_error():
@@ -34,11 +37,29 @@ def test_stitch_check_loads_pass(load_data):
 def test_stitch_check_loads_fail(load_data):
     response = load_data('monitoring/loads_fail.json')
     failed_loads = stitch_check_loads(response)
-    # Expected to return dict containing failed loads
-    assert failed_loads == {'raw_source_2': 'some_error_value'}
+    # Expected to return dict containing failed loads, returning empty dict due to date filter
+    assert failed_loads == {}
 
 
 def test_stitch_check_loads_error(load_data):
     # Expected to raise exception since response body is empty
     with pytest.raises(TypeError):
         stitch_check_loads({})
+
+
+@pytest.mark.parametrize(
+    "target_time, format, delta_hours, output",
+    [
+        (str(datetime.utcnow()), "%Y-%m-%d %H:%M:%S.%f", 1, True),
+        (str(datetime.utcnow()), "%Y-%m-%d %H:%M:%S.%f", 2, True),
+        (str(datetime.utcnow()), "%Y-%m-%d %H:%M:%S.%f", 0, False),
+    ],
+)
+def test_time_filter(target_time, format, delta_hours, output):
+    assert time_filter(target_time, format, delta_hours) == output
+
+
+def test_time_filter_error():
+    # Expected to raise exception since time format is incorrect
+    with pytest.raises(ValueError):
+        time_filter(str(datetime.utcnow()), "%Y-%m-%d %H:%M:%S", 2)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Added a filter on checking API responses for errors in airflow alerts.

- [x] Adding filter on stitch responses.
- [x] Adding filter on hightouch response. ([Waiting for another PR to be merged](https://github.com/mattermost/mattermost-data-warehouse/pull/1130))

Deployment steps -
- [x] Re-enable dag monitoring.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-48974
