### PR TITLE
Hotfix: remove old users

### DIFF
--- a/load/snowflake/roles.yaml
+++ b/load/snowflake/roles.yaml
@@ -196,30 +196,6 @@ roles:
 
 # Users
 users:
-    - adovenmuehle:
-        can_login: yes
-        member_of:
-            - accountadmin
-            - securityadmin
-
-    - rachel:
-        can_login: yes
-        member_of:
-            - accountadmin
-            - securityadmin
-
-    - eric:
-        can_login: yes
-        member_of:
-            - accountadmin
-            - securityadmin
-
-    - schiff:
-        can_login: yes
-        member_of:
-            - accountadmin
-            - securityadmin
-
     - airflow:
         can_login: yes
         member_of:


### PR DESCRIPTION
#### Summary

A few old users were removed yesterday. These users must not be in the permission bot's settings.