### PR TITLE
MM-50215: build docker image for permifrost

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,4 @@
 build
 dags
 k8s
-load
 plugins

--- a/.github/workflows/ci-permifrost.yml
+++ b/.github/workflows/ci-permifrost.yml
@@ -1,0 +1,60 @@
+name: Permifrost Tests
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/ci-permifrost.yml'
+      - 'build/permiforst.Dockerfile'
+      - 'load/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/ci-permifrost.yml'
+      - 'build/permiforst.Dockerfile'
+      - 'load/**'
+
+jobs:
+  tests:
+    name: Lint YAML file
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Lint YAML file
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  #v3.1.1
+        with:
+          file_or_dir: load/snowflake/roles.yaml
+
+  docker:
+    name: Build docker image
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Lint docker image
+        run: make docker-permifrost-lint
+
+      - name: Build & push docker image
+        run: make docker-login && make permifrost-docker-build && make permifrost-docker-push
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Sign docker image
+        run: make docker-permifrost-sign && make docker-permifrost-verify
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}

--- a/.github/workflows/ci-permifrost.yml
+++ b/.github/workflows/ci-permifrost.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c   # v.3.3.0
         with:
           fetch-depth: 1
 
@@ -41,7 +41,7 @@ jobs:
     needs: tests
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c   # v.3.3.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/ci-permifrost.yml
+++ b/.github/workflows/ci-permifrost.yml
@@ -30,6 +30,8 @@ jobs:
         uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  #v3.1.1
         with:
           file_or_dir: load/snowflake/roles.yaml
+          config_file: build/.yamllint.yml
+          format: github
 
   docker:
     name: Build docker image

--- a/.github/workflows/ci-permifrost.yml
+++ b/.github/workflows/ci-permifrost.yml
@@ -6,14 +6,16 @@ on:
       - master
     paths:
       - '.github/workflows/ci-permifrost.yml'
-      - 'build/permiforst.Dockerfile'
+      - 'build/permifrost.Dockerfile'
+      - 'build/.yamllint.yml'
       - 'load/**'
   pull_request:
     branches:
       - master
     paths:
       - '.github/workflows/ci-permifrost.yml'
-      - 'build/permiforst.Dockerfile'
+      - 'build/permifrost.Dockerfile'
+      - 'build/.yamllint.yml'
       - 'load/**'
 
 jobs:
@@ -44,7 +46,7 @@ jobs:
           fetch-depth: 1
 
       - name: Lint docker image
-        run: make docker-permifrost-lint
+        run: make permifrost-docker-lint
 
       - name: Build & push docker image
         run: make docker-login && make permifrost-docker-build && make permifrost-docker-push
@@ -53,7 +55,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Sign docker image
-        run: make docker-permifrost-sign && make docker-permifrost-verify
+        run: make permifrost-docker-sign && make permifrost-docker-verify
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ permifrost-docker-build: ## to build the docker image
 .PHONY: permifrost-docker-push
 permifrost-docker-push: ## to push the docker image
 	@$(INFO) Pushing permifrost to registry...
-	$(AT)$(DOCKER) tag ${PERMIFROST}:${APP_VERSION} $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_PERMIFROST_REPO}:${APP_VERSION} || ${FAIL}
+	$(AT)$(DOCKER) tag ${PERMIFROST_NAME}:${APP_VERSION} $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_PERMIFROST_REPO}:${APP_VERSION} || ${FAIL}
 	$(AT)$(DOCKER) push $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_PERMIFROST_REPO}:${APP_VERSION} || ${FAIL}
 # if we are on a latest semver APP_VERSION tag, also push latest
 ifneq ($(shell echo $(APP_VERSION) | egrep '^v([0-9]+\.){0,2}(\*|[0-9]+)'),)

--- a/build/.yamllint.yml
+++ b/build/.yamllint.yml
@@ -1,0 +1,9 @@
+extends: default
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 80
+    level: warning
+
+  indentation: disable

--- a/build/.yamllint.yml
+++ b/build/.yamllint.yml
@@ -7,3 +7,7 @@ rules:
     level: warning
 
   indentation: disable
+
+  truthy:
+    allowed-values: [ 'true', 'false', 'yes', 'no' ]
+    check-keys: true

--- a/build/permifrost.Dockerfile
+++ b/build/permifrost.Dockerfile
@@ -1,0 +1,57 @@
+ARG PYTHON_IMAGE=python:3.8.15-slim@sha256:fc2f284772a4443ce7238930ba9a8d5e3c720926616fca074b99213484a3820f
+
+## ---------------------------base stage ----------------------------- ##
+
+# Base image to use both for builder and base. Mainly used to cache additional dependency installations.
+# TODO: as soon as there's a stable distroless image, replace it with distroless.
+# hadolint ignore=DL3006
+FROM ${PYTHON_IMAGE} as base
+
+## standardise on locale
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+## Don't generate .pyc, enable tracebacks on seg faults, use random seed for hashing strings and unbuffer stdout/stderr.
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONFAULTHANDLER 1
+ENV PYTHONHASHSEED random
+ENV PYTHONUNBUFFERED 1
+
+## ---------------------------builder stage ----------------------------- ##
+
+FROM base as builder
+
+# Sane python defaults
+## pip timeout, don't use cache, don't check for newer version and settings
+ENV PIP_DEFAULT_TIMEOUT=100 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
+# Activate virtualenv in a shellcheck friendly way
+ENV VIRTUAL_ENV=/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install dependencies excluding dev and current package
+RUN pip install "permifrost==0.1.0"
+
+## ---------------------------final stage ----------------------------- ##
+
+FROM base as final
+
+## Copy dependencies from builder
+COPY --from=builder /venv /venv
+
+WORKDIR /app
+
+# Activate virtualenv so that this python is used (see https://pythonspeed.com/articles/activate-virtualenv-dockerfile/)
+ENV VIRTUAL_ENV=/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Copy files required for transformations
+COPY load/snowflake /app/load/snowflake
+
+# We should refrain from running as privileged user
+# Run as UID for nobody
+USER 65534

--- a/load/snowflake/roles.yaml
+++ b/load/snowflake/roles.yaml
@@ -154,7 +154,7 @@ roles:
                 write:
                     - raw.*.*
 
-    - transformer: # For automated jobs
+    - transformer:  # For automated jobs
         warehouses:
             - transform_xs
             - transform_l

--- a/load/snowflake/roles.yaml
+++ b/load/snowflake/roles.yaml
@@ -192,7 +192,7 @@ roles:
     # Object Roles
 
     # User Roles
-    
+
 
 # Users
 users:
@@ -272,6 +272,6 @@ warehouses:
 
     - reporting_m:
         size: medium
-    
+
     - transform_m:
         size: medium


### PR DESCRIPTION
#### Summary

First step for replacing external image with one maintained by mattermost.

- [x] Dockerfile for creating a permifrost image with configuration baked in the image. Uses same version of permifrost as existing image.
- [x] Lint YAML configuration file.
- [x] Update `Makefile` to include targets for building/linting permifrost docker image.
- [x] Separate github action for linting and building the image.

As soon as this PR is reviewed and merged, I'll start work on updating the DAG. 
