### PR TITLE
MM-49894: First version of event registry

### DIFF
--- a/transform/snowflake-dbt/macros/rudderstack.sql
+++ b/transform/snowflake-dbt/macros/rudderstack.sql
@@ -1,0 +1,30 @@
+
+{% macro rudder_tracks_summary(schema) -%}
+WITH tmp AS (
+    SELECT
+        -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
+        CAST(received_at AS date) AS date_received_at
+        , event
+        , event_text
+        , COUNT(*) AS event_count
+    FROM
+        {{ source(schema, 'tracks') }}
+    WHERE
+       received_at <= CURRENT_TIMESTAMP
+{% if is_incremental() %}
+       -- this filter will only be applied on an incremental run
+      AND received_at >= (SELECT MAX(date_received_at) FROM {{ this }})
+{% endif %}
+    GROUP BY 1, 2, 3
+    ORDER BY 1, 2
+)
+SELECT
+    -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
+    {{ dbt_utils.surrogate_key(['date_received_at', 'event']) }} AS id
+    , date_received_at
+    , event
+    , event_text
+    , event_count
+FROM
+    tmp
+{%- endmacro%}

--- a/transform/snowflake-dbt/macros/rudderstack.sql
+++ b/transform/snowflake-dbt/macros/rudderstack.sql
@@ -4,8 +4,8 @@ WITH tmp AS (
     SELECT
         -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
         CAST(received_at AS date) AS date_received_at
-        , event
-        , event_text
+        , event AS event_table
+        , event_text AS event_name
         , COUNT(*) AS event_count
     FROM
         {{ source(schema, 'tracks') }}
@@ -20,10 +20,10 @@ WITH tmp AS (
 )
 SELECT
     -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
-    {{ dbt_utils.surrogate_key(['date_received_at', 'event']) }} AS id
+    {{ dbt_utils.surrogate_key(['date_received_at', 'event_table']) }} AS id
     , date_received_at
-    , event
-    , event_text
+    , event_table
+    , event_name
     , event_count
 FROM
     tmp

--- a/transform/snowflake-dbt/macros/schema.yml
+++ b/transform/snowflake-dbt/macros/schema.yml
@@ -13,3 +13,10 @@ macros:
       - name: precision
         type: integer
         description: Number of decimal places. Defaults to 2.
+
+  - name: rudder_tracks_summary
+    description: Summarizes a `tracks` table by calculating daily count of each event.
+    arguments:
+      - name: schema
+        type: string
+        description: The schema containing the `tracks` table.

--- a/transform/snowflake-dbt/models/event_registry/README.md
+++ b/transform/snowflake-dbt/models/event_registry/README.md
@@ -1,0 +1,20 @@
+# Event registry
+
+The event registry schema holds a high-level view of the events that are stored to the data warehouse via Rudderstack.
+There are two main tables available:
+
+- `daily_event_stats` - stores daily count of each event by source.
+- `event_registry` - stores facts about each event for its whole lifecycle.
+
+These two tables can power a variety of different reports/analytics:
+- Time series display of each event.
+- Anomaly detection for event volumes.
+- Identify duplicate events or events reused over different parts of the product.
+
+## Future improvements
+
+The event registry can be extended to capture:
+
+- Drill down on events that have some hierarchical structure (i.e. `events` from webapp).
+- Changes in the event schemas.
+- Ownership of each event.

--- a/transform/snowflake-dbt/models/event_registry/base/base_hacktoberboard_prod.sql
+++ b/transform/snowflake-dbt/models/event_registry/base/base_hacktoberboard_prod.sql
@@ -1,0 +1,13 @@
+{{
+    config({
+        "materialized": "incremental",
+        "tags":"hourly",
+        "schema": "event_registry",
+        "incremental_strategy": "merge",
+        "unique_key": ['id'],
+        "merge_update_columns": ['event_count'],
+        "cluster_by": ['date_received_at'],
+    })
+}}
+
+{{ rudder_tracks_summary('hacktoberboard_prod') }}

--- a/transform/snowflake-dbt/models/event_registry/base/base_incident_response_prod.sql
+++ b/transform/snowflake-dbt/models/event_registry/base/base_incident_response_prod.sql
@@ -1,0 +1,13 @@
+{{
+    config({
+        "materialized": "incremental",
+        "tags":"hourly",
+        "schema": "event_registry",
+        "incremental_strategy": "merge",
+        "unique_key": ['id'],
+        "merge_update_columns": ['event_count'],
+        "cluster_by": ['date_received_at'],
+    })
+}}
+
+{{ rudder_tracks_summary('incident_response_prod') }}

--- a/transform/snowflake-dbt/models/event_registry/base/base_mattermost_docs.sql
+++ b/transform/snowflake-dbt/models/event_registry/base/base_mattermost_docs.sql
@@ -1,0 +1,13 @@
+{{
+    config({
+        "materialized": "incremental",
+        "tags":"hourly",
+        "schema": "event_registry",
+        "incremental_strategy": "merge",
+        "unique_key": ['id'],
+        "merge_update_columns": ['event_count'],
+        "cluster_by": ['date_received_at'],
+    })
+}}
+
+{{ rudder_tracks_summary('mattermost_docs') }}

--- a/transform/snowflake-dbt/models/event_registry/base/base_mattermostcom.sql
+++ b/transform/snowflake-dbt/models/event_registry/base/base_mattermostcom.sql
@@ -1,0 +1,13 @@
+{{
+    config({
+        "materialized": "incremental",
+        "tags":"hourly",
+        "schema": "event_registry",
+        "incremental_strategy": "merge",
+        "unique_key": ['id'],
+        "merge_update_columns": ['event_count'],
+        "cluster_by": ['date_received_at'],
+    })
+}}
+
+{{ rudder_tracks_summary('mattermostcom') }}

--- a/transform/snowflake-dbt/models/event_registry/base/base_mm_mobile_prod.sql
+++ b/transform/snowflake-dbt/models/event_registry/base/base_mm_mobile_prod.sql
@@ -7,6 +7,7 @@
         "unique_key": ['id'],
         "merge_update_columns": ['event_count'],
         "cluster_by": ['date_received_at'],
+        "snowflake_warehouse": "transform_l"
     })
 }}
 

