### PR TITLE
Hotfix: properly calculate number of days between start and end

### DIFF
--- a/transform/snowflake-dbt/models/event_registry/event_fact.sql
+++ b/transform/snowflake-dbt/models/event_registry/event_fact.sql
@@ -14,7 +14,7 @@ SELECT
     , MIN(event_date) AS first_triggered_at
     , MAX(event_date) AS last_triggered_at
     , SUM(event_count) AS event_total_count
-    , SUM(event_count) / DATEDIFF(day, first_triggered_at, CURRENT_TIMESTAMP) AS event_daily_average
+    , SUM(event_count) / (DATEDIFF(day, first_triggered_at, CURRENT_TIMESTAMP) + 1) AS event_daily_average
 FROM
     {{ ref('daily_event_stats') }}
 GROUP BY


### PR DESCRIPTION
#### Summary

If a new event is introduced, then the number of days since it was encountered, will be 0. This is an error in the calculation of the average number of events per day. 

Example:
```
SELECT DATEDIFF(day, '2018-08-25', '2018-08-25') AS DateDiff;

| DateDiff |
|----------|
| 0        |
```


This PR fixes the formula for calculating the average number of events per day.