### PR TITLE
MM-42451: Incorrect owner ids for accounts and contacts

### DIFF
--- a/transform/snowflake-dbt/dbt_project.yml
+++ b/transform/snowflake-dbt/dbt_project.yml
@@ -115,4 +115,4 @@ seeds:
       schema: staging
 
 vars:
-  salesforce_default_ownerid: '0053p0000064nt8AAA' #default value for salesforce ownerid
+  salesforce_default_ownerid: "'0053p0000064nt8AAA'" #default value for salesforce ownerid

--- a/transform/snowflake-dbt/dbt_project.yml
+++ b/transform/snowflake-dbt/dbt_project.yml
@@ -113,3 +113,6 @@ seeds:
       schema: staging
     nps_category_backfill:
       schema: staging
+
+vars:
+  salesforce_default_ownerid: '0053p0000064nt8AAA' #default value for salesforce ownerid

--- a/transform/snowflake-dbt/macros/hightouch.sql
+++ b/transform/snowflake-dbt/macros/hightouch.sql
@@ -1,4 +1,4 @@
-{% macro transform_ownerid(ownerid) %}
+{% macro get_ownerid_or_default(ownerid) %}
     CASE WHEN SUBSTR({{ ownerid }}, 0, 3) = '00G'
         THEN {{ var('salesforce_default_ownerid') }}
         ELSE COALESCE({{ ownerid }}, {{ var('salesforce_default_ownerid') }})

--- a/transform/snowflake-dbt/macros/hightouch.sql
+++ b/transform/snowflake-dbt/macros/hightouch.sql
@@ -1,0 +1,6 @@
+{% macro transform_ownerid(ownerid) %}
+    CASE WHEN SUBSTR({{ ownerid }}, 0, 3) = '00G'
+        THEN {{ var('salesforce_default_ownerid') }}
+        ELSE COALESCE({{ ownerid }}, {{ var('salesforce_default_ownerid') }})
+    END AS ownerid
+{% endmacro %}

--- a/transform/snowflake-dbt/macros/hightouch.sql
+++ b/transform/snowflake-dbt/macros/hightouch.sql
@@ -2,5 +2,5 @@
     CASE WHEN SUBSTR({{ ownerid }}, 0, 3) = '00G'
         THEN {{ var('salesforce_default_ownerid') }}
         ELSE COALESCE({{ ownerid }}, {{ var('salesforce_default_ownerid') }})
-    END AS ownerid
+    END
 {% endmacro %}

--- a/transform/snowflake-dbt/macros/schema.yml
+++ b/transform/snowflake-dbt/macros/schema.yml
@@ -21,7 +21,7 @@ macros:
         type: string
         description: The schema containing the `tracks` table.
 
-  - name: transform_ownerid
+  - name: get_ownerid_or_default
     description: A macro to transform ownerid to be used in salesforce.
     arguments:
       - name: ownerid

--- a/transform/snowflake-dbt/macros/schema.yml
+++ b/transform/snowflake-dbt/macros/schema.yml
@@ -20,3 +20,13 @@ macros:
       - name: schema
         type: string
         description: The schema containing the `tracks` table.
+
+  - name: transform_ownerid
+    description: A macro to trasnform ownerid to be used in salesforce.
+    arguments:
+      - name: ownerid
+        type: string
+        description: The ownerid that needs to be transformed.
+      - name: default_ownerid
+        type: string
+        description: default value to use if the ownerid starts with '00G'.

--- a/transform/snowflake-dbt/macros/schema.yml
+++ b/transform/snowflake-dbt/macros/schema.yml
@@ -22,11 +22,11 @@ macros:
         description: The schema containing the `tracks` table.
 
   - name: transform_ownerid
-    description: A macro to trasnform ownerid to be used in salesforce.
+    description: A macro to transform ownerid to be used in salesforce.
     arguments:
       - name: ownerid
         type: string
         description: The ownerid that needs to be transformed.
       - name: default_ownerid
         type: string