--- a/transform/snowflake-dbt/models/event_registry/base/base_mm_mobile_prod.sql
+++ b/transform/snowflake-dbt/models/event_registry/base/base_mm_mobile_prod.sql
@@ -1,0 +1,13 @@
+{{
+    config({
+        "materialized": "incremental",
+        "tags":"hourly",
+        "schema": "event_registry",
+        "incremental_strategy": "merge",
+        "unique_key": ['id'],
+        "merge_update_columns": ['event_count'],
+        "cluster_by": ['date_received_at'],
+    })
+}}
+
+{{ rudder_tracks_summary('mm_mobile_prod') }}

--- a/transform/snowflake-dbt/models/event_registry/base/base_mm_plugin_prod.sql
+++ b/transform/snowflake-dbt/models/event_registry/base/base_mm_plugin_prod.sql
@@ -1,0 +1,13 @@
+{{
+    config({
+        "materialized": "incremental",
+        "tags":"hourly",
+        "schema": "event_registry",
+        "incremental_strategy": "merge",
+        "unique_key": ['id'],
+        "merge_update_columns": ['event_count'],
+        "cluster_by": ['date_received_at'],
+    })
+}}
+
+{{ rudder_tracks_summary('mm_plugin_prod') }}

--- a/transform/snowflake-dbt/models/event_registry/base/base_mm_telemetry_prod.sql
+++ b/transform/snowflake-dbt/models/event_registry/base/base_mm_telemetry_prod.sql
@@ -1,0 +1,14 @@
+{{
+    config({
+        "materialized": "incremental",
+        "tags":"hourly",
+        "schema": "event_registry",
+        "incremental_strategy": "merge",
+        "unique_key": ['id'],
+        "merge_update_columns": ['event_count'],
+        "cluster_by": ['date_received_at'],
+        "snowflake_warehouse": "transform_l"
+    })
+}}
+
+{{ rudder_tracks_summary('mm_telemetry_prod') }}

