### PR TITLE
MM-49762: Document python data sources

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/sources.yml
+++ b/transform/snowflake-dbt/models/mattermost/sources.yml
@@ -4,8 +4,11 @@ sources:
   - name: mattermost
     database: ANALYTICS
     schema: mattermost
+    loader: Python
+    tags:
+      - python
 
-    tables: 
+    tables:
       - name: github_repo_categorization
       
       - name: licenses
@@ -14,7 +17,13 @@ sources:
         description: The server version and associated release date (i.e. GA date).
 
       - name: onprem_clearbit
-        description: Enriched data for on prem servers. Enrichment done using clearbit data.
+        description: |
+          Enriched data for on prem servers. Enrichment done using clearbit data and custom python script.
+
+          [Source code](https://github.com/mattermost/mattermost-data-warehouse/blob/master/utils/onprem_clearbit.py)
 
       - name: cloud_clearbit
-        description: Enriched data for cloud servers. Enrichment done using clearbit data.
+        description: |
+          Enriched data for cloud servers. Enrichment done using clearbit data and custom python script.
+
+          [Source code](https://github.com/mattermost/mattermost-data-warehouse/blob/master/utils/cloud_clearbit.py)

--- a/transform/snowflake-dbt/models/staging/sources.yml
+++ b/transform/snowflake-dbt/models/staging/sources.yml
@@ -4,10 +4,22 @@ sources:
   - name: staging
     database: ANALYTICS
     schema: staging
+    loader: Python
+    tags:
+      - python
 
     tables: 
       - name: contributor_map_data
       - name: hist_license_mapping
       - name: github_contributions_all
+        description: |
+          List of github contributions. Updated using custom ingestion script.
+          
+          [Source code](https://github.com/mattermost/mattermost-data-warehouse/blob/master/utils/github_contributors.py)
+
       - name: activities_fill_out_form
       - name: clearbit_onprem_exceptions
+        description: |
+          Exceptions happening during on prem clearbit enrichment.
+          
+          [Source code](https://github.com/mattermost/mattermost-data-warehouse/blob/master/utils/onprem_clearbit.py)

--- a/transform/snowflake-dbt/models/web/sources.yml
+++ b/transform/snowflake-dbt/models/web/sources.yml
@@ -59,6 +59,12 @@ sources:
   - name: user_agent_registry
     database: ANALYTICS
     schema: web
+    loader: Python
+    tags:
+      - python
 
     tables:
       - name: user_agent_registry
+        description: |
+          Extracts details of user agent strings and breaks them to multiple columns. Implemented with python script.
+          [Source code](https://github.com/mattermost/mattermost-data-warehouse/blob/master/utils/user_agent_parser.py).


### PR DESCRIPTION
#### Summary

Document all data sources that write data to snowflake using Python scripts.

> Note that this list doesn't include imports from S3 that are triggered via python scripts. These will be documented in a separate PR.