### PR TITLE
Hotfix: XCOM return object instead of array

### DIFF
--- a/dags/monitoring/events.py
+++ b/dags/monitoring/events.py
@@ -60,7 +60,7 @@ def table_formatter(task_id, size=10):
     def format_tables(**kwargs):
         """Format result as table"""
         ti = kwargs['ti']
-        result = ti.xcom_pull(task_ids=task_id)
+        result = ti.xcom_pull(task_ids=task_id)['new_tables']
         return tabulate(chunk(result, size, pad=True), headers='firstrow', tablefmt='github')
 
     return format_tables

--- a/dags/tests/monitoring/test_events.py
+++ b/dags/tests/monitoring/test_events.py
@@ -45,7 +45,7 @@ def test_table_formatter(mocker, input, size, output):
 
     # GIVEN: a list of items in xcom
     mock_ti = mocker.MagicMock()
-    mock_ti.xcom_pull.return_value = input
+    mock_ti.xcom_pull.return_value = {'new_tables': input}
 
     # WHEN: request to format items
     result = table_formatter('task-id', size=size)(ti=mock_ti)

--- a/tests/utils/rudderstack/test_cli.py
+++ b/tests/utils/rudderstack/test_cli.py
@@ -74,6 +74,6 @@ def test_should_print_tables_as_json(mocker):
     # THEN: expect exit code to be 1
     assert result.exit_code == 1
     # THEN: expect tables to be printed in stdout
-    assert result.stdout == '["new-table-1", "new-table-2"]\n'
+    assert result.stdout == '{"new_tables": ["new-table-1", "new-table-2"]}\n'
     # THEN: expect error to be printed in stderr
     assert result.stderr == 'Error: New tables found...\n'

--- a/utils/rudderstack/__main__.py
+++ b/utils/rudderstack/__main__.py
@@ -88,7 +88,7 @@ def list_tables(
             max_age=timedelta(days=max_age) if max_age else None,
         )
         if format_json:
-            click.echo(json.dumps(result))
+            click.echo(json.dumps({"new_tables": result}))
         else:
             for table in result:
                 click.echo(table)


### PR DESCRIPTION
#### Summary

JSON in file `/airflow/xcom/return.json` needs to be an object to map to key/value

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51005
