### PR TITLE
MM-51005: report new tables in alerting

### DIFF
--- a/dags/_helpers.py
+++ b/dags/_helpers.py
@@ -1,0 +1,26 @@
+from itertools import zip_longest
+
+
+def chunk(seq, n, pad=False, fillvalue=None):
+    """
+    Split sequence into chunks of length n.
+
+    >>> list(partition(['a', 'b', 'c', 'd']))
+
+    [('a', 'b'), ('c', 'd')]
+
+    If the length of ``seq`` is not evenly divisible by ``n``, the final tuple
+    is dropped if ``pad`` is false, or filled to length ``n`` by ``fillvalue``:
+
+    >>> list(partition(['a', 'b', 'c', 'd', 'e']))
+    [('a', 'b'), ('c', 'd')]
+
+    >>> list(partition(2, [1, 2, 3, 4, 5], pad=True, fillvalue=None))
+    [(1, 2), (3, 4), (5, None)]
+
+    """
+    args = [iter(seq)] * n
+    if pad:
+        return zip_longest(*args, fillvalue=fillvalue)
+    else:
+        return zip(*args)

--- a/dags/general/monitoring.py
+++ b/dags/general/monitoring.py
@@ -3,24 +3,13 @@ from datetime import datetime
 
 from airflow import DAG
 from airflow.models import Variable
-from airflow.models.xcom import XCom
 from airflow.operators.http_operator import SimpleHttpOperator
 from airflow.operators.python_operator import PythonOperator
-from airflow.utils.db import provide_session
 
-from dags.airflow_utils import send_alert
+from dags.airflow_utils import cleanup_xcom, send_alert
 from dags.general._helpers import resolve_hightouch, resolve_stitch
 
 task_logger = logging.getLogger('airflow.task')
-
-
-# To clean up Xcom after dag finished run.
-@provide_session
-def cleanup_xcom(**context):
-    dag = context["dag"]
-    dag_id = dag._dag_id
-    session = context["session"]
-    session.query(XCom).filter(XCom.dag_id == dag_id).delete()
 
 
 default_args = {'on_failure_callback': send_alert}

--- a/dags/monitoring/events.py
+++ b/dags/monitoring/events.py
@@ -3,9 +3,12 @@ from datetime import datetime, timedelta
 from airflow import DAG
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from airflow.models import Variable
+from airflow.operators.python_operator import PythonOperator
 from airflow.utils.trigger_rule import TriggerRule
+from tabulate import tabulate
 
-from dags.airflow_utils import MATTERMOST_DATAWAREHOUSE_IMAGE, pod_defaults, send_alert
+from dags._helpers import chunk
+from dags.airflow_utils import MATTERMOST_DATAWAREHOUSE_IMAGE, cleanup_xcom, pod_defaults, send_alert
 from dags.kube_secrets import (
     SNOWFLAKE_ACCOUNT,
     SNOWFLAKE_LOAD_DATABASE,
@@ -53,6 +56,16 @@ dag = DAG(
 )
 
 
+def table_formatter(task_id, size=10):
+    def format_tables(**kwargs):
+        """Format result as table"""
+        ti = kwargs['ti']
+        result = ti.xcom_pull(task_ids=task_id)
+        return tabulate(chunk(result, size, pad=True), headers='firstrow', tablefmt='github')
+
+    return format_tables
+
+
 def get_pod_operators(dag):
     result = []
     schemas = Variable.get("rudder_schemas", deserialize_json=True)
@@ -75,22 +88,49 @@ def get_pod_operators(dag):
                 "rudder list ${SNOWFLAKE_LOAD_DATABASE} "
                 + schema
                 + " -w ${SNOWFLAKE_LOAD_WAREHOUSE} -r ${SNOWFLAKE_LOAD_ROLE} --max-age {{ var.value.rudder_max_age }}"
+                + " --format-json > /airflow/xcom/return.json"
             ],
+            do_xcom_push=True,
             dag=dag,
         )
