### PR TITLE
MM-51001: setup permissions for archive database

### DIFF
--- a/load/snowflake/roles.yaml
+++ b/load/snowflake/roles.yaml
@@ -5,6 +5,9 @@ databases:
     - analytics:
         shared: no
 
+    - archive:
+        shared: no
+
     - raw:
         shared: no
 
@@ -42,28 +45,34 @@ roles:
                 read:
                     - raw
                     - analytics
+                    - archive
                     - dev
                 write:
                     - raw
                     - analytics
+                    - archive
                     - dev
             schemas:
                 read:
                     - raw.*
                     - analytics.*
+                    - archive.*
                     - dev.*
                 write:
                     - raw.*
                     - analytics.*
+                    - archive.*
                     - dev.*
             tables:
                 read:
                     - raw.*.*
                     - analytics.*.*
+                    - archive.*.*
                     - dev.*.*
                 write:
                     - raw.*.*
                     - analytics.*.*
+                    - archive.*.*
                     - dev.*.*
 
     ## Regular Roles
@@ -141,18 +150,24 @@ roles:
             databases:
                 read:
                     - raw
+                    - archive
                 write:
                     - raw
+                    - archive
             schemas:
                 read:
                     - raw.*
+                    - archive.*
                 write:
                     - raw.*
+                    - archive.*
             tables:
                 read:
                     - raw.*.*
+                    - archive.*.*
                 write:
                     - raw.*.*
+                    - archive.*.*
 
     - transformer:  # For automated jobs
         warehouses:
@@ -164,6 +179,7 @@ roles:
                 read:
                     - raw
                     - analytics
+                    - archive
                     - snowflake
                     - dev
                 write:
@@ -174,19 +190,23 @@ roles:
                 read:
                     - raw.*
                     - analytics.*
+                    - archive.*
                     - snowflake.account_usage
                     - dev.*
                 write:
                     - analytics.*
+                    - archive.*
                     - dev.*
             tables:
                 read:
                     - raw.*.*
                     - analytics.*.*
+                    - archive.*.*
                     - snowflake.account_usage.*
                     - dev.*.*
                 write:
                     - analytics.*.*
+                    - archive.*.*
                     - dev.*.*
 
     # Object Roles


### PR DESCRIPTION
#### Summary

Setup permissions for `ARCHIVE` database.
- Admin users read/write access
- Transformer users read/write access
- Loader users read/write access

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51001