-        description: default value to use if the ownerid starts with '00G'.
+        description: default value to use if the ownerid starts with '00G'. Stored in dbt variables.

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
@@ -12,8 +12,10 @@ WITH existing_contacts AS (
         contact.dwh_external_id__c,
         CASE
             WHEN SUBSTR(
-                contact.ownerid
-            ) = '005' THEN NULL
+                contact.ownerid,
+                0,
+                3
+            ) = '00G' THEN NULL
             ELSE contact.ownerid
         END AS ownerid,
         ROW_NUMBER() over (
@@ -31,8 +33,10 @@ existing_leads AS (
         LEAD.dwh_external_id__c,
         CASE
             WHEN SUBSTR(
-                LEAD.ownerid
-            ) = '005' THEN NULL
+                LEAD.ownerid,
+                0,
+                3
+            ) = '00G' THEN NULL
             ELSE LEAD.ownerid
         END AS ownerid,
         ROW_NUMBER() over (

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
@@ -10,15 +10,7 @@ WITH existing_contacts AS (
         contact.sfid,
         contact.email,
         contact.dwh_external_id__c,
-        CASE
-            WHEN SUBSTR(
-                contact.ownerid,
-                0,
-                3
-            ) = '00G' THEN NULL
-            ELSE contact.ownerid
-        END AS ownerid,
-        ROW_NUMBER() over (
+        contact.ownerid ROW_NUMBER() over (
             PARTITION BY contact.email
             ORDER BY
                 createddate DESC
@@ -31,15 +23,7 @@ existing_leads AS (
         LEAD.sfid,
         LEAD.email,
         LEAD.dwh_external_id__c,
-        CASE
-            WHEN SUBSTR(
-                LEAD.ownerid,
-                0,
-                3
-            ) = '00G' THEN NULL
-            ELSE LEAD.ownerid
-        END AS ownerid,
-        ROW_NUMBER() over (
+        LEAD.ownerid ROW_NUMBER() over (
             PARTITION BY LEAD.email
             ORDER BY
                 createddate DESC
@@ -50,11 +34,9 @@ existing_leads AS (
 customers_with_cloud_paid_subs AS (
     SELECT
         customers_with_cloud_paid_subs.*,
-        COALESCE(
-            existing_leads.ownerid,
-            existing_contacts.ownerid,
-            '0053p0000064nt8AAA'
-        ) AS ownerid
+        {{ transform_ownerid(
+            'COALESCE(existing_leads.ownerid, existing_contacts.ownerid)'
+        ) }} AS ownerid
     FROM
         {{ ref('customers_with_cloud_paid_subs') }}
         LEFT JOIN {{ ref('account') }}

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
@@ -1,38 +1,78 @@
-{{config({
-    "schema": "hightouch",
+{{ config(
+    { "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
-  })
-}}
-with existing_contacts as (
-    select
+    "tags" :["hourly","blapi"] }
+) }}
+
+WITH existing_contacts AS (
+
+    SELECT
         contact.sfid,
         contact.email,
         contact.dwh_external_id__c,
-        contact.ownerid,
-        row_number() over (partition by contact.email order by createddate desc) as row_num
-    from {{ ref('contact') }}
-), existing_leads as (
-    select
-        lead.sfid,
-        lead.email,
-        lead.dwh_external_id__c,
-        lead.ownerid,
-        row_number() over (partition by lead.email order by createddate desc) as row_num
-    from {{ ref('lead') }}
-), customers_with_cloud_paid_subs as (
+        CASE
+            WHEN SUBSTR(
+                contact.ownerid
+            ) = '005' THEN NULL
+            ELSE contact.ownerid
+        END AS ownerid,
+        ROW_NUMBER() over (
+            PARTITION BY contact.email
+            ORDER BY
+                createddate DESC
+        ) AS row_num
+    FROM
+        {{ ref('contact') }}
+),
+existing_leads AS (
+    SELECT
+        LEAD.sfid,
+        LEAD.email,
+        LEAD.dwh_external_id__c,
+        CASE
+            WHEN SUBSTR(
+                LEAD.ownerid
+            ) = '005' THEN NULL
+            ELSE LEAD.ownerid
+        END AS ownerid,
+        ROW_NUMBER() over (
+            PARTITION BY LEAD.email
+            ORDER BY
+                createddate DESC
+        ) AS row_num
+    FROM
+        {{ ref('lead') }}
+),
+customers_with_cloud_paid_subs AS (
     SELECT
         customers_with_cloud_paid_subs.*,
-        COALESCE(existing_leads.ownerid, existing_contacts.ownerid, '0053p0000064nt8AAA') AS ownerid
-    FROM {{ ref('customers_with_cloud_paid_subs') }}
-    LEFT JOIN {{ ref('account') }}
+        COALESCE(
+            existing_leads.ownerid,
+            existing_contacts.ownerid,
+            '0053p0000064nt8AAA'
+        ) AS ownerid
+    FROM
+        {{ ref('customers_with_cloud_paid_subs') }}
+        LEFT JOIN {{ ref('account') }}
         ON customers_with_cloud_paid_subs.domain = account.cbit__clearbitdomain__c
-            OR customers_with_cloud_paid_subs.account_external_id = account.dwh_external_id__c
-    LEFT JOIN existing_contacts ON customers_with_cloud_paid_subs.email = existing_contacts.email and existing_contacts.row_num = 1
-    LEFT JOIN existing_leads ON customers_with_cloud_paid_subs.email = existing_leads.email and existing_leads.row_num = 1
-    WHERE account.id IS NULL AND existing_contacts.sfid IS NULL -- create account only when contact does not exist
-    AND customers_with_cloud_paid_subs.hightouch_sync_eligible
-    AND customers_with_cloud_paid_subs.status in ('canceled', 'active') 
-    AND customers_with_cloud_paid_subs.SKU = 'Cloud Professional'
+        OR customers_with_cloud_paid_subs.account_external_id = account.dwh_external_id__c
+        LEFT JOIN existing_contacts
+        ON customers_with_cloud_paid_subs.email = existing_contacts.email
+        AND existing_contacts.row_num = 1
+        LEFT JOIN existing_leads
+        ON customers_with_cloud_paid_subs.email = existing_leads.email
+        AND existing_leads.row_num = 1
+    WHERE
+        account.id IS NULL
+        AND existing_contacts.sfid IS NULL -- create account only when contact does not exist
+        AND customers_with_cloud_paid_subs.hightouch_sync_eligible
+        AND customers_with_cloud_paid_subs.status IN (
+            'canceled',
+            'active'
+        )
+        AND customers_with_cloud_paid_subs.sku = 'Cloud Professional'
 )
-SELECT * FROM customers_with_cloud_paid_subs
+SELECT
+    *
+FROM
+    customers_with_cloud_paid_subs

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
@@ -10,7 +10,8 @@ WITH existing_contacts AS (
         contact.sfid,
         contact.email,
         contact.dwh_external_id__c,
-        contact.ownerid ROW_NUMBER() over (
+        contact.ownerid,
+        ROW_NUMBER() over (
             PARTITION BY contact.email
             ORDER BY
                 createddate DESC
@@ -23,7 +24,8 @@ existing_leads AS (
         LEAD.sfid,
         LEAD.email,
         LEAD.dwh_external_id__c,
-        LEAD.ownerid ROW_NUMBER() over (
+        LEAD.ownerid,
+        ROW_NUMBER() over (
             PARTITION BY LEAD.email
             ORDER BY
                 createddate DESC

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
@@ -34,7 +34,7 @@ existing_leads AS (
 customers_with_cloud_paid_subs AS (
     SELECT
         customers_with_cloud_paid_subs.*,
-        {{ transform_ownerid(
+        {{ get_ownerid_or_default(
             'COALESCE(existing_leads.ownerid, existing_contacts.ownerid)'
         ) }} AS ownerid
     FROM

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -27,7 +27,7 @@ freemium_contacts_to_sync AS (
             customers_with_cloud_paid_subs.last_name,
             customers_with_cloud_paid_subs.email
         ) AS contact_last_name,
-        existing_lead.id AS duplicate_lead_id,
+        existing_leads.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
         {{ get_ownerid_or_default('existing_leads.ownerid') }} AS ownerid,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -11,8 +11,10 @@ WITH existing_lead AS (
         LEAD.email,
         CASE
             WHEN SUBSTR(
-                LEAD.ownerid
-            ) = '005' THEN NULL
+                LEAD.ownerid,
+                0,
+                3
+            ) = '00G' THEN NULL
             ELSE LEAD.ownerid
         END AS ownerid
     FROM

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -1,37 +1,64 @@
-{{config({
-    "schema": "hightouch",
+{{ config(
+    { "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
-  })
-}}
+    "tags" :["hourly","blapi"] }
+) }}
 -- create contact
 WITH existing_lead AS (
+
     SELECT
-        lead.id,
-        lead.email,
-        lead.ownerid
-    FROM {{ ref('lead') }}
-    WHERE converteddate IS NULL
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY lead.email ORDER BY lead.createddate DESC) = 1
-), freemium_contacts_to_sync as (
+        LEAD.id,
+        LEAD.email,
+        CASE
+            WHEN SUBSTR(
+                LEAD.ownerid
+            ) = '005' THEN NULL
+            ELSE LEAD.ownerid
+        END AS ownerid
+    FROM
+        {{ ref('lead') }}
+    WHERE
+        converteddate IS NULL qualify ROW_NUMBER() over (
+            PARTITION BY LEAD.email
+            ORDER BY
+                LEAD.createddate DESC
+        ) = 1
+),
+freemium_contacts_to_sync AS (
     SELECT
         customers_with_cloud_paid_subs.email,
         customers_with_cloud_paid_subs.first_name,
-        COALESCE(customers_with_cloud_paid_subs.last_name, customers_with_cloud_paid_subs.email) AS contact_last_name,
+        COALESCE(
+            customers_with_cloud_paid_subs.last_name,
+            customers_with_cloud_paid_subs.email
+        ) AS contact_last_name,
         existing_lead.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
-        COALESCE(existing_lead.ownerid, '0053p0000064nt8AAA') AS ownerid,
+        COALESCE(
+            existing_lead.ownerid,
+            '0053p0000064nt8AAA'
+        ) AS ownerid,
         'Cloud Purchase' AS most_recent_action,
         'Cloud Professional' AS most_recent_action_detail,
         'Referral' AS lead_source,
         'Cloud Starter' AS lead_source_detail
-    FROM {{ ref('customers_with_cloud_paid_subs') }}
-    LEFT JOIN {{ ref('contact') }} ON customers_with_cloud_paid_subs.email = contact.email
-    LEFT JOIN existing_lead ON customers_with_cloud_paid_subs.email = existing_lead.email
-    WHERE contact.id IS NULL
-    AND customers_with_cloud_paid_subs.hightouch_sync_eligible
-    AND customers_with_cloud_paid_subs.status in ('canceled', 'active') 
-    AND customers_with_cloud_paid_subs.SKU = 'Cloud Professional'
+    FROM
+        {{ ref('customers_with_cloud_paid_subs') }}
+        LEFT JOIN {{ ref('contact') }}
+        ON customers_with_cloud_paid_subs.email = contact.email
+        LEFT JOIN existing_lead
+        ON customers_with_cloud_paid_subs.email = existing_lead.email
+    WHERE
+        contact.id IS NULL
+        AND customers_with_cloud_paid_subs.hightouch_sync_eligible
+        AND customers_with_cloud_paid_subs.status IN (
+            'canceled',
+            'active'
+        )
+        AND customers_with_cloud_paid_subs.sku = 'Cloud Professional'
 )
-SELECT * FROM freemium_contacts_to_sync
+SELECT
+    *
+FROM
+    freemium_contacts_to_sync

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -30,7 +30,7 @@ freemium_contacts_to_sync AS (
         existing_lead.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
-        {{ transform_ownerid('existing_leads.ownerid') }} AS ownerid,
+        {{ get_ownerid_or_default('existing_leads.ownerid') }} AS ownerid,
         'Cloud Purchase' AS most_recent_action,
         'Cloud Professional' AS most_recent_action_detail,
         'Referral' AS lead_source,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -4,7 +4,7 @@
     "tags" :["hourly","blapi"] }
 ) }}
 -- create contact
-WITH existing_lead AS (
+WITH existing_leads AS (
 
     SELECT
         LEAD.id,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -9,14 +9,7 @@ WITH existing_lead AS (
     SELECT
         LEAD.id,
         LEAD.email,
-        CASE
-            WHEN SUBSTR(
-                LEAD.ownerid,
-                0,
-                3
-            ) = '00G' THEN NULL
-            ELSE LEAD.ownerid
-        END AS ownerid
+        LEAD.ownerid
     FROM
         {{ ref('lead') }}
     WHERE
@@ -37,10 +30,7 @@ freemium_contacts_to_sync AS (
         existing_lead.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
-        COALESCE(
-            existing_lead.ownerid,
-            '0053p0000064nt8AAA'
-        ) AS ownerid,
+        {{ transform_ownerid('existing_leads.ownerid') }} AS ownerid,
         'Cloud Purchase' AS most_recent_action,
         'Cloud Professional' AS most_recent_action_detail,
         'Referral' AS lead_source,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -28,7 +28,7 @@ freemium_contacts_to_sync AS (
             customers_with_cloud_paid_subs.email
         ) AS contact_last_name,
         existing_leads.id AS duplicate_lead_id,
-        -- existing_lead.email AS duplicate_lead_email,
+        -- existing_leads.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
         {{ get_ownerid_or_default('existing_leads.ownerid') }} AS ownerid,
         'Cloud Purchase' AS most_recent_action,
@@ -39,8 +39,8 @@ freemium_contacts_to_sync AS (
         {{ ref('customers_with_cloud_paid_subs') }}
         LEFT JOIN {{ ref('contact') }}
         ON customers_with_cloud_paid_subs.email = contact.email
-        LEFT JOIN existing_lead
-        ON customers_with_cloud_paid_subs.email = existing_lead.email
+        LEFT JOIN existing_leads
+        ON customers_with_cloud_paid_subs.email = existing_leads.email
     WHERE
         contact.id IS NULL
         AND customers_with_cloud_paid_subs.hightouch_sync_eligible

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
@@ -1,14 +1,14 @@
-{{config({
-    "schema": "hightouch",
+{{ config(
+    { "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
-  })
-}}
+    "tags" :["hourly","blapi"] }
+) }}
 -- lead or contact already exists
 WITH existing_lead AS (
+
     SELECT
-        lead.id,
-        lead.email,
+        LEAD.id,
+        LEAD.email,
         CASE
             WHEN SUBSTR(
                 LEAD.ownerid,
@@ -17,28 +17,50 @@ WITH existing_lead AS (
             ) = '00G' THEN NULL
             ELSE LEAD.ownerid
         END AS ownerid
-    FROM {{ ref('lead') }}
-    WHERE converteddate IS NULL
-    QUALIFY ROW_NUMBER() OVER (PARTITION BY lead.email ORDER BY lead.createddate DESC) = 1
-), freemium_contacts_to_sync as (
+    FROM
+        {{ ref('lead') }}
+    WHERE
+        converteddate IS NULL qualify ROW_NUMBER() over (
+            PARTITION BY LEAD.email
+            ORDER BY
+                LEAD.createddate DESC
+        ) = 1
+),
+freemium_contacts_to_sync AS (
     SELECT
         customers_with_cloud_paid_subs.email,
         customers_with_cloud_paid_subs.first_name,
-        COALESCE(customers_with_cloud_paid_subs.last_name, customers_with_cloud_paid_subs.email) AS contact_last_name,
+        COALESCE(
+            customers_with_cloud_paid_subs.last_name,
+            customers_with_cloud_paid_subs.email
+        ) AS contact_last_name,
         existing_lead.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
-        COALESCE(existing_lead.ownerid, '0053p0000064nt8AAA') AS ownerid,
+        COALESCE(
+            existing_lead.ownerid,
+            '0053p0000064nt8AAA'
+        ) AS ownerid,
         'Cloud Purchase' AS most_recent_action,
         'Cloud Professional' AS most_recent_action_detail,
         'Referral' AS lead_source,
         'Cloud Starter' AS lead_source_detail
-    FROM {{ ref('customers_with_cloud_paid_subs') }}
-    LEFT JOIN {{ ref('contact') }} ON customers_with_cloud_paid_subs.email = contact.email
-    LEFT JOIN existing_lead ON customers_with_cloud_paid_subs.email = existing_lead.email
-    WHERE contact.id IS NOT NULL
-    AND customers_with_cloud_paid_subs.hightouch_sync_eligible
-    AND customers_with_cloud_paid_subs.status in ('canceled', 'active') 
-    AND customers_with_cloud_paid_subs.SKU = 'Cloud Professional'
+    FROM
+        {{ ref('customers_with_cloud_paid_subs') }}
+        LEFT JOIN {{ ref('contact') }}
+        ON customers_with_cloud_paid_subs.email = contact.email
+        LEFT JOIN existing_lead
+        ON customers_with_cloud_paid_subs.email = existing_lead.email
+    WHERE
+        contact.id IS NOT NULL
+        AND customers_with_cloud_paid_subs.hightouch_sync_eligible
+        AND customers_with_cloud_paid_subs.status IN (
+            'canceled',
+            'active'
+        )
+        AND customers_with_cloud_paid_subs.sku = 'Cloud Professional'
 )
-SELECT * FROM freemium_contacts_to_sync
+SELECT
+    *
+FROM
+    freemium_contacts_to_sync

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
@@ -27,7 +27,7 @@ freemium_contacts_to_sync AS (
             customers_with_cloud_paid_subs.last_name,
             customers_with_cloud_paid_subs.email
         ) AS contact_last_name,
-        existing_lead.id AS duplicate_lead_id,
+        existing_leads.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
         {{ get_ownerid_or_default('existing_leads.ownerid') }} AS ownerid,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
@@ -30,7 +30,7 @@ freemium_contacts_to_sync AS (
         existing_lead.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
-        {{ transform_ownerid('existing_leads.ownerid') }} AS ownerid,
+        {{ get_ownerid_or_default('existing_leads.ownerid') }} AS ownerid,
         'Cloud Purchase' AS most_recent_action,
         'Cloud Professional' AS most_recent_action_detail,
         'Referral' AS lead_source,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
@@ -9,7 +9,14 @@ WITH existing_lead AS (
     SELECT
         lead.id,
         lead.email,
-        lead.ownerid
+        CASE
+            WHEN SUBSTR(
+                LEAD.ownerid,
+                0,
+                3
+            ) = '00G' THEN NULL
+            ELSE LEAD.ownerid
+        END AS ownerid
     FROM {{ ref('lead') }}
     WHERE converteddate IS NULL
     QUALIFY ROW_NUMBER() OVER (PARTITION BY lead.email ORDER BY lead.createddate DESC) = 1

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
@@ -4,7 +4,7 @@
     "tags" :["hourly","blapi"] }
 ) }}
 -- lead or contact already exists
-WITH existing_lead AS (
+WITH existing_leads AS (
 
     SELECT
         LEAD.id,

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
@@ -9,14 +9,7 @@ WITH existing_lead AS (
     SELECT
         LEAD.id,
         LEAD.email,
-        CASE
-            WHEN SUBSTR(
-                LEAD.ownerid,
-                0,
-                3
-            ) = '00G' THEN NULL
-            ELSE LEAD.ownerid
-        END AS ownerid
+        LEAD.ownerid
     FROM
         {{ ref('lead') }}
     WHERE
@@ -37,10 +30,7 @@ freemium_contacts_to_sync AS (
         existing_lead.id AS duplicate_lead_id,
         -- existing_lead.email AS duplicate_lead_email,
         customers_with_cloud_paid_subs.account_external_id,
-        COALESCE(
-            existing_lead.ownerid,
-            '0053p0000064nt8AAA'
-        ) AS ownerid,
+        {{ transform_ownerid('existing_leads.ownerid') }} AS ownerid,
         'Cloud Purchase' AS most_recent_action,
         'Cloud Professional' AS most_recent_action_detail,
         'Referral' AS lead_source,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Issue -> Incorrect lookup field `ownerid` is causing hightouch syncs to fail since owner does not exist.
Fix -> Whenever we find an owner that starts with '00G', we should make the contact owner 0053p0000064nt8AAA, which is a fallback sales user. 

Tested updated model using queries - 
1. select old.ownerid, new.ownerid from ANALYTICS.HIGHTOUCH.FREEMIUM_CONTACT old left join ANALYTICS.HIGHTOUCH.FREEMIUM_CONTACT_NEW new on old.email = new.email;
2. select old.ownerid, new.ownerid from ANALYTICS.HIGHTOUCH.FREEMIUM_ACCOUNT old left join ANALYTICS.HIGHTOUCH.FREEMIUM_ACCOUNT_NEW new on old.email = new.email;

Backfill is not required since records with incorrect owner ids were not synced into salesforce.
- [x]  Fixed syntax errors causing cloud dbt job to fail. (CI on snowflake-dbt would have detected this)
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-42451