-        failure_op = MattermostOperator(
+
+        apply_format = PythonOperator(
+            task_id=f'apply-format-{schema}',
+            provide_context=True,  # provide context is for getting the TI (task instance ) parameters
+            dag=dag,
+            python_callable=table_formatter(f"check-new-tables-{schema}"),
+            trigger_rule=TriggerRule.ALL_FAILED,
+        )
+
+        alert_op = MattermostOperator(
             mattermost_conn_id='mattermost',
-            text=f'New event tables detected in schema {schema}',
+            attachments=[
+                {
+                    'title': ':warning: New tables created in the past {{ var.value.rudder_max_age }} days',
+                    'color': '#ffcc00',
+                    'text': f'{{ ti.xcom_pull(task_ids="apply-format-{schema}") }}',
+                },
+            ],
+            icon_emoji=':warning:',
             username='Airflow',
             task_id=f"check-new-tables-{schema}-handle-failure",
             dag=dag,
-            trigger_rule=TriggerRule.ALL_FAILED,
         )
-        op >> failure_op
+
+        op >> apply_format >> alert_op
+
         result.append(op)
 
     return result
 
 
+clean_xcom = PythonOperator(
+    task_id="clean_xcom",
+    python_callable=cleanup_xcom,
+    provide_context=True,
+    dag=dag,
+)
+
 pod_operators = get_pod_operators(dag)
-pod_operators
+
+pod_operators >> clean_xcom

--- a/dags/tests/monitoring/test_events.py
+++ b/dags/tests/monitoring/test_events.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytest
 from airflow import DAG
 
 
@@ -20,11 +21,34 @@ def test_should_create_pod_operators():
     assert result[0].task_id == 'check-new-tables-schema1'
     assert result[0].arguments == [
         'rudder list ${SNOWFLAKE_LOAD_DATABASE} schema1 -w ${SNOWFLAKE_LOAD_WAREHOUSE} '
-        '-r ${SNOWFLAKE_LOAD_ROLE} --max-age {{ var.value.rudder_max_age }}'
+        '-r ${SNOWFLAKE_LOAD_ROLE} --max-age {{ var.value.rudder_max_age }} '
+        '--format-json > /airflow/xcom/return.json'
     ]
 
     assert result[1].task_id == 'check-new-tables-schema2'
     assert result[1].arguments == [
         'rudder list ${SNOWFLAKE_LOAD_DATABASE} schema2 -w ${SNOWFLAKE_LOAD_WAREHOUSE} '
-        '-r ${SNOWFLAKE_LOAD_ROLE} --max-age {{ var.value.rudder_max_age }}'
+        '-r ${SNOWFLAKE_LOAD_ROLE} --max-age {{ var.value.rudder_max_age }} '
+        '--format-json > /airflow/xcom/return.json'
     ]
+
+
+@pytest.mark.parametrize(
+    "input,size,output",
+    [
+        [['a', 'b', 'c', 'd', 'e'], 2, '| a   | b   |\n|-----|-----|\n| c   | d   |\n| e   |     |'],
+        [['a', 'b', 'c', 'd', 'e'], 3, '| a   | b   | c   |\n|-----|-----|-----|\n| d   | e   |     |'],
+    ],
+)
+def test_table_formatter(mocker, input, size, output):
+    from dags.monitoring.events import table_formatter
+
+    # GIVEN: a list of items in xcom
+    mock_ti = mocker.MagicMock()
+    mock_ti.xcom_pull.return_value = input
+
+    # WHEN: request to format items
+    result = table_formatter('task-id', size=size)(ti=mock_ti)
+
+    # THEN: expect to be in proper table
+    assert result == output

--- a/dags/tests/test_helpers.py
+++ b/dags/tests/test_helpers.py
@@ -1,0 +1,17 @@
+import pytest
+
+from dags._helpers import chunk
+
+
+@pytest.mark.parametrize(
+    "input,size,pad,output",
+    [
+        [['a', 'b', 'c', 'd'], 2, False, [('a', 'b'), ('c', 'd')]],
+        [['a', 'b', 'c', 'd', 'e'], 2, False, [('a', 'b'), ('c', 'd')]],
+        [['a', 'b', 'c', 'd', 'e'], 2, True, [('a', 'b'), ('c', 'd'), ('e', None)]],
+        [[], 2, False, []],
+        [[], 2, True, []],
+    ],
+)
+def test_chunks(input, size, pad, output):
+    assert list(chunk(input, size, pad=pad)) == output

--- a/plugins/operators/mattermost_operator.py
+++ b/plugins/operators/mattermost_operator.py
@@ -33,8 +33,11 @@ class MattermostOperator(SimpleHttpOperator):
         text="",
         channel=None,
         username=None,
+        icon_url=None,
+        icon_emoji=None,
         type=None,
         props=None,
+        attachments=None,
         **kwargs,
     ) -> None:
         super().__init__(endpoint=None, **kwargs)
