### PR TITLE
MM-51001: fix permissions for transformer

### DIFF
--- a/load/snowflake/roles.yaml
+++ b/load/snowflake/roles.yaml
@@ -185,6 +185,7 @@ roles:
                 write:
                     - raw
                     - analytics
+                    - archive
                     - dev
             schemas:
                 read:


### PR DESCRIPTION
#### Summary

Previous changes result in error `Database archive referenced in schema write privileges but not in database privileges for role transformer`. This PR fixes this. Validated by running using `--dry` locally.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51001