### PR TITLE
MM-50113: Add tests for cloud professional subscriptions

### DIFF
--- a/transform/snowflake-dbt/models/data_quality_layer/analytics/clearbit/schema.yml
+++ b/transform/snowflake-dbt/models/data_quality_layer/analytics/clearbit/schema.yml
@@ -71,6 +71,7 @@ models:
         tests:
           - not_null
           - unique
+          
       - name: domain
         description: The domain of the customer i.e substring of email in most cases
         tests:

--- a/transform/snowflake-dbt/models/data_quality_layer/analytics/clearbit/schema.yml
+++ b/transform/snowflake-dbt/models/data_quality_layer/analytics/clearbit/schema.yml
@@ -75,4 +75,3 @@ models:
         description: The domain of the customer i.e substring of email in most cases
         tests:
           - not_null
-          

--- a/transform/snowflake-dbt/models/data_quality_layer/analytics/clearbit/schema.yml
+++ b/transform/snowflake-dbt/models/data_quality_layer/analytics/clearbit/schema.yml
@@ -61,3 +61,18 @@ models:
         description: Whether there are missing clearbit data (1) or not (0).
         tests:
           - not_null
+
+  - name: dq_cloud_professional
+    description: Information about paid customers with `Cloud Professional` subscription.
+
+    columns:
+      - name: email
+        description:  The email of the customer who subscribed for cloud professional subscription.
+        tests:
+          - not_null
+          - unique
+      - name: domain
+        description: The domain of the customer i.e substring of email in most cases
+        tests:
+          - not_null
+          

--- a/transform/snowflake-dbt/models/data_quality_layer/hightouch/subscriptions/dq_cloud_professional.sql
+++ b/transform/snowflake-dbt/models/data_quality_layer/hightouch/subscriptions/dq_cloud_professional.sql
@@ -1,0 +1,35 @@
+{{ config(
+    { "materialized": "table",
+    "schema": "data_quality",
+    "tags": "data-quality" }
+) }}
+
+WITH cloud_professional_subscriptions AS (
+
+    SELECT
+        stage.email,
+        stage.domain,
+        A.sfid AS account_sfid,
+        co.sfid AS contact_sfid,
+        o.sfid AS opportunity_sfid,
+        start_date
+    FROM
+        {{ ref('customers_with_cloud_paid_subs') }}
+        stage
+        LEFT JOIN "ANALYTICS"."ORGM"."LEAD" l
+        ON l.email = stage.email
+        LEFT JOIN {{ ref('contact') }}
+        co
+        ON co.email = stage.email
+        LEFT JOIN {{ ref('account') }} A
+        ON A.dwh_external_id__c = stage.account_external_id
+        LEFT JOIN {{ ref('opportunity') }}
+        o
+        ON o.dwh_external_id__c = stage.opportunity_external_id
+    WHERE
+        sku = 'Cloud Professional'
+)
+SELECT
+    *
+FROM
+    cloud_professional_subscriptions

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/schema.yml
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/schema.yml
@@ -1,0 +1,86 @@
+version: 2
+
+models:
+  - name: freemium_account
+    description: Accounts having current subscription as `Cloud Professional`, to be inserted into salesforce.
+    columns:
+      - name: account_external_id
+        tests:
+          - not_null
+          - unique
+      - name: ownerid
+        tests: 
+          - not_null
+  - name: freemium_account_update
+    description: Accounts having current subscription as `Cloud Professional` already existing in salesforce, to be updated with new fields.
+    columns:
+      - name: account_external_id
+        tests:
+          - not_null
+          - unique
+      - name: ownerid
+        tests: 
+          - not_null
+  - name: freemium_contact
+    description: Contacts having current subscription as `Cloud Professional`, to be inserted into salesforce.
+    columns:
+      - name: contact_external_id
+        tests:
+          - not_null
+          - unique
+      - name: ownerid
+        tests: 
+          - not_null
+      - name: duplicate_lead_id
+        tests:
+          - not_null
+  - name: freemium_contact_update
+    description: Contacts having current subscription as `Cloud Professional` already existing in salesforce, to be updated with new fields.
+    columns:
+      - name: contact_external_id
+        tests:
+          - not_null
+          - unique
+      - name: ownerid
+        tests: 
+          - not_null
+      - name: duplicate_lead_id
+        tests:
+          - not_null
+  - name: freemium_opportunity
+    description: Opportunities having current subscription as `Cloud Professional`, to be inserted into salesforce.
+    columns:
+      - name: opportunity_external_id
+        tests:
+          - not_null
+          - unique
+      - name: account_lookup_id
+        tests:
+          - not_null
+      - name: email
+        tests:
+          - not_null
+  - name: freemium_opportunitylineitem_for_update
+    description:  Opportunitylineitems having current subscription as `Cloud Professional`, to be updated into salesforce.
+    columns:
+      - name: product_id
+        tests:
+          - not_null
+      - name: opportunity_external_id
+        tests:
+          - not_null
+  - name: cancelled_account_update
+    description: Accounts that cancelled subscription for `Cloud Professional`, to be updated into salesforce.
+    columns:
+      - name: account_external_id
+        tests:
+          - not_null
+          - unique
+  - name: cancelled_opportunity_update
+    description: Opportunity that cancelled subscription for `Cloud Professional`, to be updated into salesforce.
+    columns:
+      - name: opportunity_sfid
+        tests:
+          - not_null
+          - unique
+

--- a/transform/snowflake-dbt/tests/data_quality/hightouch/subscriptions/test_cloud_professional.sql
+++ b/transform/snowflake-dbt/tests/data_quality/hightouch/subscriptions/test_cloud_professional.sql
@@ -1,0 +1,21 @@
+{{ config(
+    tags = ['data-quality']
+) }}
+
+SELECT
+    *
+FROM
+    {{ ref('dq_cloud_professional') }}
+WHERE
+    -- Fetch all opportunities/contacts/accounts not synced into salesforce.
+    (
+        (
+            account_sfid IS NULL
+            AND contact_sfid IS NULL
+        )
+        OR (
+            opportunity_sfid IS NULL
+        )
+    )
+    AND start_date IS NOT NULL
+    AND start_date < DATEADD(DAY, -1, CURRENT_DATE())


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Collects rows from the stage table and compares it with destination `ORGM`. Entity is confirmed as synced into salesforce if `sfid` exists for it.
- [x] Added basic tests for unique and not_null fields in schema.yml
- [x] Added tests for dql that run daily via airflow 

Deployment steps - N/A (assuming it runs via airflow nightly job because of tag `data-quality`)
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-50113
