### PR TITLE
MM-49762: Document rudderstack data sources

### DIFF
--- a/transform/snowflake-dbt/models/focalboard/sources.yml
+++ b/transform/snowflake-dbt/models/focalboard/sources.yml
@@ -4,6 +4,13 @@ sources:
   - name: hacktoberboard_prod
     database: 'RAW'
     schema: hacktoberboard_prod
+    loader: Rudderstack
+    description: |
+      Focalboard telemetry data, pushed via Rudderstack.
+
+      [Source code](https://github.com/mattermost/focalboard/blob/main/server/services/telemetry/telemetry.go)
+    tags:
+      - rudderstack
 
     tables:
       - name: activity

--- a/transform/snowflake-dbt/models/incident_response_dev/sources.yml
+++ b/transform/snowflake-dbt/models/incident_response_dev/sources.yml
@@ -1,0 +1,24 @@
+version: 2
+
+sources:
+  - name: incident_response_dev
+    database: 'RAW'
+    schema: incident_response_dev
+    loader: Rudderstack
+    description: |
+      Playbook plugin telemetry dev data. Published via Rudderstack Go client.
+      
+      [Source code](https://github.com/mattermost/mattermost-plugin-playbooks/blob/master/server/telemetry/rudder.go#L578)
+    tags:
+      - rudderstack
+
+    tables:
+      - name: frontend
+      - name: incident
+      - name: incident_created
+      - name: playbook
+      - name: rudder_discards
+        description: Stores records that rudder failed to store to the warehouse.
+      - name: tasks
+      - name: tracks
+        description: Stores all events capture via rudderstack's `track` functionality.

--- a/transform/snowflake-dbt/models/incident_response_prod/sources.yml
+++ b/transform/snowflake-dbt/models/incident_response_prod/sources.yml
@@ -1,0 +1,56 @@
+version: 2
+
+sources:
+  - name: incident_response_prod
+    database: 'RAW'
+    schema: incident_response_prod
+    loader: Rudderstack
+    description: |
+      Playbook plugin telemetry production data. Published via Rudderstack Go client.
+      
+      [Source code](https://github.com/mattermost/mattermost-plugin-playbooks/blob/master/server/telemetry/rudder.go#L578)
+
+    tags:
+      - rudderstack
+
+    tables:
+      - name: add_checklist_item
+      - name: change_commander
+      - name: change_stage
+      - name: channel_action
+      - name: check_checklist_item
+      - name: checklists
+      - name: create_incident
+      - name: create_playbook
+      - name: delete_playbook
+      - name: end_incident
+      - name: frontend
+      - name: incident
+      - name: lhs_category
+      - name: modify_state_checklist_item
+      - name: move_checklist_item
+      - name: notify_admins
+      - name: pages
+      - name: playbook
+      - name: playbookrun_action
+      - name: playbookrun_create
+      - name: playbookrun_follow
+      - name: playbookrun_leave
+      - name: playbookrun_participate
+      - name: playbookrun_unfollow
+      - name: playbookrun_update_actions
+      - name: remove_checklist_item
+      - name: rename_checklist_item
+      - name: restart_incident
+      - name: rudder_discards
+      - name: run_checklist_item_slash_command
+      - name: set_assignee
+      - name: settings
+      - name: start_trial
+      - name: taskactions_action_executed
+      - name: taskactions_triggered
+      - name: taskactions_updated
+      - name: tasks
+      - name: tracks
+      - name: uncheck_checklist_item
+      - name: update_playbook

--- a/transform/snowflake-dbt/models/mattermost_nps/sources.yml
+++ b/transform/snowflake-dbt/models/mattermost_nps/sources.yml
@@ -13,14 +13,3 @@ sources:
       
       - name: nps_feedback
         description: 'NPS feedback data'
-
-  - name: mm_plugin_prod
-    database: 'RAW'
-    schema: mm_plugin_prod
-
-    tables: 
-      - name: nps_nps_score
-        description: 'NPS score data'
-      
-      - name: nps_nps_feedback
-        description: 'NPS feedback data'

--- a/transform/snowflake-dbt/models/mattermostcom/sources.yml
+++ b/transform/snowflake-dbt/models/mattermostcom/sources.yml
@@ -4,6 +4,11 @@ sources:
   - name: mattermostcom
     database: 'RAW'
     schema: mattermostcom
+    loader: Rudderstack
+    description: |
+      Mattermost.com events captured using Rudderstack's JS framework.
+    tags:
+      - rudderstack
 
     tables:
       - name: pages

--- a/transform/snowflake-dbt/models/mm_calls_test_go/sources.yml
+++ b/transform/snowflake-dbt/models/mm_calls_test_go/sources.yml
@@ -1,0 +1,31 @@
+version: 2
+
+sources:
+  - name: mm_calls_test_go
+    database: raw
+    schema: mm_calls_test_go
+    loader: Rudderstack
+    description: |
+      Telemetry data for calls plugin.
+      
+      [Source code - Backend](https://github.com/mattermost/mattermost-plugin-calls/blob/main/server/telemetry/telemetry.go)
+      [Source code - Frontend](https://github.com/mattermost/mattermost-plugin-calls/blob/main/webapp/src/types/telemetry.ts)
+    tags:
+      - rudderstack
+
+    tables:
+      - name: call_ended
+      - name: call_notify_admin
+      - name: call_started
+      - name: call_user_joined
+      - name: call_user_left
+      - name: tracks
+      - name: user_close_expanded_view
+      - name: user_close_participants_list
+      - name: user_lower_hand
+      - name: user_open_channel_link
+      - name: user_open_expanded_view
+      - name: user_open_participants_list
+      - name: user_raise_hand
+      - name: user_share_screen
+      - name: user_unshare_screen

--- a/transform/snowflake-dbt/models/mm_mobile_beta/sources.yml
+++ b/transform/snowflake-dbt/models/mm_mobile_beta/sources.yml
@@ -1,0 +1,82 @@
+version: 2
+
+sources:
+  - name: mm_mobile_beta
+    database: raw
+    schema: mm_mobile_beta
+    loader: Rudderstack
+    description: |
+      Mobile app telemetry pushed using Rudderstack. This schema is for beta releases. 
+      
+      [Source code](https://github.com/mattermost/mattermost-mobile/blob/main/app/managers/analytics.ts)
+    tags:
+      - rudderstack
+
+    tables:
+      - name: action_channels_add_member
+      - name: action_channels_favorite
+      - name: action_channels_join
+      - name: action_channels_leave
+      - name: action_channels_remove_member
+      - name: action_channels_unfavorite
+      - name: action_posts_flag
+      - name: action_posts_unflag
+      - name: api_channel_get
+      - name: api_channel_get_by_name_and_team_name
+      - name: api_channels_add_member
+      - name: api_channels_convert_to_private
+      - name: api_channels_create
+      - name: api_channels_create_direct
+      - name: api_channels_create_group
+      - name: api_channels_delete
+      - name: api_channels_patch
+      - name: api_channels_remove_member
+      - name: api_channels_unarchive
+      - name: api_files_upload
+      - name: api_get_known_users
+      - name: api_integrations_used
+      - name: api_interactive_messages_button_clicked
+      - name: api_interactive_messages_dialog_submitted
+      - name: api_interactive_messages_menu_selected
+      - name: api_post_set_unread_post
+      - name: api_posts_create
+      - name: api_posts_delete
+      - name: api_posts_get_after
+      - name: api_posts_get_before
+      - name: api_posts_get_flagged
+      - name: api_posts_get_pinned
+      - name: api_posts_patch
+      - name: api_posts_pin
+      - name: api_posts_replied
+      - name: api_posts_search
+      - name: api_posts_search_mention
+      - name: api_posts_unpin
+      - name: api_profiles_get
+      - name: api_profiles_get_by_ids
+      - name: api_profiles_get_by_usernames
+      - name: api_profiles_get_in_channel
+      - name: api_profiles_get_in_team
+      - name: api_profiles_get_not_in_channel
+      - name: api_reactions_delete
+      - name: api_reactions_save
+      - name: api_search_users
+      - name: api_teams_get_team_by_name
+      - name: api_teams_invite_members
+      - name: api_users_login
+      - name: api_users_logout
+      - name: api_users_send_password_reset
+      - name: api_users_set_default_profile_picture
+      - name: api_users_update_channel_notifications
+      - name: application_backgrounded
+      - name: application_installed
+      - name: application_opened
+      - name: application_updated
+      - name: complete_suggestion
+      - name: get_suggestions_failed
+      - name: get_suggestions_initiated
+      - name: get_suggestions_success
+      - name: identifies
+      - name: rudder_discards
+      - name: screens
+      - name: tracks
+      - name: users

--- a/transform/snowflake-dbt/models/mm_mobile_prod/sources.yml
+++ b/transform/snowflake-dbt/models/mm_mobile_prod/sources.yml
@@ -4,10 +4,11 @@ sources:
   - name: mm_mobile_prod
     database: 'RAW'
     schema: mm_mobile_prod
+    loader: Rudderstack
     description: |
-      Mobile app data stored using Rudderstack. Rudderstack documentation offers an in-depth documentation of the
-      [warehouse schema](https://www.rudderstack.com/docs/destinations/warehouse-destinations/warehouse-schema/).
-      The code that performs the tracking [is available here](https://github.com/mattermost/mattermost-mobile/blob/main/app/managers/analytics.ts#L105).
+      Mobile app telemetry pushed using Rudderstack. This schema is for production releases. 
+      
+      [Source code](https://github.com/mattermost/mattermost-mobile/blob/main/app/managers/analytics.ts)
     tags: ['rudderstack']
 
     tables:

--- a/transform/snowflake-dbt/models/mm_mobile_test/sources.yml
+++ b/transform/snowflake-dbt/models/mm_mobile_test/sources.yml
@@ -1,0 +1,80 @@
+version: 2
+
+sources:
+  - name: mm_mobile_test
+    database: raw
+    schema: mm_mobile_test
+    loader: Rudderstack
+    description: |
+      Mobile app telemetry pushed using Rudderstack. This schema is for test releases. 
+      
+      [Source code](https://github.com/mattermost/mattermost-mobile/blob/main/app/managers/analytics.ts)
+    tags:
+      - rudderstack
+
+    tables:
+      - name: action_channels_add_member
+      - name: action_channels_favorite
+      - name: action_channels_join
+      - name: action_channels_leave
+      - name: action_channels_remove_member
+      - name: action_channels_unfavorite
+      - name: action_posts_flag
+      - name: action_posts_unflag
+      - name: api_channel_get
+      - name: api_channel_get_by_name_and_team_name
+      - name: api_channels_add_member
+      - name: api_channels_convert_to_private
+      - name: api_channels_create
+      - name: api_channels_create_direct
+      - name: api_channels_create_group
+      - name: api_channels_delete
+      - name: api_channels_patch
+      - name: api_channels_remove_member
+      - name: api_channels_unarchive
+      - name: api_files_upload
+      - name: api_integrations_used
+      - name: api_interactive_messages_button_clicked
+      - name: api_interactive_messages_dialog_submitted
+      - name: api_interactive_messages_menu_selected
+      - name: api_post_set_unread_post
+      - name: api_posts_create
+      - name: api_posts_delete
+      - name: api_posts_get_after
+      - name: api_posts_get_before
+      - name: api_posts_get_flagged
+      - name: api_posts_get_pinned
+      - name: api_posts_patch
+      - name: api_posts_pin
+      - name: api_posts_replied
+      - name: api_posts_search
+      - name: api_posts_search_mention
+      - name: api_posts_unpin
+      - name: api_profiles_get
+      - name: api_profiles_get_by_ids
+      - name: api_profiles_get_by_usernames
+      - name: api_profiles_get_in_channel
+      - name: api_profiles_get_not_in_channel
+      - name: api_reactions_delete
+      - name: api_reactions_save
+      - name: api_search_users
+      - name: api_teams_get_team_by_name
+      - name: api_teams_invite_members
+      - name: api_users_login
+      - name: api_users_logout
+      - name: api_users_send_password_reset
+      - name: api_users_set_default_profile_picture
+      - name: api_users_update_channel_notifications
+      - name: application_backgrounded
+      - name: application_installed
+      - name: application_opened
+      - name: application_updated
+      - name: complete_suggestion
+      - name: get_suggestions_failed
+      - name: get_suggestions_initiated
+      - name: get_suggestions_success
+      - name: identifies
+      - name: rudder_discards
+      - name: screens
+      - name: tracks
+      - name: users

--- a/transform/snowflake-dbt/models/mm_plugin_dev/sources.yml
+++ b/transform/snowflake-dbt/models/mm_plugin_dev/sources.yml
@@ -1,0 +1,101 @@
+version: 2
+
+sources:
+  - name: mm_plugin_dev
+    database: raw
+    schema: mm_plugin_dev
+    loader: Rudderstack
+    description: |
+      Plugin telemetry pushed via Rudderstack. Please check related plugin repo for telemetry.
+      
+      This schema contains dev data.
+    tags:
+      - rudderstack
+
+    tables:
+      - name: activity
+      - name: apps_framework_call
+      - name: apps_framework_install
+      - name: apps_framework_oauth_complete
+      - name: apps_framework_uninstall
+      - name: blocks
+      - name: change_stage
+      - name: com_mattermost_mscalendar_automatic_status_update
+      - name: com_mattermost_mscalendar_user_deauthenticated
+      - name: config
+      - name: create_incident
+      - name: create_playbook
+      - name: end_incident
+      - name: event
+      - name: gcal_automatic_status_update
+      - name: gcal_user_authenticated
+      - name: gcal_user_deauthenticated
+      - name: gcal_welcome_flow_completion
+      - name: github_stats
+      - name: gitlab_stats
+      - name: identifies
+      - name: jiomeet_start_meeting
+      - name: jira_migrate_user_disconnected
+      - name: jira_setup_wizard_announcement_complete
+      - name: jira_setup_wizard_announcement_start
+      - name: jira_setup_wizard_jira_config_complete
+      - name: jira_setup_wizard_jira_config_start
+      - name: jira_setup_wizard_start
+      - name: jira_setup_wizard_user_connect_complete
+      - name: jira_setup_wizard_user_connect_start
+      - name: jira_setup_wizard_webhook_complete
+      - name: jira_setup_wizard_webhook_start
+      - name: jira_user_connected
+      - name: jira_user_disconnected
+      - name: jira_v2revert_submitted
+      - name: jitsi_start_meeting
+      - name: ktalk_start_meeting
+      - name: modify_state_checklist_item
+      - name: mscalendar_automatic_status_update
+      - name: mscalendar_daily_summary_sent
+      - name: mscalendar_user_authenticated
+      - name: mscalendar_user_deauthenticated
+      - name: mscalendar_welcome_flow_completion
+      - name: msteamsmeetings_connect
+      - name: msteamsmeetings_disconnect
+      - name: msteamsmeetings_meeting_duplicated
+      - name: msteamsmeetings_meeting_forced
+      - name: msteamsmeetings_meeting_started
+      - name: nps_nps_disable
+      - name: nps_nps_feedback
+      - name: nps_nps_score
+      - name: pages
+      - name: restart_incident
+      - name: rudder_discards
+      - name: server
+      - name: todo_accept_issue
+      - name: todo_add_issue
+      - name: todo_bump_issue
+      - name: todo_command
+      - name: todo_complete_issue
+      - name: todo_daily_summary_sent
+      - name: todo_edit_issue
+      - name: todo_frontend_click_lhs_in
+      - name: todo_frontend_click_lhs_my
+      - name: todo_frontend_click_lhs_out
+      - name: todo_frontend_custom_post_accept
+      - name: todo_frontend_custom_post_complete
+      - name: todo_frontend_custom_post_remove
+      - name: todo_frontend_rhs_add
+      - name: todo_frontend_rhs_edit
+      - name: todo_frontend_toggle_inbox
+      - name: todo_frontend_toggle_my
+      - name: todo_remove_issue
+      - name: todo_send_issue
+      - name: todo_update_issue
+      - name: tracks
+      - name: update_playbook
+      - name: users
+      - name: workspaces
+      - name: zoom_connect
+      - name: zoom_disconnect
+      - name: zoom_meeting_duplicated
+      - name: zoom_meeting_forced
+      - name: zoom_oauth_mode_change
+      - name: zoom_start_meeting
+      - name: zoom_stats

--- a/transform/snowflake-dbt/models/mm_plugin_prod/sources.yml
+++ b/transform/snowflake-dbt/models/mm_plugin_prod/sources.yml
@@ -1,0 +1,63 @@
+version: 2
+
+sources:
+  - name: mm_plugin_prod
+    database: raw
+    schema: mm_plugin_prod
+    loader: Rudderstack
+    description: |
+      Plugin telemetry pushed via Rudderstack. Please check related plugin repo for telemetry.
+      
+      This schema contains production data.
+    tags:
+      - rudderstack
+
+    tables:
+      - name: apps_framework_call
+      - name: apps_framework_install
+      - name: apps_framework_oauth_complete
+      - name: apps_framework_uninstall
+      - name: github_stats
+      - name: gitlab_stats
+      - name: mscalendar_automatic_status_update
+      - name: mscalendar_daily_summary_sent
+      - name: mscalendar_user_authenticated
+      - name: mscalendar_user_deauthenticated
+      - name: mscalendar_welcome_flow_completion
+      - name: msteamsmeetings_connect
+      - name: msteamsmeetings_disconnect
+      - name: msteamsmeetings_meeting_duplicated
+      - name: msteamsmeetings_meeting_forced
+      - name: msteamsmeetings_meeting_started
+      - name: nps_nps_disable
+      - name: nps_nps_feedback
+        description: 'NPS feedback data'
+      - name: nps_nps_score
+        description: 'NPS score data'
+      - name: rudder_discards
+      - name: todo_accept_issue
+      - name: todo_add_issue
+      - name: todo_bump_issue
+      - name: todo_change_issue_assignment
+      - name: todo_command
+      - name: todo_complete_issue
+      - name: todo_daily_summary_sent
+      - name: todo_edit_issue
+      - name: todo_frontend_click_lhs_in
+      - name: todo_frontend_click_lhs_my
+      - name: todo_frontend_click_lhs_out
+      - name: todo_frontend_custom_post_accept
+      - name: todo_frontend_custom_post_complete
+      - name: todo_frontend_custom_post_remove
+      - name: todo_frontend_rhs_add
+      - name: todo_frontend_toggle_inbox
+      - name: todo_frontend_toggle_my
+      - name: todo_remove_issue
+      - name: todo_send_issue
+      - name: tracks
+      - name: zoom_connect
+      - name: zoom_disconnect
+      - name: zoom_meeting_duplicated
+      - name: zoom_meeting_forced
+      - name: zoom_oauth_mode_change
+      - name: zoom_start_meeting

--- a/transform/snowflake-dbt/models/mm_telemetry_prod/sources.yml
+++ b/transform/snowflake-dbt/models/mm_telemetry_prod/sources.yml
@@ -4,13 +4,15 @@ sources:
   - name: mm_telemetry_prod
     database: 'RAW'
     schema: mm_telemetry_prod
+    loader: Rudderstack
     description: |
       Mattermost server and webapp telemetry data. Stored using Rudderstack. Rudderstack documentations offers an
       in-depth documentation of the [warehouse schema](https://www.rudderstack.com/docs/destinations/warehouse-destinations/warehouse-schema/).
       
-      The code that sends the events is available at:
-      - [Server](https://github.com/mattermost/mattermost-server/blob/master/services/telemetry/telemetry.go)
-      - [Webapp](https://github.com/mattermost/mattermost-webapp/blob/master/packages/mattermost-redux/src/client/rudder.ts)
+      This schema contains production data.
+      
+      [Server source](https://github.com/mattermost/mattermost-server/blob/master/services/telemetry/telemetry.go)
+      [Webapp source](https://github.com/mattermost/mattermost-webapp/blob/master/packages/mattermost-redux/src/client/rudder.ts)
     tags: ['rudderstack']
 
     tables:

--- a/transform/snowflake-dbt/models/mm_telemetry_qa/sources.yml
+++ b/transform/snowflake-dbt/models/mm_telemetry_qa/sources.yml
@@ -1,0 +1,69 @@
+version: 2
+
+sources:
+  - name: mm_telemetry_qa
+    database: raw
+    schema: mm_telemetry_qa
+    loader: Rudderstack
+    description: |
+      Mattermost server and webapp telemetry data. Stored using Rudderstack. Rudderstack documentations offers an
+      in-depth documentation of the [warehouse schema](https://www.rudderstack.com/docs/destinations/warehouse-destinations/warehouse-schema/).
+      
+      This schema contains QA data.
+      
+      [Server source](https://github.com/mattermost/mattermost-server/blob/master/services/telemetry/telemetry.go)
+      [Webapp source](https://github.com/mattermost/mattermost-webapp/blob/master/packages/mattermost-redux/src/client/rudder.ts)
+    tags:
+      - rudderstack
+
+    tables:
+      - name: _groups
+      - name: activity
+      - name: channel_moderation
+      - name: config_analytics
+      - name: config_announcement
+      - name: config_audit
+      - name: config_bleve
+      - name: config_client_requirements
+      - name: config_cluster
+      - name: config_compliance
+      - name: config_data_retention
+      - name: config_display
+      - name: config_elasticsearch
+      - name: config_email
+      - name: config_experimental
+      - name: config_file
+      - name: config_guest_accounts
+      - name: config_image_proxy
+      - name: config_ldap
+      - name: config_localization
+      - name: config_log
+      - name: config_message_export
+      - name: config_metrics
+      - name: config_nativeapp
+      - name: config_notifications_log
+      - name: config_oauth
+      - name: config_password
+      - name: config_plugin
+      - name: config_privacy
+      - name: config_rate
+      - name: config_saml
+      - name: config_service
+      - name: config_sql
+      - name: config_support
+      - name: config_team
+      - name: config_theme
+      - name: elasticsearch
+      - name: event
+      - name: identifies
+      - name: license
+      - name: pages
+      - name: permissions_general
+      - name: permissions_system_scheme
+      - name: permissions_team_schemes
+      - name: plugins
+      - name: rudder_discards
+      - name: server
+      - name: tracks
+      - name: users
+      - name: warn_metrics

--- a/transform/snowflake-dbt/models/mm_telemetry_rc/sources.yml
+++ b/transform/snowflake-dbt/models/mm_telemetry_rc/sources.yml
@@ -1,0 +1,25 @@
+version: 2
+
+sources:
+  - name: mm_telemetry_rc
+    database: raw
+    schema: mm_telemetry_rc
+    loader: Rudderstack
+    description: |
+      Mattermost server and webapp telemetry data. Stored using Rudderstack. Rudderstack documentations offers an
+      in-depth documentation of the [warehouse schema](https://www.rudderstack.com/docs/destinations/warehouse-destinations/warehouse-schema/).
+      
+      This schema contains RC data.
+      
+      [Server source](https://github.com/mattermost/mattermost-server/blob/master/services/telemetry/telemetry.go)
+      [Webapp source](https://github.com/mattermost/mattermost-webapp/blob/master/packages/mattermost-redux/src/client/rudder.ts)
+    tags:
+      - rudderstack
+
+    tables:
+      - name: activity
+      - name: identifies
+      - name: pages
+      - name: rudder_discards
+      - name: tracks
+      - name: users

--- a/transform/snowflake-dbt/models/portal_prod/sources.yml
+++ b/transform/snowflake-dbt/models/portal_prod/sources.yml
@@ -4,10 +4,14 @@ sources:
   - name: portal_prod
     database: 'RAW'
     schema: portal_prod
+    loader: Rudderstack
     description: |
       Portal data stored using Rudderstack. Rudderstack documentation offers an in-depth documentation of the
       [warehouse schema](https://www.rudderstack.com/docs/destinations/warehouse-destinations/warehouse-schema/).
-      The code that performs the tracking [is available here](https://github.com/mattermost/customer-web-server/blob/master/webapp/src/utils/rudder.tsx).
+      
+      This schema contains production data.
+      
+      [Source code](https://github.com/mattermost/customer-web-server/blob/master/webapp/src/utils/rudder.tsx).
     tags: ['rudderstack']
 
     tables:

--- a/transform/snowflake-dbt/models/portal_test/sources.yml
+++ b/transform/snowflake-dbt/models/portal_test/sources.yml
@@ -1,0 +1,16 @@
+version: 2
+
+sources:
+  - name: portal_test
+    database: 'RAW'
+    schema: portal_test
+    loader: Rudderstack
+    description: |
+      Portal data stored using Rudderstack. Rudderstack documentation offers an in-depth documentation of the
+      [warehouse schema](https://www.rudderstack.com/docs/destinations/warehouse-destinations/warehouse-schema/).
+      
+      This schema contains test data.
+      
+      [Source code](https://github.com/mattermost/customer-web-server/blob/master/webapp/src/utils/rudder.tsx).
+    tags:
+      - rudderstack

--- a/transform/snowflake-dbt/models/support_portal/sources.yml
+++ b/transform/snowflake-dbt/models/support_portal/sources.yml
@@ -4,6 +4,10 @@ sources:
   - name: support_portal
     database: 'RAW'
     schema: support_portal
+    loader: Rudderstack
+    description: Support portal events pushed via Rudderstack.
+    tags:
+      - rudderstack
 
     tables:
       - name: pages

--- a/transform/snowflake-dbt/models/web/sources.yml
+++ b/transform/snowflake-dbt/models/web/sources.yml
@@ -4,6 +4,12 @@ sources:
   - name: mattermost_docs
     database: RAW
     schema: mattermost_docs
+    loader: Rudderstack
+    description: |
+      Telemetry data for [Mattermost Docs](https://docs.mattermost.com/). Pushed via Rudderstack.
+    tags:
+      - rudderstack
+
 
   - name: web
     database: ANALYTICS

--- a/transform/snowflake-dbt/packages.yml
+++ b/transform/snowflake-dbt/packages.yml
@@ -1,3 +1,5 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 0.8.4
+  - package: dbt-labs/codegen
+    version: 0.9.0


### PR DESCRIPTION
#### Summary

- [x] Add missing documentation for all data sources for data published via Rudderstack.
- [x] Use `rudderstack` tag for all rudderstack originating sources.
- [x] Move plugin source to a separate source file.
- [x] Add [codegen](https://hub.getdbt.com/dbt-labs/codegen/latest/) plugin to assist with generation of sources.