### PR TITLE
MM-49607: Professional opportunity sync notes

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
@@ -23,7 +23,7 @@ with existing_contacts as (
 ), customers_with_cloud_paid_subs as (
     SELECT
         customers_with_cloud_paid_subs.*,
-        COALESCE(existing_lead.ownerid, existing_contacts.ownerid, '0053p0000064nt8AAA') AS ownerid
+        COALESCE(existing_leads.ownerid, existing_contacts.ownerid, '0053p0000064nt8AAA') AS ownerid
     FROM {{ ref('customers_with_cloud_paid_subs') }}
     LEFT JOIN {{ ref('account') }}
         ON customers_with_cloud_paid_subs.domain = account.cbit__clearbitdomain__c

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
@@ -23,14 +23,14 @@ with existing_contacts as (
 ), customers_with_cloud_paid_subs as (
     SELECT
         customers_with_cloud_paid_subs.*,
-        '0053p0000064nt8AAA' AS ownerid
+        COALESCE(existing_lead.ownerid, existing_contacts.ownerid, '0053p0000064nt8AAA') AS ownerid
     FROM {{ ref('customers_with_cloud_paid_subs') }}
     LEFT JOIN {{ ref('account') }}
         ON customers_with_cloud_paid_subs.domain = account.cbit__clearbitdomain__c
             OR customers_with_cloud_paid_subs.account_external_id = account.dwh_external_id__c
     LEFT JOIN existing_contacts ON customers_with_cloud_paid_subs.email = existing_contacts.email and existing_contacts.row_num = 1
     LEFT JOIN existing_leads ON customers_with_cloud_paid_subs.email = existing_leads.email and existing_leads.row_num = 1
-    WHERE account.id IS NULL
+    WHERE account.id IS NULL AND existing_contacts.sfid IS NULL -- create account only when contact does not exist
     AND customers_with_cloud_paid_subs.hightouch_sync_eligible
     AND customers_with_cloud_paid_subs.status in ('canceled', 'active') 
     AND customers_with_cloud_paid_subs.SKU = 'Cloud Professional'

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
@@ -28,11 +28,9 @@ with existing_contacts as (
     LEFT JOIN {{ ref('account') }}
         ON customers_with_cloud_paid_subs.domain = account.cbit__clearbitdomain__c
             OR customers_with_cloud_paid_subs.account_external_id = account.dwh_external_id__c
-    LEFT JOIN {{ source('orgm', 'account_domain_mapping') }}
-        ON customers_with_cloud_paid_subs.domain = account_domain_mapping.domain
     LEFT JOIN existing_contacts ON customers_with_cloud_paid_subs.email = existing_contacts.email and existing_contacts.row_num = 1
     LEFT JOIN existing_leads ON customers_with_cloud_paid_subs.email = existing_leads.email and existing_leads.row_num = 1
-    WHERE account.id IS NULL AND account_domain_mapping.accountid IS NULL
+    WHERE account.id IS NULL
     AND customers_with_cloud_paid_subs.hightouch_sync_eligible
     AND customers_with_cloud_paid_subs.status in ('canceled', 'active') 
     AND customers_with_cloud_paid_subs.SKU = 'Cloud Professional'

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
@@ -8,8 +8,7 @@
 WITH customers_with_cloud_paid_subs as (
     SELECT
         customers_with_cloud_paid_subs.*,
-        "Customer" as account_type,
-        '0053p0000064nt8AAA' AS ownerid
+        "Customer" as account_type
     FROM {{ ref('customers_with_cloud_paid_subs') }}
     LEFT JOIN {{ ref('account') }}
         ON customers_with_cloud_paid_subs.domain = account.cbit__clearbitdomain__c

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
@@ -14,9 +14,7 @@ WITH customers_with_cloud_paid_subs as (
     LEFT JOIN {{ ref('account') }}
         ON customers_with_cloud_paid_subs.domain = account.cbit__clearbitdomain__c
             OR customers_with_cloud_paid_subs.account_external_id = account.dwh_external_id__c
-    LEFT JOIN {{ source('orgm', 'account_domain_mapping') }}
-        ON customers_with_cloud_paid_subs.domain = account_domain_mapping.domain
-    WHERE account.id IS NOT NULL AND account_domain_mapping.accountid IS NOT NULL
+    WHERE account.id IS NOT NULL
     AND customers_with_cloud_paid_subs.hightouch_sync_eligible
     AND customers_with_cloud_paid_subs.status in ('canceled', 'active') 
     AND customers_with_cloud_paid_subs.SKU = 'Cloud Professional'

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
@@ -8,6 +8,7 @@
 WITH customers_with_cloud_paid_subs as (
     SELECT
         customers_with_cloud_paid_subs.*,
+        "Customer" as account_type,
         '0053p0000064nt8AAA' AS ownerid
     FROM {{ ref('customers_with_cloud_paid_subs') }}
     LEFT JOIN {{ ref('account') }}

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
@@ -8,7 +8,7 @@
 WITH customers_with_cloud_paid_subs as (
     SELECT
         customers_with_cloud_paid_subs.*,
-        "Customer" as account_type
+        'Customer' as account_type
     FROM {{ ref('customers_with_cloud_paid_subs') }}
     LEFT JOIN {{ ref('account') }}
         ON customers_with_cloud_paid_subs.domain = account.cbit__clearbitdomain__c

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -8,7 +8,8 @@
 WITH existing_lead AS (
     SELECT
         lead.id,
-        lead.email
+        lead.email,
+        lead.ownerid
     FROM {{ ref('lead') }}
     WHERE converteddate IS NULL
     QUALIFY ROW_NUMBER() OVER (PARTITION BY lead.email ORDER BY lead.createddate DESC) = 1
@@ -20,7 +21,7 @@ WITH existing_lead AS (
         existing_lead.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
-        '0053p0000064nt8AAA' AS ownerid,
+        COALESCE(existing_lead.ownerid, '0053p0000064nt8AAA') AS ownerid
         'Cloud Purchase' AS most_recent_action,
         'Cloud Professional' AS most_recent_action_detail,
         'Referral' AS lead_source,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -21,7 +21,7 @@ WITH existing_lead AS (
         existing_lead.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
-        COALESCE(existing_lead.ownerid, '0053p0000064nt8AAA') AS ownerid
+        COALESCE(existing_lead.ownerid, '0053p0000064nt8AAA') AS ownerid,
         'Cloud Purchase' AS most_recent_action,
         'Cloud Professional' AS most_recent_action_detail,
         'Referral' AS lead_source,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
@@ -8,7 +8,8 @@
 WITH existing_lead AS (
     SELECT
         lead.id,
-        lead.email
+        lead.email,
+        lead.ownerid
     FROM {{ ref('lead') }}
     WHERE converteddate IS NULL
     QUALIFY ROW_NUMBER() OVER (PARTITION BY lead.email ORDER BY lead.createddate DESC) = 1
@@ -20,7 +21,7 @@ WITH existing_lead AS (
         existing_lead.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
-        '0053p0000064nt8AAA' AS ownerid,
+        COALESCE(existing_lead.ownerid, '0053p0000064nt8AAA') AS ownerid
         'Cloud Purchase' AS most_recent_action,
         'Cloud Professional' AS most_recent_action_detail,
         'Referral' AS lead_source,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
@@ -21,7 +21,7 @@ WITH existing_lead AS (
         existing_lead.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
-        COALESCE(existing_lead.ownerid, '0053p0000064nt8AAA') AS ownerid
+        COALESCE(existing_lead.ownerid, '0053p0000064nt8AAA') AS ownerid,
         'Cloud Purchase' AS most_recent_action,
         'Cloud Professional' AS most_recent_action_detail,
         'Referral' AS lead_source,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunity.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunity.sql
@@ -9,7 +9,7 @@ WITH freemium_opportunity_to_sync AS (
     SELECT
         customers_with_cloud_paid_subs.*,
         SPLIT_PART(cloud_dns, '.', 0) ||
-            ' Cloud Subscription FY' || RIGHT(SPLIT_PART(customers_with_cloud_paid_subs.end_date, '-', 0),2) AS opportunity_name,
+            ' Cloud Subscription' AS opportunity_name,
         'New Subscription' AS opportunity_type,
         0 as new_new_arr_override,
         '0053p0000064nt8AAA' AS ownerid,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem.sql
@@ -20,6 +20,7 @@ WITH opportunitylineitems_to_sync AS (
         'Monthly Billing' as product_type,
         'New' as product_line_type,
         1 as quantity,
+        10 * quantity as total_price, -- (price of 1 sub = 10 USD) there should be another way of updating the total_price instead of hard code.
         'Discount' as pricing_method,
         0 as discount_calc,
         false as sales_price_needs_to_be_updated


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Fixed errors/warnings with professional subscription hightouch sync.
Models affected wrt changes - 
1. Opportunity
2. OpportunityLineItem
3. Account

Removed joins with account_domain_mapping as it was leading to incorrect results.

- [x] Hightouch sync for one time update of previous models (Salesforce_updates_model)
- [ ] Configuration changes in hightouch
         1. Cloud professional account update (update mapping for customer_type)
         2. Cloud professional opportunity insert (replace warehouse_external_id with account_lookup_id)
         3. Cloud professional opportunitylineitem insert (replace hard coded string field with price)
         4. Set opportunity sync to run downstream of account. Account -> Contact -> Opportunity -> OpportunityLineItem.
 - [x] Tested with queries pasted in jira.
 
 Deployment steps 
 - [ ] Run one time hightouch sync (Salesforce_updates_model)
 - [ ] Update sync configuration in hightouch
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-45778