### PR TITLE
MM-50377: Add staging models for mobile

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -36,7 +36,8 @@ models:
     # Config indicated by + and applies to all files under models/example/
     staging:
       +materialized: view
-      schema: staging
+      # Ideally this would have been named staging. Unfortunately there's already a schema with that name.
+      schema: dbt_staging
       tags: ['staging']
     intermediate:
       +materialized: ephemeral
@@ -49,3 +50,9 @@ models:
       schema: utilities
       tags: [ 'utilities' ]
 
+
+# Configuration variables
+
+vars:
+  # Common event columns to keep (if they are part of the table)
+  base_event_columns: ['ID', 'RECEIVED_AT', 'EVENT', 'EVENT_TEXT', 'CATEGORY', 'TYPE', 'USER_ID', 'USER_ACTUAL_ID' ]

--- a/transform/mattermost-analytics/macros/rudderstack/_rudderstack_docs.md
+++ b/transform/mattermost-analytics/macros/rudderstack/_rudderstack_docs.md
@@ -1,0 +1,3 @@
+# Rudderstack macros
+
+Helpful macros for manipulating Rudderstack schemas.

--- a/transform/mattermost-analytics/macros/rudderstack/_rudderstack_schema.yml
+++ b/transform/mattermost-analytics/macros/rudderstack/_rudderstack_schema.yml
@@ -1,0 +1,24 @@
+version: 2
+
+macros:
+  - name: join_tracks_event_tables
+    description: |
+      A macro that joins event tables to a single table, keeping the extra columns. 
+      
+      Rudderstack stores one row in two tables for each event. 
+      - `tracks`, which holds generic information about the event, and
+      - `event_name`, which holds the extra user defined properties. 
+      
+      This macro joins all tables except the default tables defined in
+      [warehouse schema](https://www.rudderstack.com/docs/destinations/warehouse-destinations/warehouse-schema). It also
+      allows for filtering which columns to keep. This can be useful in scenarios where events share properties (i.e. 
+      indicating event hierarchy, A/B test allocations etc).
+
+    arguments:
+      - name: schema
+        type: string
+        description: The schema that contains the event tables.
+      - name: columns
+        type: list
+        description: The list of columns to keep.
+

--- a/transform/mattermost-analytics/macros/rudderstack/join_tracks_event_tables.sql
+++ b/transform/mattermost-analytics/macros/rudderstack/join_tracks_event_tables.sql
@@ -1,0 +1,28 @@
+{% macro join_tracks_event_tables(schema, columns=[]) -%}
+    {%-
+        set rudderstack_tables = ['IDENTIFIES', 'USERS', 'TRACKS', 'PAGES', 'SCREENS', 'GROUPS', 'ALIASES', 'RUDDER_DISCARDS']
+    -%}
+    {%- set all_relations = dbt_utils.get_relations_by_pattern(schema, '%', database='RAW') | list -%}
+    {%- set relations = all_relations | rejectattr('identifier', 'in', rudderstack_tables) | list -%}
+    {%- set include = var('base_event_columns') -%}
+
+    {%- if columns -%}
+        {# If user defined columns to keep, filter them #}
+        {{
+            dbt_utils.union_relations(
+                relations=relations,
+                include=columns,
+                source_column_name=None
+            )
+        }}
+    {%- else -%}
+        {# Keep all columns #}
+        {{
+            dbt_utils.union_relations(
+                relations=relations,
+                source_column_name=None
+            )
+        }}
+    {%- endif -%}
+
+{%- endmacro%}

--- a/transform/mattermost-analytics/models/staging/mm_mobile_prod/_mm_mobile_prod__models.yml
+++ b/transform/mattermost-analytics/models/staging/mm_mobile_prod/_mm_mobile_prod__models.yml
@@ -18,5 +18,7 @@ models:
         description: The type of the event.
       - name: user_id
         description: The ID of the user that sent the event.
+      - name: server_id
+        description: The ID of the server the event originated from.
       - name: received_at
         description: Timestamp registered by RudderStack when the event was ingested (received).

--- a/transform/mattermost-analytics/models/staging/mm_mobile_prod/_mm_mobile_prod__models.yml
+++ b/transform/mattermost-analytics/models/staging/mm_mobile_prod/_mm_mobile_prod__models.yml
@@ -9,9 +9,9 @@ models:
       - name: event_id
         description: The event's id.
       - name: event_name
-        description: The name of the event table.
-      - name: event_table
         description: The name of the event.
+      - name: event_table
+        description: The name of the event table.
       - name: category
         description: The event's category.
       - name: type

--- a/transform/mattermost-analytics/models/staging/mm_mobile_prod/_mm_mobile_prod__models.yml
+++ b/transform/mattermost-analytics/models/staging/mm_mobile_prod/_mm_mobile_prod__models.yml
@@ -1,0 +1,22 @@
+version: 2
+
+models:
+  - name: stg_mm_mobile_prod__tracks
+    description: |
+      Reconstructed `tracks` table using custom properties expected to be in the events.
+
+    columns:
+      - name: event_id
+        description: The event's id.
+      - name: event_name
+        description: The name of the event table.
+      - name: event_table
+        description: The name of the event.
+      - name: category
+        description: The event's category.
+      - name: type
+        description: The type of the event.
+      - name: user_id
+        description: The ID of the user that sent the event.
+      - name: received_at
+        description: Timestamp registered by RudderStack when the event was ingested (received).

--- a/transform/mattermost-analytics/models/staging/mm_mobile_prod/_mm_mobile_prod__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mm_mobile_prod/_mm_mobile_prod__sources.yml
@@ -1,0 +1,83 @@
+version: 2
+
+sources:
+  - name: mm_mobile_prod
+    database: 'RAW'
+    schema: mm_mobile_prod
+    loader: Rudderstack
+    description: |
+      Mobile app telemetry pushed using Rudderstack. This schema is for production releases. 
+      
+      [Source code](https://github.com/mattermost/mattermost-mobile/blob/main/app/managers/analytics.ts)
+    tags: ['rudderstack']
+
+    tables:
+      - name: action_channels_add_member
+      - name: action_channels_favorite
+      - name: action_channels_join
+      - name: action_channels_leave
+      - name: action_channels_remove_member
+      - name: action_channels_unfavorite
+      - name: action_posts_flag
+      - name: action_posts_unflag
+      - name: api_channel_get
+      - name: api_channel_get_by_name_and_team_name
+      - name: api_channels_add_member
+      - name: api_channels_convert_to_private
+      - name: api_channels_create
+      - name: api_channels_create_direct
+      - name: api_channels_create_group
+      - name: api_channels_delete
+      - name: api_channels_patch
+      - name: api_channels_remove_member
+      - name: api_channels_unarchive
+      - name: api_channels_update_privacy
+      - name: api_files_upload
+      - name: api_get_known_users
+      - name: api_integrations_used
+      - name: api_interactive_messages_button_clicked
+      - name: api_interactive_messages_dialog_submitted
+      - name: api_interactive_messages_menu_selected
+      - name: api_post_set_unread_post
+      - name: api_posts_create
+      - name: api_posts_delete
+      - name: api_posts_get_after
+      - name: api_posts_get_before
+      - name: api_posts_get_flagged
+      - name: api_posts_get_pinned
+      - name: api_posts_patch
+      - name: api_posts_pin
+      - name: api_posts_replied
+      - name: api_posts_search
+      - name: api_posts_search_mention
+      - name: api_posts_unpin
+      - name: api_profiles_get
+      - name: api_profiles_get_by_ids
+      - name: api_profiles_get_by_usernames
+      - name: api_profiles_get_in_channel
+      - name: api_profiles_get_in_team
+      - name: api_profiles_get_not_in_channel
+      - name: api_reactions_delete
+      - name: api_reactions_save
+      - name: api_search_users
+      - name: api_teams_get_team_by_name
+      - name: api_teams_invite_members
+      - name: api_teams_remove_members
+      - name: api_users_login
+      - name: api_users_logout
+      - name: api_users_send_password_reset
+      - name: api_users_set_default_profile_picture
+      - name: api_users_update_channel_notifications
+      - name: application_backgrounded
+      - name: application_installed
+      - name: application_opened
+      - name: application_updated
+      - name: complete_suggestion
+      - name: get_suggestions_failed
+      - name: get_suggestions_initiated
+      - name: get_suggestions_success
+      - name: identifies
+      - name: rudder_discards
+      - name: screens
+      - name: tracks
+      - name: users

--- a/transform/mattermost-analytics/models/staging/mm_mobile_prod/_mm_mobile_prod_docs.md
+++ b/transform/mattermost-analytics/models/staging/mm_mobile_prod/_mm_mobile_prod_docs.md
@@ -1,0 +1,3 @@
+# Mattermost Mobile Telemetry
+
+Contains events from mobile apps.

--- a/transform/mattermost-analytics/models/staging/mm_mobile_prod/base/base_mm_mobile_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_mobile_prod/base/base_mm_mobile_prod__tracks.sql
@@ -1,0 +1,8 @@
+{{
+    config({
+        "tags":"hourly",
+        "snowflake_warehouse": "transform_l"
+    })
+}}
+
+{{ join_tracks_event_tables('mm_mobile_prod', columns=var('base_event_columns')) }}

--- a/transform/mattermost-analytics/models/staging/mm_mobile_prod/stg_mm_mobile_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_mobile_prod/stg_mm_mobile_prod__tracks.sql
@@ -14,6 +14,7 @@ SELECT
      id               AS event_id
      , event          AS event_table
      , event_text     AS event_name
+     , category       AS category
      , type           AS type
      , user_id        AS server_id
      , user_actual_id AS user_id

--- a/transform/mattermost-analytics/models/staging/mm_mobile_prod/stg_mm_mobile_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_mobile_prod/stg_mm_mobile_prod__tracks.sql
@@ -1,0 +1,21 @@
+{{
+    config({
+        "tags":"hourly",
+    })
+}}
+
+WITH tracks AS (
+    SELECT
+        {{ dbt_utils.star(ref('base_mm_mobile_prod__tracks')) }}
+    FROM
+        {{ ref ('base_mm_mobile_prod__tracks') }}
+)
+SELECT
+     id               AS event_id
+     , event          AS event_table
+     , event_text     AS event_name
+     , type           AS type
+     , user_id        AS server_id
+     , user_actual_id AS user_id
+     , received_at    AS received_at
+FROM tracks


### PR DESCRIPTION
#### Summary

Contains staging model for mobile event. Structure follows [staging best practices by DBT](https://docs.getdbt.com/guides/best-practices/how-we-structure/2-staging).

The following models are added:
- [base_mm_mobile_prod__tracks.sql](https://github.com/mattermost/mattermost-data-warehouse/compare/MM-50377-event-hierarchy-mobile?expand=1#diff-03ace77837d45a18fa9d2f707b7a87113d6f6691d00e6a3ea60fedfe43df98b5) - merges tables together, keeping columns.
-  [stg_mm_mobile_prod__tracks.sql](https://github.com/mattermost/mattermost-data-warehouse/compare/MM-50377-event-hierarchy-mobile?expand=1#diff-1c528ed377cb38df8e2d33c281d0170cb828ffa214df457959981f8e07064da2) - performs renaming in the columns and it's the model to be used by intermediate or mart models.
