### PR TITLE
Chore: fix images used in make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,6 +400,12 @@ data-image: ## to start a bash shell on the data image
 	$(AT)$(DOCKER) compose -f ${DOCKER_COMPOSE_DBT_FILE} run data_image bash || ${FAIL}
 	$(AT)$(OK) Exited data-image
 
+.PHONY: permifrost-image
+permifrost-image: ## to start a bash shell on the permifrost image
+	$(AT)$(INFO) Attaching to permifrost-image and mounting repo...
+	$(AT)$(DOCKER) compose -f ${DOCKER_COMPOSE_DBT_FILE} run permifrost bash || ${FAIL}
+	$(AT)$(OK) Exited permifrost-image
+
 .PHONY: clean
 clean: ## to clean-up
 	@$(INFO) cleaning...

--- a/build/docker-compose.dbt.yml
+++ b/build/docker-compose.dbt.yml
@@ -50,25 +50,24 @@ services:
           read_only: True
 
     data_image:
-      image: docker.io/adovenmm/data-image:v01.21.1
+      build:
+        dockerfile: build/Dockerfile
+        context: ../
       env_file:
         - ../.dbt.env
       restart: always
+      entrypoint: [ "" ]
       command: bash -c "/bin/bash"
-      working_dir: /usr/local/analytics/
-      volumes:
-        - type: bind
-          source: .
-          target: /usr/local/analytics
 
     permifrost:
-      image: docker.io/adovenmm/permifrost:latest
+      build:
+        dockerfile: build/permifrost.Dockerfile
+        context: ../
       env_file:
         - ../.dbt.env
       restart: always
-      command: /bin/bash -c "permifrost grant roles.yaml"
+      command: /bin/bash -c "/bin/bash"
       volumes:
         - type: bind
-          source: ./load/snowflake/roles.yaml
-          target: /roles.yaml
-          read_only: True
+          source: ../load
+          target: /app/load

--- a/poetry.lock
+++ b/poetry.lock
@@ -326,7 +326,7 @@ unicode-backport = ["unicodedata2"]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1573,6 +1573,8 @@ files = [
     {file = "psycopg2_binary-2.9.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:e67b3c26e9b6d37b370c83aa790bbc121775c57bfb096c2e77eacca25fd0233b"},
     {file = "psycopg2_binary-2.9.5-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:5fc447058d083b8c6ac076fc26b446d44f0145308465d745fba93a28c14c9e32"},
     {file = "psycopg2_binary-2.9.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d892bfa1d023c3781a3cab8dd5af76b626c483484d782e8bd047c180db590e4c"},
+    {file = "psycopg2_binary-2.9.5-cp311-cp311-win32.whl", hash = "sha256:2abccab84d057723d2ca8f99ff7b619285d40da6814d50366f61f0fc385c3903"},
+    {file = "psycopg2_binary-2.9.5-cp311-cp311-win_amd64.whl", hash = "sha256:bef7e3f9dc6f0c13afdd671008534be5744e0e682fb851584c8c3a025ec09720"},
     {file = "psycopg2_binary-2.9.5-cp36-cp36m-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:6e63814ec71db9bdb42905c925639f319c80e7909fb76c3b84edc79dadef8d60"},
     {file = "psycopg2_binary-2.9.5-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:212757ffcecb3e1a5338d4e6761bf9c04f750e7d027117e74aa3cd8a75bb6fbd"},
     {file = "psycopg2_binary-2.9.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f8a9bcab7b6db2e3dbf65b214dfc795b4c6b3bb3af922901b6a67f7cb47d5f8"},
@@ -2024,7 +2026,7 @@ version = "5.1"
 description = "YAML parser and emitter for Python"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = "*"
 files = [
     {file = "PyYAML-5.1-cp27-cp27m-win32.whl", hash = "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2"},
     {file = "PyYAML-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba"},
@@ -2431,7 +2433,7 @@ greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platfo
 
 [package.extras]
 aiomysql = ["aiomysql", "greenlet (!=0.4.17)"]
-aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing_extensions (!=3.10.0.1)"]
+aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing-extensions (!=3.10.0.1)"]
 asyncio = ["greenlet (!=0.4.17)"]
 asyncmy = ["asyncmy (>=0.2.3,!=0.2.4)", "greenlet (!=0.4.17)"]
 mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2)"]
@@ -2441,14 +2443,14 @@ mssql-pyodbc = ["pyodbc"]
 mypy = ["mypy (>=0.910)", "sqlalchemy2-stubs"]
 mysql = ["mysqlclient (>=1.4.0)", "mysqlclient (>=1.4.0,<2)"]
 mysql-connector = ["mysql-connector-python"]
-oracle = ["cx_oracle (>=7)", "cx_oracle (>=7,<8)"]
+oracle = ["cx-oracle (>=7)", "cx-oracle (>=7,<8)"]
 postgresql = ["psycopg2 (>=2.7)"]
 postgresql-asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
 postgresql-pg8000 = ["pg8000 (>=1.16.6,!=1.29.0)"]
 postgresql-psycopg2binary = ["psycopg2-binary"]
 postgresql-psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql", "pymysql (<1)"]
-sqlcipher = ["sqlcipher3_binary"]
+sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "tabulate"
@@ -2817,4 +2819,4 @@ xmlsec = ["xmlsec (>=0.6.1)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c74b2607d55848f539c512a43f6921be798e8fbb4c4202fc1b7d070f76dbc069"
+content-hash = "0ed13054ab78a35f4ae44f142c543f8583d768e642caaf04bab5b67a10ff2934"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ sqlalchemy = "1.4.41"
 pytest = "^7.1.3"
 markupsafe = "2.0.1"
 ghapi = "^1.0.3"
+click = "^8.1.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"


### PR DESCRIPTION
#### Summary

Use internal images for data image and permifrost. This allows starting the images locally without a need to setup a dev environment.

- [x] Updated `docker-compose.yml` to use new images.
- [x] Added missing dependency.
- [x] Mounting permission configuration on permifrost image so that changes will be reflected in the image during development.