### PR TITLE
Hotfix: move tracks columns to macro

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -55,10 +55,3 @@ models:
       +materialized: table
       schema: utilities
       tags: [ 'utilities' ]
-
-
-# Configuration variables
-
-vars:
-  # Common event columns to keep (if they are part of the table)
-  base_event_columns: ['ID', 'RECEIVED_AT', 'EVENT', 'EVENT_TEXT', 'CATEGORY', 'TYPE', 'USER_ID', 'USER_ACTUAL_ID' ]

--- a/transform/mattermost-analytics/macros/rudderstack/_rudderstack_schema.yml
+++ b/transform/mattermost-analytics/macros/rudderstack/_rudderstack_schema.yml
@@ -53,3 +53,8 @@ macros:
       - name: source_name
         type: string
         description: An optional name for the source table. If not defined, the name of the relation will be used.
+
+  - name: get_base_event_columns
+    description: |
+      Returns the list of columns to use from rudderstack tables. This list contains columns that are expected to be
+      in [every event table](https://www.rudderstack.com/docs/destinations/warehouse-destinations/warehouse-schema/#standard-rudderstack-properties

--- a/transform/mattermost-analytics/macros/rudderstack/get_base_event_columns.sql
+++ b/transform/mattermost-analytics/macros/rudderstack/get_base_event_columns.sql
@@ -1,0 +1,3 @@
+{% macro get_base_event_columns() -%}
+    {{ return(['ID', 'RECEIVED_AT', 'EVENT', 'EVENT_TEXT', 'CATEGORY', 'TYPE', 'USER_ID', 'USER_ACTUAL_ID', 'TIMESTAMP']) }}
+{%- endmacro%}

--- a/transform/mattermost-analytics/macros/rudderstack/join_tracks_event_tables.sql
+++ b/transform/mattermost-analytics/macros/rudderstack/join_tracks_event_tables.sql
@@ -4,7 +4,7 @@
     -%}
     {%- set all_relations = dbt_utils.get_relations_by_pattern(schema, '%', database='RAW') | list -%}
     {%- set relations = all_relations | rejectattr('identifier', 'in', rudderstack_tables) | list -%}
-    {%- set include = var('base_event_columns') -%}
+    {%- set include = get_base_event_columns() -%}
 
     {%- if columns -%}
         {# If user defined columns to keep, filter them #}

--- a/transform/mattermost-analytics/models/staging/hacktoberboard_prod/base/base_hacktoberboard_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/hacktoberboard_prod/base/base_hacktoberboard_prod__tracks.sql
@@ -1,2 +1,2 @@
 
-{{ join_tracks_event_tables('hacktoberboard_prod', columns=var('base_event_columns')) }}
+{{ join_tracks_event_tables('hacktoberboard_prod', columns=get_base_event_columns()) }}

--- a/transform/mattermost-analytics/models/staging/incident_response_prod/base/base_incident_response_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/incident_response_prod/base/base_incident_response_prod__tracks.sql
@@ -1,2 +1,2 @@
 
-{{ join_tracks_event_tables('incident_response_prod', columns=var('base_event_columns')) }}
+{{ join_tracks_event_tables('incident_response_prod', columns=get_base_event_columns()) }}

--- a/transform/mattermost-analytics/models/staging/mattermost_docs/base/base_mattermost_docs__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mattermost_docs/base/base_mattermost_docs__tracks.sql
@@ -1,2 +1,2 @@
 
-{{ join_tracks_event_tables('mattermost_docs', columns=var('base_event_columns')) }}
+{{ join_tracks_event_tables('mattermost_docs', columns=get_base_event_columns()) }}

--- a/transform/mattermost-analytics/models/staging/mattermostcom/base/base_mattermostcom__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mattermostcom/base/base_mattermostcom__tracks.sql
@@ -1,2 +1,2 @@
 
-{{ join_tracks_event_tables('mattermostcom', columns=var('base_event_columns')) }}
+{{ join_tracks_event_tables('mattermostcom', columns=get_base_event_columns()) }}

--- a/transform/mattermost-analytics/models/staging/mm_mobile_prod/base/base_mm_mobile_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_mobile_prod/base/base_mm_mobile_prod__tracks.sql
@@ -4,4 +4,4 @@
     })
 }}
 
-{{ join_tracks_event_tables('mm_mobile_prod', columns=var('base_event_columns')) }}
+{{ join_tracks_event_tables('mm_mobile_prod', columns=get_base_event_columns()) }}

--- a/transform/mattermost-analytics/models/staging/mm_plugin_prod/base/base_mm_plugin_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_plugin_prod/base/base_mm_plugin_prod__tracks.sql
@@ -4,4 +4,4 @@
     })
 }}
 
-{{ join_tracks_event_tables('mm_plugin_prod', columns=var('base_event_columns')) }}
+{{ join_tracks_event_tables('mm_plugin_prod', columns=get_base_event_columns()) }}

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_mm_telemetry_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_mm_telemetry_prod__tracks.sql
@@ -4,7 +4,7 @@
 {{
     dbt_utils.union_relations(
         relations=relations,
-        include=var('base_event_columns'),
+        include=get_base_event_columns(),
         source_column_name=None
     )
 }}

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_rc/base/base_mm_telemetry_rc__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_rc/base/base_mm_telemetry_rc__tracks.sql
@@ -4,7 +4,7 @@
 {{
     dbt_utils.union_relations(
         relations=relations,
-        include=var('base_event_columns'),
+        include=get_base_event_columns(),
         source_column_name=None
     )
 }}

--- a/transform/mattermost-analytics/models/staging/portal_prod/base/base_portal_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/portal_prod/base/base_portal_prod__tracks.sql
@@ -1,2 +1,2 @@
 
-{{ join_tracks_event_tables('portal_prod', columns=var('base_event_columns')) }}
+{{ join_tracks_event_tables('portal_prod', columns=get_base_event_columns()) }}


### PR DESCRIPTION
#### Summary

Models using a `var` will not be marked as `modified` if a change happens in the var. This is a [limitation of DBT](https://docs.getdbt.com/reference/node-selection/state-comparison-caveats#vars). This PR is a workaround for this limitation.

Required to fix https://github.com/mattermost/mattermost-data-warehouse/pull/1192