### PR TITLE
Hotfix: use proper key for id

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_hacktoberboard_prod_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_hacktoberboard_prod_aggregated_to_date.sql
@@ -3,7 +3,7 @@
         "materialized": "incremental",
         "tags":"hourly",
         "incremental_strategy": "merge",
-        "unique_key": ['id'],
+        "unique_key": ['daily_event_id'],
         "merge_update_columns": ['event_count'],
         "cluster_by": ['date_received_at'],
     })

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_incident_response_prod_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_incident_response_prod_aggregated_to_date.sql
@@ -3,7 +3,7 @@
         "materialized": "incremental",
         "tags":"hourly",
         "incremental_strategy": "merge",
-        "unique_key": ['id'],
+        "unique_key": ['daily_event_id'],
         "merge_update_columns": ['event_count'],
         "cluster_by": ['date_received_at'],
     })

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mattermost_docs_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mattermost_docs_aggregated_to_date.sql
@@ -3,7 +3,7 @@
         "materialized": "incremental",
         "tags":"hourly",
         "incremental_strategy": "merge",
-        "unique_key": ['id'],
+        "unique_key": ['daily_event_id'],
         "merge_update_columns": ['event_count'],
         "cluster_by": ['date_received_at'],
     })

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mattermostcom_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mattermostcom_aggregated_to_date.sql
@@ -3,7 +3,7 @@
         "materialized": "incremental",
         "tags":"hourly",
         "incremental_strategy": "merge",
-        "unique_key": ['id'],
+        "unique_key": ['daily_event_id'],
         "merge_update_columns": ['event_count'],
         "cluster_by": ['date_received_at'],
     })

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mm_mobile_prod_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mm_mobile_prod_aggregated_to_date.sql
@@ -3,7 +3,7 @@
         "materialized": "incremental",
         "tags":"hourly",
         "incremental_strategy": "merge",
-        "unique_key": ['id'],
+        "unique_key": ['daily_event_id'],
         "merge_update_columns": ['event_count'],
         "cluster_by": ['date_received_at'],
         "snowflake_warehouse": "transform_l"

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mm_plugin_prod_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mm_plugin_prod_aggregated_to_date.sql
@@ -3,7 +3,7 @@
         "materialized": "incremental",
         "tags":"hourly",
         "incremental_strategy": "merge",
-        "unique_key": ['id'],
+        "unique_key": ['daily_event_id'],
         "merge_update_columns": ['event_count'],
         "cluster_by": ['date_received_at'],
     })

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mm_telemetry_prod_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mm_telemetry_prod_aggregated_to_date.sql
@@ -3,7 +3,7 @@
         "materialized": "incremental",
         "tags":"hourly",
         "incremental_strategy": "merge",
-        "unique_key": ['id'],
+        "unique_key": ['daily_event_id'],
         "merge_update_columns": ['event_count'],
         "cluster_by": ['date_received_at'],
         "snowflake_warehouse": "transform_l"

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mm_telemetry_rc_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mm_telemetry_rc_aggregated_to_date.sql
@@ -3,7 +3,7 @@
         "materialized": "incremental",
         "tags":"hourly",
         "incremental_strategy": "merge",
-        "unique_key": ['id'],
+        "unique_key": ['daily_event_id'],
         "merge_update_columns": ['event_count'],
         "cluster_by": ['date_received_at'],
         "snowflake_warehouse": "transform_l"

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_portal_prod_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_portal_prod_aggregated_to_date.sql
@@ -3,7 +3,7 @@
         "materialized": "incremental",
         "tags":"hourly",
         "incremental_strategy": "merge",
-        "unique_key": ['id'],
+        "unique_key": ['daily_event_id'],
         "merge_update_columns": ['event_count'],
         "cluster_by": ['date_received_at'],
     })


### PR DESCRIPTION
#### Summary

The key used for identifying how to merge new columns is incorrectly mentioned as `id`, where it's `daily_event_id`. This hotfix solves this issue for now. 

In order to avoid having the same issue in the future, it would be nice to run the changed models and related tests on a separate schema. I will create a separate ticket for this.