--- a/transform/snowflake-dbt/models/event_registry/base/base_portal_prod.sql
+++ b/transform/snowflake-dbt/models/event_registry/base/base_portal_prod.sql
@@ -1,0 +1,13 @@
+{{
+    config({
+        "materialized": "incremental",
+        "tags":"hourly",
+        "schema": "event_registry",
+        "incremental_strategy": "merge",
+        "unique_key": ['id'],
+        "merge_update_columns": ['event_count'],
+        "cluster_by": ['date_received_at'],
+    })
+}}
+
+{{ rudder_tracks_summary('portal_prod') }}

--- a/transform/snowflake-dbt/models/event_registry/daily_event_stats.sql
+++ b/transform/snowflake-dbt/models/event_registry/daily_event_stats.sql
@@ -1,0 +1,59 @@
+{{
+    config({
+        "materialized": "table",
+        "tags":"hourly",
+        "schema": "event_registry",
+        "cluster_by": ['date_received_at', 'source'],
+    })
+}}
+-- depends_on: {{ ref('base_portal_prod') }}
+-- depends_on: {{ ref('base_mattermostcom') }}
+-- depends_on: {{ ref('base_incident_response_prod') }}
+-- depends_on: {{ ref('base_mattermost_docs') }}
+-- depends_on: {{ ref('base_hacktoberboard_prod') }}
+-- depends_on: {{ ref('base_mm_mobile_prod') }}
+-- depends_on: {{ ref('base_mm_plugin_prod') }}
+-- depends_on: {{ ref('base_mm_telemetry_prod') }}
+
+-- Schemas containing telemetry data.
+{%
+    set schemas =  [
+        'portal_prod',
+        'mattermostcom',
+        'incident_response_prod',
+        'mattermost_docs',
+        'hacktoberboard_prod',
+        'mm_mobile_prod',
+        'mm_plugin_prod',
+        'mm_telemetry_prod'
+    ]
+%}
+
+WITH
+{% for schema_ in schemas %}
+    base_{{schema_}} AS (
+    SELECT
+        date_received_at
+        , event
+        , event_text
+        , event_count
+        , '{{schema_}}' AS source
+    FROM
+        {{ ref('base_' + schema_) }}
+    )
+    {% if not loop.last -%}, {%- endif %}
+{% endfor %}
+{% for schema_ in schemas %}
+-- A few conventions followed here:
+-- - Timestamps/date names must end with _at
+-- - Count columns must end with _count
+-- - Columns that are useful for internal functionality have _ as a prefix
+SELECT
+    -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
+    {{ dbt_utils.surrogate_key(['date_received_at', 'event', 'source']) }} AS id
+    , *
+FROM
+    base_{{schema_}}
+    {% if not loop.last -%} UNION ALL {%- endif %}
+{% endfor %}
+

--- a/transform/snowflake-dbt/models/event_registry/daily_event_stats.sql
+++ b/transform/snowflake-dbt/models/event_registry/daily_event_stats.sql
@@ -3,7 +3,7 @@
         "materialized": "table",
         "tags":"hourly",
         "schema": "event_registry",
-        "cluster_by": ['date_received_at', 'source'],
+        "cluster_by": ['event_date', 'source'],
     })
 }}
 -- depends_on: {{ ref('base_portal_prod') }}
@@ -33,11 +33,11 @@ WITH
 {% for schema_ in schemas %}
     base_{{schema_}} AS (
     SELECT
-        date_received_at
-        , event
-        , event_text
-        , event_count
+        date_received_at AS event_date
+        , event_table
+        , event_name
         , '{{schema_}}' AS source
+        , event_count
     FROM
         {{ ref('base_' + schema_) }}
     )
@@ -50,7 +50,7 @@ WITH
 -- - Columns that are useful for internal functionality have _ as a prefix
 SELECT
     -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
-    {{ dbt_utils.surrogate_key(['date_received_at', 'event', 'source']) }} AS id
+    {{ dbt_utils.surrogate_key(['event_date', 'event_table', 'source']) }} AS id
     , *
 FROM
     base_{{schema_}}

