### PR TITLE
MM-50552: CLI for moving tables between databases & schemas

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -22,6 +22,7 @@ Options:
 
 Commands:
   list  List Rudderstack event tables for given database and schema.
+  move  Move tables to target database/schema.
 ```
 
 Help is available at any command/sub-command, simply by adding `-h`/`--help` at the end of the command.
@@ -32,14 +33,58 @@ Let's go over the subcommands.
 
 Simply run `rudder list ...` providing the proper arguments.
 
-Example:
+The following example will list all event tables in database `RAW`, schema `mattermost_docs`:
+
 ```bash
 $ rudder list RAW mattermost_docs -a cca12345.us-east-1 -u joe@doe.com -r role_name -w warehouse_small
 Password: 
 DOC_EVENT
+NEW_TABLE
+...
 ```
 
-Options can also be set using environment variables. Here's the possible configuration variables:
+The following example will list all event tables in database `RAW`, schema `mattermost_docs` that have been
+created in the past two days:
+
+```bash
+$ rudder list RAW mattermost_docs -a cca12345.us-east-1 -u joe@doe.com -r role_name -w warehouse_small --max-age 2
+Password: 
+NEW_TABLE
+...
+```
+
+### Move tables
+
+Move all tables listed in input file/stdin from source database/schema to target/database schema.
+
+Simply run `rudder move ...` providing the proper arguments.
+
+The following example will move all tables listed in `tables.txt` from `DEV.STAGING` to `ARCHIVE.OLD_STAGING`
+
+```bash
+$ rudder move DEV STAGING ARCHIVE OLD_STAGING tables.txt -a cca12345.us-east-1 -u joe@doe.com -r role_name -w warehouse_small 
+Password: 
+Moving DEV.STAGING.table_to_archive ✓
+...
+```
+
+If you want to use stdin rather than a file, you can specify `-` as input. Press  `[CTRL] + D` any time to stop.
+
+Example:
+
+```bash
+$ rudder move DEV STAGING ARCHIVE OLD_STAGING - -a cca12345.us-east-1 -u joe@doe.com -r role_name -w warehouse_small 
+Password: 
+
+table_to_archive
+Moving DEV.STAGING.table_to_archive ✓
+...
+```
+
+
+### Configuring using environment variables
+
+Options for all subcommands can also be set using environment variables. Here's the possible configuration variables:
 
 | Environment Variable  | Example value       | Required | Description                               |
 |-----------------------|---------------------|----------|-------------------------------------------|
@@ -49,7 +94,7 @@ Options can also be set using environment variables. Here's the possible configu
 | `SNOWFLAKE_WAREHOUSE` | `cca12345.us-east1` | No       | The snowflake warehouse to use            |
 | `SNOWFLAKE_ROLE`      | `cca12345.us-east1` | No       | The snowflake role to use                 |
 
- 
+
 ## Contributors
 
 Retrieves a list of contributors by iterating over all repos in the organization and checking merged PRs. The results

--- a/tests/utils/test_post_docs_data.py
+++ b/tests/utils/test_post_docs_data.py
@@ -1,5 +1,4 @@
 import pytest
-
 import responses as test_responses  # importing as test_responses, due to conflict with import in conftest.py
 import snowflake.connector
 

--- a/utils/db/helpers.py
+++ b/utils/db/helpers.py
@@ -1,9 +1,9 @@
 from collections import namedtuple
-from typing import List, TextIO
+from typing import List
 
 from snowflake.sqlalchemy import URL
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection, Engine
 
 TableStats = namedtuple('TableStats', ['schema', 'name', 'rows', 'created_at'])
 
@@ -73,3 +73,30 @@ def upload_csv_as_table(engine: Engine, file: str, schema: str, table: str) -> N
         conn.execute(f"CREATE TEMPORARY STAGE IF NOT EXISTS {schema}.{table}")
         conn.execute(f"PUT file://{file} @{schema}.{table} OVERWRITE=TRUE")
         conn.execute(f"COPY INTO {schema}.{table} FROM @{schema}.{table} FILE_FORMAT = (TYPE = CSV SKIP_HEADER = 1)")
+
+
+def move_table(
+    conn: Connection,
+    table: str,
+    source_database: str,
+    source_schema: str,
+    target_database: str,
+    target_schema: str,
+    postfix: str = None,
+) -> None:
+    """
+    Moves table from source database/schema to target database/schema.
+
+    :param conn: the SQLAlchemy connection to use for moving the table information.
+    :param table: the table to move.
+    :param source_database: the database where the table is currently located at.
+    :param source_schema: the schema where the table is currently located at.
+    :param target_database: the database to move the table to.
+    :param target_schema: the schema to move the table to.
+    :param postfix: (optional) postfix to append to the table at the target database.
+    """
+    query = f'''
+        ALTER TABLE {source_database}.{source_schema}.{table}
+        RENAME TO {target_database}.{target_schema}.{table}{postfix if postfix else ''}
+    '''
+    conn.execute(query)

--- a/utils/rudderstack/__main__.py
+++ b/utils/rudderstack/__main__.py
@@ -1,10 +1,12 @@
 from datetime import timedelta
 
 import click
-from click import UsageError
+from click import ClickException, UsageError
+from snowflake.connector import ProgrammingError
+from sqlalchemy.exc import SQLAlchemyError
 
 from utils.db.helpers import snowflake_engine
-from utils.rudderstack.service import list_event_tables
+from utils.rudderstack.service import list_event_tables, move_tables
 
 
 @click.group()
@@ -56,18 +58,6 @@ def list_tables(
 ) -> None:
     """
     List Rudderstack event tables for given database and schema.
-    \f
-
-    :param database: the database containing the schema.
-    :param schema: the schema containing the events.
-    :param account: the name of the snowflake account.
-    :param user: the name of the user for connecting to snowflake.
-    :param password: the password for connecting to snowflake.
-    :param warehouse: the warehouse to use when connecting to snowflake.
-    :param role: the role to use when connecting to snowflake.
-    :param min_rows: include tables with at least this number of rows (inclusive).
-    :param max_rows: include tables with no more rows than this number of rows (inclusive).
-    :param max_age: include tables that have been created up to this number of days ago.
     """
     engine = snowflake_engine(
         {
@@ -93,6 +83,80 @@ def list_tables(
             click.echo(table)
     except ValueError as e:
         raise UsageError(str(e))
+    finally:
+        engine.dispose()
+
+
+@rudder.command('move', short_help='Move tables to target database/schema.')
+@click.argument('source_database')
+@click.argument('source_schema')
+@click.argument('target_database')
+@click.argument('target_schema')
+@click.argument('input', type=click.File('r'))
+@click.option('-a', '--account', envvar='SNOWFLAKE_ACCOUNT', required=True, help='the name of the snowflake account')
+@click.option(
+    '-u', '--user', envvar='SNOWFLAKE_USER', required=True, help='the name of the user for connecting to snowflake'
+)
+@click.option(
+    '-p',
+    '--password',
+    envvar='SNOWFLAKE_PASSWORD',
+    required=True,
+    prompt=True,
+    hide_input=True,
+    help='the password for connecting to snowflake',
+)
+@click.option(
+    '-w', '--warehouse', envvar='SNOWFLAKE_WAREHOUSE', help='the warehouse to use when connecting to snowflake'
+)
+@click.option('-r', '--role', envvar='SNOWFLAKE_ROLE', help='the role to use when connecting to snowflake')
+@click.option('--postfix', type=str, help='append this postfix to all tables moved')
+def move(
+    source_database: str,
+    source_schema: str,
+    target_database: str,
+    target_schema: str,
+    input: click.File,
+    account: str,
+    user: str,
+    password: str,
+    warehouse: str,
+    role: str,
+    postfix: str = None,
+) -> None:
+    """
+    Move all tables in <INPUT> from source database/schema to target/database schema.
+
+    INPUT can be either a filename or - for stdin.
+
+    Example:
+    rudder move RAW EVENTS ARCHIVE OLD_EVENTS tables.txt # add connection options here
+    """
+    engine = snowflake_engine(
+        {
+            "SNOWFLAKE_ACCOUNT": account,
+            "SNOWFLAKE_USER": user,
+            "SNOWFLAKE_PASSWORD": password,
+            "SNOWFLAKE_DATABASE": source_database,
+            "SNOWFLAKE_SCHEMA": source_schema,
+            "SNOWFLAKE_WAREHOUSE": warehouse,
+            "SNOWFLAKE_ROLE": role,
+        }
+    )
+
+    def table_provider():
+        for table in input:
+            if table.strip():
+                click.echo(f"Moving {source_database}.{source_schema}.{table}", nl=False)
+                yield table
+                click.secho(" \N{check mark}", fg="green", bold=True)
+
+    try:
+        move_tables(engine, table_provider(), source_database, source_schema, target_database, target_schema, postfix)
+    except (ProgrammingError, SQLAlchemyError) as e:
+        raise ClickException(str(e))
+    finally:
+        engine.dispose()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

CLI utility for moving tables between databases/schemas.

- [x] CLI that calls `ALTER TABLE` for each table per line in a file (or stdin).
- [x] Add instructions in documentation.
- [x] Improve documentation in other `rudder` command.