### PR TITLE
MM-48911: Incorrect cloud opportunity date

### DIFF
--- a/transform/snowflake-dbt/models/blapi/customers_with_cloud_paid_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_cloud_paid_subs.sql
@@ -35,7 +35,7 @@ with current_subscriptions AS(
         current_subscriptions.company,
         left(coalesce(current_subscriptions.company, customers.email), 40) as company_name,
         current_subscriptions.status,
-        to_varchar(current_subscriptions.start_date, 'yyyy-MM-dd HH:mm:ss.SSS Z') as start_date,
+        TO_DATE(current_subscriptions.date_converted_to_paid) as start_date,
         to_varchar(DATEADD(month, 1, current_subscriptions.start_date), 'yyyy-MM-dd HH:mm:ss.SSS Z') as end_date, -- only for cloud professional subscriptions
         current_subscriptions.created >= '2022-06-14' as hightouch_sync_eligible,
         ROW_NUMBER() OVER (PARTITION BY current_subscriptions.id ORDER BY invoices.created DESC) as row_num

--- a/transform/snowflake-dbt/models/stripe/subscriptions.sql
+++ b/transform/snowflake-dbt/models/stripe/subscriptions.sql
@@ -30,7 +30,7 @@ WITH subscriptions AS (
         ,subscriptions.plan:"name"::varchar as edition
         ,subscriptions.metadata:"sfdc-migrated-opportunity-sfid"::varchar as sfdc_migrated_opportunity_sfid
         ,subscriptions.metadata:"internal_purchase_order"::varchar as purchase_order_num
-        ,subscriptions.metadata:"cws-date-converted-to-paid"::varchar as date_converted_to_paid
+        ,TO_TIMESTAMP_NTZ(subscriptions.metadata:"cws-date-converted-to-paid"::int) as date_converted_to_paid
         ,TO_TIMESTAMP_NTZ(subscriptions.metadata:"cws-license-end-date"::int) as license_end_date
         ,TO_TIMESTAMP_NTZ(subscriptions.metadata:"cws-actual-renewal-date"::int / 1000) as actual_renewal_date
         ,subscriptions."START"


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Self-serve cloud transactions have incorrect start_date due to incorrect mapping with subscriptions.start

- [x] Updated cast for date_converted_to_paid to datetime, instead of number in subscriptions table.
select count(1) from ANALYTICS.STRIPE.SUBSCRIPTIONS_STRIPE a left join ANALYTICS.STRIPE.SUBSCRIPTIONS b on a.id = b.id where TO_VARCHAR(TO_DATE(a.date_converted_to_paid)) != TO_VARCHAR(TO_DATE(TO_TIMESTAMP_NTZ(b.DATE_CONVERTED_TO_PAID::int))) -- 0 rows
- [x] Updated cloud Professional opportunity to use date_converted_to_paid as start_date.
- [x] Tested in snowflake so that no other table is affected with this change.
- [x] Hightouch sync to update the previous opportunities.

Deployment steps - 
- [x] Run hightouch sync salesforce-updates-model, for one time update of previous opportunities.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-48911