--- a/transform/snowflake-dbt/models/event_registry/event_fact.sql
+++ b/transform/snowflake-dbt/models/event_registry/event_fact.sql
@@ -3,21 +3,21 @@
         "materialized": "table",
         "tags":"hourly",
         "schema": "event_registry",
-        "cluster_by": ['source', 'event'],
+        "cluster_by": ['source', 'event_table'],
     })
 }}
 SELECT
-    {{ dbt_utils.surrogate_key(['event', 'source']) }} AS id
-    , event
-    , event_text
+    {{ dbt_utils.surrogate_key(['event_table', 'source']) }} AS id
+    , event_table
+    , event_name
     , source
-    , MIN(date_received_at) AS first_triggered_at
-    , MAX(date_received_at) AS last_triggered_at
+    , MIN(event_date) AS first_triggered_at
+    , MAX(event_date) AS last_triggered_at
     , SUM(event_count) AS event_total_count
     , SUM(event_count) / DATEDIFF(day, first_triggered_at, CURRENT_TIMESTAMP) AS event_daily_average
 FROM
     {{ ref('daily_event_stats') }}
 GROUP BY
-    event,
-    event_text,
+    event_table,
+    event_name,
     source

--- a/transform/snowflake-dbt/models/event_registry/event_registry.sql
+++ b/transform/snowflake-dbt/models/event_registry/event_registry.sql
@@ -1,0 +1,23 @@
+{{
+    config({
+        "materialized": "table",
+        "tags":"hourly",
+        "schema": "event_registry",
+        "cluster_by": ['source', 'event'],
+    })
+}}
+SELECT
+    {{ dbt_utils.surrogate_key(['event', 'source']) }} AS id
+    , event
+    , event_text
+    , source
+    , MIN(date_received_at) AS first_triggered_at
+    , MAX(date_received_at) AS last_triggered_at
+    , SUM(event_count) AS event_total_count
+    , SUM(event_count) / DATEDIFF(day, first_triggered_at, CURRENT_TIMESTAMP) AS event_daily_average
+FROM
+    {{ ref('daily_event_stats') }}
+GROUP BY
+    event,
+    event_text,
+    source

