### PR TITLE
MM-51337: add k3s cluster to run with airflow

### DIFF
--- a/build/airflow-kubeconfig.py
+++ b/build/airflow-kubeconfig.py
@@ -1,0 +1,10 @@
+"""
+Adjusts k3s kubernetes configuration so that k3s cluster is accessible from airflow.
+"""
+
+import yaml
+
+with open('kubeconfig.yaml', 'r') as fp, open('airflow-kube.yaml', 'w') as outfp:
+    data = yaml.safe_load(fp)
+    data['clusters'][0]['cluster']['server'] = 'https://k3s-server:6443'
+    yaml.dump(data, outfp)

--- a/build/docker-compose.airflow.yml
+++ b/build/docker-compose.airflow.yml
@@ -28,11 +28,14 @@ services:
       - AIRFLOW_DATABASE_PASSWORD=bitnami1
       - AIRFLOW_EXECUTOR=CeleryExecutor
       - AIRFLOW_LOAD_EXAMPLES=no
-      - NAMESPACE=airflow
+      - AIRFLOW_FERNET_KEY=JWk2WQr0hIeVmpOoG7OyWvVwz1IS4XtzbRoV8u0qaNw=
+      - NAMESPACE=default
+      - ENVIRONMENT=docker-compose
     volumes:
       - airflow_scheduler_data:/bitnami
       - ../dags:/opt/bitnami/airflow/dags/dags
       - ../plugins:/opt/bitnami/airflow/dags/plugins
+      - .:/opt/kube
 
   airflow-worker:
     depends_on:
@@ -45,11 +48,14 @@ services:
       - AIRFLOW_DATABASE_PASSWORD=bitnami1
       - AIRFLOW_EXECUTOR=CeleryExecutor
       - AIRFLOW_LOAD_EXAMPLES=no
-      - NAMESPACE=airflow
+      - AIRFLOW_FERNET_KEY=JWk2WQr0hIeVmpOoG7OyWvVwz1IS4XtzbRoV8u0qaNw=
+      - NAMESPACE=default
+      - ENVIRONMENT=docker-compose
     volumes:
       - airflow_worker_data:/bitnami
       - ../dags:/opt/bitnami/airflow/dags/dags
       - ../plugins:/opt/bitnami/airflow/dags/plugins
+      - .:/opt/kube
 
   airflow:
     depends_on:
@@ -62,13 +68,56 @@ services:
       - AIRFLOW_DATABASE_PASSWORD=bitnami1
       - AIRFLOW_EXECUTOR=CeleryExecutor
       - AIRFLOW_LOAD_EXAMPLES=no
-      - NAMESPACE=airflow
+      - AIRFLOW_FERNET_KEY=JWk2WQr0hIeVmpOoG7OyWvVwz1IS4XtzbRoV8u0qaNw=
+      - NAMESPACE=default
+      - ENVIRONMENT=docker-compose
     ports:
       - '8080:8080'
     volumes:
       - airflow_data:/bitnami
       - ../dags:/opt/bitnami/airflow/dags/dags
       - ../plugins:/opt/bitnami/airflow/dags/plugins
+      - .:/opt/kube
+
+
+  # Local kubernetes cluster
+  k3s-server:
+    image: "rancher/k3s:${K3S_VERSION:-latest}"
+    command:
+    - server
+    tmpfs:
+    - /run
+    - /var/run
+    privileged: true
+    environment:
+    - K3S_TOKEN=secret
+    - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+    - K3S_KUBECONFIG_MODE=666
+    volumes:
+    - .:/output
+    ports:
+    - 6443:6443
+
+  k3s-agent:
+    image: "rancher/k3s:${K3S_VERSION:-latest}"
+    command:
+    - agent
+    tmpfs:
+    - /run
+    - /var/run
+    privileged: true
+    environment:
+    - K3S_URL=https://k3s-server:6443
+    - K3S_TOKEN=secret
+
+  k3s-airflow-config:
+    image: python:3.8.15-slim@sha256:fc2f284772a4443ce7238930ba9a8d5e3c720926616fca074b99213484a3820f
+    depends_on:
+      - k3s-agent
+      - k3s-server
+    command: bash -c "pip install pyyaml && cd /output && python airflow-kubeconfig.py"
+    volumes:
+      - .:/output
 
 volumes:
   airflow_scheduler_data:

--- a/dags/airflow_utils.py
+++ b/dags/airflow_utils.py
@@ -15,6 +15,7 @@ MATTERMOST_DATAWAREHOUSE_IMAGE = "mattermost/mattermost-data-warehouse:master"
 
 mm_webhook_url = os.getenv("MATTERMOST_WEBHOOK_URL")
 DEFAULT_AIRFLOW_NAMESPACE = "airflow-dev"  # to prevent tests from failing
+IS_DEV_MODE = os.getenv("ENVIRONMENT") == 'docker-compose'
 
 # Set the resources for the task pods
 pod_resources = Resources(request_memory="500Mi", request_cpu="500m")
@@ -28,6 +29,11 @@ pod_defaults = {
     "namespace": os.environ.get('NAMESPACE', DEFAULT_AIRFLOW_NAMESPACE),
     "cmds": ["/bin/bash", "-c"],
 }
+
+if IS_DEV_MODE:
+    # Override defaults for dev mode
+    pod_defaults["in_cluster"] = False
+    pod_defaults["config_file"] = "/opt/kube/airflow-kube.yaml"
 
 # Default environment variables for worker pods
 env = os.environ.copy()

--- a/docs/Airflow.md
+++ b/docs/Airflow.md
@@ -4,9 +4,6 @@ A small development environment for airflow. Follow the instructions to start a 
 the local airflow starts, any changes inside `dags` or `plugins` directory will be automatically reflected (no need to
 restart!).
 
-> Note that this version starts a local environment using `CeleryExecutor`. It should be enough for developing and testing 
-> custom operators. Unfortunately any DAG that is using `KubernetesPodOperator` won't run successfully. This shall be
-> improved in the future.
 
 ## Local airflow environment
 
@@ -19,7 +16,27 @@ restart!).
 At the root of the project run 
 
 ```bash
-docker compose -f build/docker-compose-airflow.yml up
+docker compose -f build/docker-compose.airflow.yml up
 ```
 
-After a while you can access airflow at [http://localhost:8080](http://localhost:8080), with username/password `user`/`bitnami`.
+After a while you can access airflow at [http://localhost:8080](http://localhost:8080), with 
+username/password `user`/`bitnami`.
+
+### Configuring secrets
+
+Create a secret with name `airflow`:
+
+```shell
+kubectx --kubeconfig=./build/kubeconfig.yaml create secret generic airflow
+```
+
+> Secret only needs to be created once.
+
+To add values to the secret run:
+
+```shell
+kubectl --kubeconfig=./build/kubeconfig.yaml edit secret airflow   
+```
+
+Specify the values you'd like to add. More details on how to manage secrets is 
+[available here](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/).


### PR DESCRIPTION
#### Summary

Setup local dev environment to send `KubernetesPodOperator` tasks to local k8s cluster.

- [x] Start local [k3s](https://k3s.io/) using same docker compose file as docker compose. 
- [x] Auto-generate kubernetes config for airflow.
- [x] Adjust `airflow_utils` so that local k8s cluster will be used.
- [x] Update docs.

Tested using different DAGs. 

> The only manual step required for running k8s tasks is setting up secrets. Documentation provides instructions on how to do that.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51337
