### PR TITLE
MM-50377: add focalboard events

### DIFF
--- a/transform/mattermost-analytics/models/staging/hacktoberboard_prod/_hacktoberboard_prod__docs.md
+++ b/transform/mattermost-analytics/models/staging/hacktoberboard_prod/_hacktoberboard_prod__docs.md
@@ -1,0 +1,3 @@
+# hacktoberboard_prod
+
+Contains events from Focalboard.

--- a/transform/mattermost-analytics/models/staging/hacktoberboard_prod/_hacktoberboard_prod__models.yml
+++ b/transform/mattermost-analytics/models/staging/hacktoberboard_prod/_hacktoberboard_prod__models.yml
@@ -14,7 +14,7 @@ models:
         description: The name of the event table.
       - name: category
         description: The event's category.
-      - name: type
+      - name: event_type
         description: The type of the event.
       - name: user_id
         description: The ID of the user that sent the event.

--- a/transform/mattermost-analytics/models/staging/hacktoberboard_prod/_hacktoberboard_prod__models.yml
+++ b/transform/mattermost-analytics/models/staging/hacktoberboard_prod/_hacktoberboard_prod__models.yml
@@ -1,0 +1,24 @@
+version: 2
+
+models:
+  - name: stg_hacktoberboard_prod__tracks
+    description: |
+      Reconstructed `tracks` table using custom properties expected to be in the events.
+
+    columns:
+      - name: event_id
+        description: The event's id.
+      - name: event_name
+        description: The name of the event.
+      - name: event_table
+        description: The name of the event table.
+      - name: category
+        description: The event's category.
+      - name: type
+        description: The type of the event.
+      - name: user_id
+        description: The ID of the user that sent the event.
+      - name: server_id
+        description: The ID of the server the event originated from.
+      - name: received_at
+        description: Timestamp registered by RudderStack when the event was ingested (received).

--- a/transform/mattermost-analytics/models/staging/hacktoberboard_prod/_hacktoberboard_prod__sources.yml
+++ b/transform/mattermost-analytics/models/staging/hacktoberboard_prod/_hacktoberboard_prod__sources.yml
@@ -1,0 +1,29 @@
+version: 2
+
+sources:
+  - name: hacktoberboard_prod
+    database: 'RAW'
+    schema: hacktoberboard_prod
+    loader: Rudderstack
+    description: |
+      Focalboard telemetry data, pushed via Rudderstack.
+
+      [Source code](https://github.com/mattermost/focalboard/blob/main/server/services/telemetry/telemetry.go)
+    tags:
+      - rudderstack
+
+    # Omitting event tables that seem to originate from non-Mattermost sources (i.e. pen tests)
+    tables:
+      - name: activity
+      - name: blocks
+      - name: boards
+      - name: config
+      - name: event
+      - name: identifies
+      - name: pages
+      - name: rudder_discards
+      - name: server
+      - name: teams
+      - name: tracks
+      - name: users
+      - name: workspaces

--- a/transform/mattermost-analytics/models/staging/hacktoberboard_prod/base/base_hacktoberboard_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/hacktoberboard_prod/base/base_hacktoberboard_prod__tracks.sql
@@ -1,0 +1,8 @@
+{{
+    config({
+        "tags":"hourly",
+    })
+}}
+
+
+{{ join_tracks_event_tables('hacktoberboard_prod', columns=var('base_event_columns')) }}

--- a/transform/mattermost-analytics/models/staging/hacktoberboard_prod/stg_hacktoberboard_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/hacktoberboard_prod/stg_hacktoberboard_prod__tracks.sql
@@ -1,0 +1,24 @@
+{{
+    config({
+        "tags":"hourly",
+    })
+}}
+
+WITH tracks AS (
+    SELECT
+        {{ dbt_utils.star(ref('base_hacktoberboard_prod__tracks')) }}
+    FROM
+        {{ ref('base_hacktoberboard_prod__tracks') }}
+)
+SELECT
+        id AS event_id
+        , event AS event_table
+        , event_text AS event_name
+        , category AS category
+        -- Prefer type, but backfill with event if it's not present
+        , COALESCE(type, event_text) AS event_type
+        , user_id AS server_id
+        , user_actual_id AS user_id
+        , received_at AS received_at
+FROM
+    tracks


### PR DESCRIPTION
#### Summary

Add staging views for focalboard events. These tables should be used for event registry.

