### PR TITLE
MM-51105: tidy notification operator

### DIFF
--- a/dags/tests/monitoring/test_events.py
+++ b/dags/tests/monitoring/test_events.py
@@ -34,13 +34,13 @@ def test_should_create_pod_operators():
 
 
 @pytest.mark.parametrize(
-    "input,size,output",
+    "input,output",
     [
-        [['a', 'b', 'c', 'd', 'e'], 2, '| a   | b   |\n|-----|-----|\n| c   | d   |\n| e   |     |'],
-        [['a', 'b', 'c', 'd', 'e'], 3, '| a   | b   | c   |\n|-----|-----|-----|\n| d   | e   |     |'],
+        [[], ''],
+        [['a', 'b', 'c', 'd', 'e'], ' - a\n - b\n - c\n - d\n - e'],
     ],
 )
-def test_table_formatter(mocker, input, size, output):
+def test_table_formatter(mocker, input, output):
     from dags.monitoring.events import table_formatter
 
     # GIVEN: a list of items in xcom
@@ -48,7 +48,7 @@ def test_table_formatter(mocker, input, size, output):
     mock_ti.xcom_pull.return_value = {'new_tables': input}
 
     # WHEN: request to format items
-    result = table_formatter('task-id', size=size)(ti=mock_ti)
+    result = table_formatter('task-id')(ti=mock_ti)
 
     # THEN: expect to be in proper table
     assert result == output

--- a/plugins/hooks/mattermost_webhook_hook.py
+++ b/plugins/hooks/mattermost_webhook_hook.py
@@ -66,6 +66,9 @@ class MattermostWebhookHook(HttpHook):
             'username': self.username,
             'type': self.type,
             'props': self.props,
+            'icon_url': self.icon_url,
+            'icon_emoji': self.icon_emoji,
+            'attachments': self.attachments,
         }
         return json.dumps({k: v for k, v in msg.items() if v is not None})
 

--- a/plugins/operators/mattermost_operator.py
+++ b/plugins/operators/mattermost_operator.py
@@ -18,19 +18,13 @@ class MattermostOperator(SimpleHttpOperator):
     :param props: Sets the post props, a JSON property bag for storing extra or meta data on the post.
     """
 
-    template_fields = (
-        'text',
-        'channel',
-        'username',
-        'type',
-        'props',
-    )
+    template_fields = ('text', 'channel', 'username', 'type', 'props', 'attachments')
 
     def __init__(
         self,
         *,
         mattermost_conn_id,
-        text="",
+        text=None,
         channel=None,
         username=None,
         icon_url=None,

--- a/plugins/tests/operators/test_mattermost_operator.py
+++ b/plugins/tests/operators/test_mattermost_operator.py
@@ -32,6 +32,7 @@ def test_template_fields(dag, full_config):
         'username',
         'type',
         'props',
+        'attachments'
     )
 
     assert template_fields == operator.template_fields

--- a/plugins/tests/operators/test_mattermost_operator.py
+++ b/plugins/tests/operators/test_mattermost_operator.py
@@ -26,14 +26,7 @@ def test_create_min_config(dag, min_config):
 def test_template_fields(dag, full_config):
     operator = MattermostOperator(task_id="mattermost_task", dag=dag, **full_config)
 
-    template_fields = (
-        'text',
-        'channel',
-        'username',
-        'type',
-        'props',
-        'attachments'
-    )
+    template_fields = ('text', 'channel', 'username', 'type', 'props', 'attachments')
 
     assert template_fields == operator.template_fields
 


### PR DESCRIPTION
#### Summary

Fixes/improvements related to the DAG reporting new event tables.

- [x] Properly define `attachments` as a template field in `MattermostOperator`. This allows for proper variable replacement.
- [x] Make default `text` value equal to `null` in `MattermostOperator`. This field can be null if `attachments` is defined.
- [x] Convert message to list (from table). The formatting was getting messed if the number of tables is small.
- [x] Cleanup xcom in the beginning. This is a limitation of current version of airflow used internally. If a task is skipped, downstream tasks are skipped, even if a proper `trigger_rule` has been set. This was a [known issue](https://github.com/apache/airflow/issues/7858), fixed in recent versions of airflow. The main difference now is that the DAG will always start with the XCOM cleanup, leaving XCOM values available. This can actually be useful for debugging.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51005