--- a/transform/snowflake-dbt/models/event_registry/event_registry.yml
+++ b/transform/snowflake-dbt/models/event_registry/event_registry.yml
@@ -1,0 +1,76 @@
+version: 2
+
+models:
+  - name: base_tracks
+    description: >
+      Daily event information. Doesn't contain rows for events on dates where 
+      no events of that type were submitted.
+
+    columns:
+      - name: id
+        description: A unique id for each event/date/source combination.
+        tests:
+          - unique
+          - not_null
+      - name: date_received_at
+        description: The date that events of the current type were received.
+        tests:
+          - not_null
+      - name: event
+        description: The name of the corresponding event table.
+        tests:
+          - not_null
+      - name: event_text
+        description: The name of the event.
+        tests:
+          - not_null
+      - name: source
+        description: The name of the source that the event are submitted from.
+        tests:
+          - not_null
+      - name: event_count
+        description: The total number of events submitted for the current date.
+        tests:
+          - not_null
+
+  - name: event_registry
+    description: |
+      Provides a list of events captured using Rudderstack's 
+      [track](https://www.rudderstack.com/docs/event-spec/standard-events/track/) API call. 
+
+    columns:
+      - name: id
+        description: A unique id for each event.
+        tests:
+          - unique
+          - not_null
+      - name: event
+        description: The name of the corresponding event table.
+        tests:
+          - not_null
+      - name: event_text
+        description: The name of the event.
+        tests:
+          - not_null
+      - name: source
+        description: The name of the source that the event are submitted from.
+        tests:
+          - not_null
+      - name: first_triggered_at
+        description: The first date that the event was triggered at.
+        tests:
+          - not_null
+      - name: last_triggered_at
+        description: The last date that the event was triggered at.
+        tests:
+          - not_null
+      - name: event_total_count
+        description: The total number of events
+        tests:
+          - not_null
+      - name: event_daily_average
+        description: >
+          Average number of events per day. Calculated as the total number of events divided by the number of days 
+          between first triggered date and today.
+        tests:
+          - not_null

--- a/transform/snowflake-dbt/models/event_registry/event_registry.yml
+++ b/transform/snowflake-dbt/models/event_registry/event_registry.yml
@@ -1,39 +1,7 @@
 version: 2
 
 models:
-  - name: base_tracks
-    description: >
-      Daily event information. Doesn't contain rows for events on dates where 
-      no events of that type were submitted.
-
-    columns:
-      - name: id
-        description: A unique id for each event/date/source combination.
-        tests:
-          - unique
-          - not_null
-      - name: date_received_at
-        description: The date that events of the current type were received.
-        tests:
-          - not_null
-      - name: event
-        description: The name of the corresponding event table.
-        tests:
-          - not_null
-      - name: event_text
-        description: The name of the event.
-        tests:
-          - not_null
-      - name: source
-        description: The name of the source that the event are submitted from.
-        tests:
-          - not_null
-      - name: event_count
-        description: The total number of events submitted for the current date.
-        tests:
-          - not_null
-
-  - name: event_registry
+  - name: event_fact
     description: |
       Provides a list of events captured using Rudderstack's 
       [track](https://www.rudderstack.com/docs/event-spec/standard-events/track/) API call. 
@@ -44,11 +12,11 @@ models:
         tests:
           - unique
           - not_null
-      - name: event
+      - name: event_table
         description: The name of the corresponding event table.
         tests:
           - not_null
-      - name: event_text
+      - name: event_name
         description: The name of the event.
         tests:
           - not_null
@@ -72,5 +40,37 @@ models:
         description: >
           Average number of events per day. Calculated as the total number of events divided by the number of days 
           between first triggered date and today.
+        tests:
+          - not_null
+
+  - name: daily_event_stats
+    description: |
+      Provides a list of events per day captured using Rudderstack's 
+      [track](https://www.rudderstack.com/docs/event-spec/standard-events/track/) API call. 
+
+    columns:
+      - name: id
+        description: A unique id for each event.
+        tests:
+          - unique
+          - not_null
+      - name: event_date
+        description: The date that the event was received.
+        tests:
+          - not_null
+      - name: event_table
+        description: The name of the corresponding event table.
+        tests:
+          - not_null
+      - name: event_name
+        description: The name of the event.
+        tests:
+          - not_null
+      - name: source
+        description: The name of the source that the event are submitted from.
+        tests:
+          - not_null
+      - name: event_count
+        description: The total number of events for the given date and time.
         tests:
           - not_null

--- a/transform/snowflake-dbt/models/focalboard/sources.yml
+++ b/transform/snowflake-dbt/models/focalboard/sources.yml
@@ -18,3 +18,4 @@ sources:
       - name: server
       - name: workspaces
       - name: blocks
+      - name: tracks

--- a/transform/snowflake-dbt/models/mattermostcom/sources.yml
+++ b/transform/snowflake-dbt/models/mattermostcom/sources.yml
@@ -19,3 +19,4 @@ sources:
         description: 'Information pertaining to the user and purchased license (subscription_id) for users that successfully purchased a license via the Mattermost Customer Portal (customers.mattermost.com).'
       - name: marketo_form_submit
         description: 'Raw Marketo Form Submit data.'
+      - name: tracks

--- a/transform/snowflake-dbt/models/web/sources.yml
+++ b/transform/snowflake-dbt/models/web/sources.yml
@@ -10,6 +10,10 @@ sources:
     tags:
       - rudderstack
 
+    tables:
+      - name: tracks
+
+
 
   - name: web
     database: ANALYTICS


### PR DESCRIPTION
#### Summary

First version of event registry. Iterates over all Rudderstack [tracks](https://www.rudderstack.com/docs/destinations/warehouse-destinations/warehouse-schema/#track) table and joins them across sources. 

Please note the following design choices:
- Ignoring all segment originating events for now.
- Each `tracks` table has its own `base` model. This allows more finegrained control on table level.  A side benefit of this is that new `tracks` can be added without requiring complex incremental logic. This also helped greatly in optimizing execution time.
- Base tables are updated incrementally to reduce resource usage.
- Repeatable code has been extracted to a macro. This will make it easier. 
- There were some missing table definitions for `tracks` tables in sources that needed to be added. 