### PR TITLE
Mm 51081 add project evaluator to mattermost analytics

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -55,3 +55,19 @@ models:
       +materialized: table
       schema: utilities
       tags: [ 'utilities' ]
+    dbt_project_evaluator:
+      +schema: dbt_project_evaluator
+
+tests:
+  dbt_project_evaluator:
+    # Set DBT project
+    +severity: "{{ env_var('DBT_PROJECT_EVALUATOR_SEVERITY', 'warn') }}"
+    other_prefixes: eg_
+
+# Configuration variables
+vars:
+  dbt_project_evaluator:
+    # Set test and doc coverage to 75% (default is 100%)
+    documentation_coverage_target: 75
+    test_coverage_target: 75
+

--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -55,13 +55,17 @@ models:
       +materialized: table
       schema: utilities
       tags: [ 'utilities' ]
-    dbt_project_evaluator:
-      +schema: dbt_project_evaluator
 
+seeds:
+  dbt_project_evaluator:
+    dbt_project_evaluator_exceptions:
+      +enabled: false
+      
 tests:
   dbt_project_evaluator:
     # Set DBT project
     +severity: "{{ env_var('DBT_PROJECT_EVALUATOR_SEVERITY', 'warn') }}"
+    staging_prefixes: stg_,base_
     other_prefixes: eg_
 
 # Configuration variables

--- a/transform/mattermost-analytics/packages.yml
+++ b/transform/mattermost-analytics/packages.yml
@@ -3,3 +3,5 @@ packages:
     version: 1.0.0
   - package: dbt-labs/codegen
     version: 0.9.0
+  - package: dbt-labs/dbt_project_evaluator
+    version: 0.4.1

--- a/transform/mattermost-analytics/seeds/dbt_project_evaluator_exceptions.csv
+++ b/transform/mattermost-analytics/seeds/dbt_project_evaluator_exceptions.csv
@@ -1,0 +1,3 @@
+fct_name,column_name,id_to_exclude,comment
+fct_root_models,child,base_%__tracks,Models called base_%__tracks union multiple sources
+fct_staging_dependent_on_staging,child,stg_%__tracks,Models called stg_%__tracks align the name of unioned sources


### PR DESCRIPTION
#### Summary

Adds DBT project evaluator in a warn-only mode.

- [x] Add dbt project evaluator package
- [x] Add basic configuration (75% test and documentation coverage, known prefixes, making warn/error configurable via env var)
- [x] Add seed file for configuring known exceptions to the rules


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51081
