### PR TITLE
Chore: move project evaluator models to their own separate schema

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -56,6 +56,10 @@ models:
       schema: utilities
       tags: [ 'utilities' ]
 
+  dbt_project_evaluator:
+    schema:
+      mart_dbt_project_evaluator
+
 seeds:
   dbt_project_evaluator:
     dbt_project_evaluator_exceptions:


### PR DESCRIPTION
#### Summary

DBT Project evaluator models were added to default schema. This configuration change moves them to a separate schema.


