### PR TITLE
MM - 49567 Adding time for the job to pick up security data

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/server_fact.sql
@@ -33,7 +33,7 @@ WITH sdd AS (
             OR NOT EXISTS (SELECT 1 FROM {{this}} SF WHERE SF.SERVER_ID = SDD.SERVER_ID AND SDD.timestamp <= CURRENT_TIMESTAMP)
             GROUP BY 1
             {% if is_incremental() %}
-            HAVING MAX(CASE WHEN in_security OR in_mm2_server THEN timestamp ELSE NULL END) > (SELECT MAX(last_active_date) - INTERVAL '2 HOURS' FROM {{this}})
+            HAVING MAX(CASE WHEN in_security OR in_mm2_server THEN timestamp ELSE NULL END) > (SELECT MAX(last_active_date) - INTERVAL '6 HOURS' FROM {{this}})
             {% endif %}
           ),
 


### PR DESCRIPTION
Impact: There is a data gap in server_fact and this only occurs in incremental load, the field last_telemetry_active_date coming from security data isn't being updated. This happens because if the job fails in dbt for whatever reason and fails more than 2 hours, the incremental logic doesn't pick up certain rows and the condition updated in this PR is never fulfilled leading to the fields being empty. This can be easily fixed by a full refresh of the table, however I am giving enough room of 6 hours for the job to look back, provided the dbt hourly job failure is resolved within 6 hours.

Testing: Changes have been fully tested locally and a full refresh back filled all the data.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

