### PR TITLE
MM-48911: Updated start_date for cloud paid subscriptions

### DIFF
--- a/transform/snowflake-dbt/models/blapi/customers_with_cloud_paid_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_cloud_paid_subs.sql
@@ -9,7 +9,7 @@
 with current_subscriptions AS(
     SELECT 
         *,
-        cloud_paid_subscriptions."START" as start_date
+        cloud_paid_subscriptions."DATE_CONVERTED_TO_PAID" as start_date
     FROM       
         {{ ref('cloud_paid_subscriptions') }}
         WHERE row_num = 1


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Self-serve cloud transactions have incorrect start_date due to incorrect mapping with subscriptions.start

- [x] Updated cloud Professional opportunity to use date_converted_to_paid as start_date.
- [x] Tested in snowflake so that no other table is affected with this change.
- [x] Hightouch sync to update the previous opportunities.

Deployment steps - 
- [x] Run hightouch sync salesforce-updates-model, for one time update of previous opportunities.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-48911
