### PR TITLE
Changing user_events_telemetry job to run in nightly schedule

### DIFF
--- a/transform/snowflake-dbt/models/events/user_events_telemetry.sql
+++ b/transform/snowflake-dbt/models/events/user_events_telemetry.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "events",
-    "tags":"union",
+    "tags":"nightly",
     "snowflake_warehouse": "transform_l"
   })
 }}


### PR DESCRIPTION
Impact: This PR changes user_events_telemetry job to run in nightly schedule. I have identified that loading the table and selecting from this large table isn't running any queries at all. We aren't able to do any type of analysis and its holding back many Analytics tickets, that I am currently working on. We would not require this near real time data for Analytics, if there is ever a requirement to view real time data we could use the individual tables, for example - one scenario I can imagine where we would need real time data is when we want to see our own information on the Portal, say I want to see the flow of a user when signing up to a Cloud workspace. For this, we could just use the portal events table and it would be much more faster even.

Testing: Yesterday the job failed due to a column missing, and the job kept failing until I resolved the column issue. That was the only time I was able to run my query and progress on my work. 

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