@@ -42,8 +45,11 @@ class MattermostOperator(SimpleHttpOperator):
         self.text = text
         self.channel = channel
         self.username = username
+        self.icon_url = icon_url
+        self.icon_emoji = icon_emoji
         self.type = type
         self.props = props
+        self.attachments = attachments
 
     def hook(self):
         return MattermostWebhookHook(
@@ -51,8 +57,11 @@ class MattermostOperator(SimpleHttpOperator):
             text=self.text,
             channel=self.channel,
             username=self.username,
+            icon_url=self.icon_url,
+            icon_emoji=self.icon_emoji,
             type=self.type,
             props=self.props,
+            attachments=self.attachments,
         )
 
     def execute(self, context):

--- a/tests/utils/rudderstack/test_cli.py
+++ b/tests/utils/rudderstack/test_cli.py
@@ -41,3 +41,39 @@ def test_should_print_tables(mocker):
     assert result.stdout == 'new-table-1\nnew-table-2\n'
     # THEN: expect error to be printed in stderr
     assert result.stderr == 'Error: New tables found...\n'
+
+
+def test_should_print_tables_as_json(mocker):
+    mock_sf_engine = mocker.patch("utils.rudderstack.__main__.snowflake_engine")
+    mock_sf_engine.return_value = mocker.Mock()
+    mock_list_event_table = mocker.patch("utils.rudderstack.__main__.list_event_tables")
+    runner = CliRunner(mix_stderr=False)
+    # GIVEN: list event tables returns two new tables
+    mock_list_event_table.return_value = ['new-table-1', 'new-table-2']
+
+    # WHEN: request to list tables
+    result = runner.invoke(
+        list_tables,
+        [
+            "db",
+            "schema",
+            "-a",
+            "account",
+            "-u",
+            "user",
+            "-p",
+            "password",
+            "-w",
+            "warehouse",
+            "-r",
+            "role",
+            "--format-json",
+        ],
+    )
+
+    # THEN: expect exit code to be 1
+    assert result.exit_code == 1
+    # THEN: expect tables to be printed in stdout
+    assert result.stdout == '["new-table-1", "new-table-2"]\n'
+    # THEN: expect error to be printed in stderr
+    assert result.stderr == 'Error: New tables found...\n'

--- a/utils/rudderstack/__main__.py
+++ b/utils/rudderstack/__main__.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 
 import click
@@ -44,6 +45,7 @@ def rudder() -> None:
 @click.option(
     '--max-age', type=click.IntRange(0), help='include tables that have been created up to this number of days ago'
 )
+@click.option('--format-json', is_flag=True, help='use JSON as output format')
 def list_tables(
     database: str,
     schema: str,
@@ -55,6 +57,7 @@ def list_tables(
     min_rows: int,
     max_rows: int,
     max_age: int,
+    format_json: bool,
 ) -> None:
     """
     List Rudderstack event tables for given database and schema.
@@ -79,8 +82,11 @@ def list_tables(
             max_rows=max_rows,
             max_age=timedelta(days=max_age) if max_age else None,
         )
-        for table in result:
-            click.echo(table)
+        if format_json:
+            click.echo(json.dumps(result))
+        else:
+            for table in result:
+                click.echo(table)
         # Make sure that exit code is > 0 if tables are found
         if result:
             raise click.ClickException("New tables found...")


### PR DESCRIPTION
#### Summary

Adds richer information to alerting for new rudderstack telemetry.

- [x] Write list of tables as JSON output. Required so that output of scripts can be propagated to [XCOM](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/xcoms.html).
- [x] Update mattermost operator to support [attachments](https://developers.mattermost.com/integrate/reference/message-attachments/) and icon overrides. 
- [x] Update DAG to propagate check results to mattermost operator via a formatting python operator.
- [x] Move clean  xcom library to `airflow_utils` 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51005

