### PR TITLE
MM-51730: run mattermost analytics nightly

### DIFF
--- a/dags/transformation/dbt_nightly.py
+++ b/dags/transformation/dbt_nightly.py
@@ -73,5 +73,25 @@ dbt_run_cloud_nightly = KubernetesPodOperator(
     dag=dag,
 )
 
+dbt_run_cloud_mattermost_analytics_nightly = KubernetesPodOperator(
+    **pod_defaults,
+    image=MATTERMOST_DATAWAREHOUSE_IMAGE,  # Uses latest build from master
+    task_id="dbt-cloud-mattermost-analytics-nightly",
+    name="dbt-cloud-mattermost-analytics-nightly",
+    secrets=[
+        DBT_CLOUD_API_ACCOUNT_ID,
+        DBT_CLOUD_API_KEY,
+        SNOWFLAKE_ACCOUNT,
+        SNOWFLAKE_USER,
+        SNOWFLAKE_PASSWORD,
+        SNOWFLAKE_TRANSFORM_ROLE,
+        SNOWFLAKE_TRANSFORM_WAREHOUSE,
+        SNOWFLAKE_TRANSFORM_SCHEMA,
+        SSH_KEY,
+    ],
+    env_vars=env_vars,
+    arguments=["python -m  utils.run_dbt_cloud_job 254981 \"Mattermost Analytics DBT nightly\""],
+    dag=dag,
+)
 
-dbt_run_cloud_nightly
+dbt_run_cloud_mattermost_analytics_nightly >> dbt_run_cloud_nightly

--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -38,25 +38,25 @@ models:
       +materialized: view
       # Ideally this would have been named staging. Unfortunately there's already a schema with that name.
       schema: dbt_staging
-      tags: ['staging', 'hourly']
+      tags: ['staging', 'nightly']
     intermediate:
       +materialized: ephemeral
       tags: ['intermediate']
       data_eng:
         schema: int_data_eng
-        tags: ['hourly']
+        tags: ['nightly']
       web_app:
         schema: int_web_app
-        tags: ['hourly']
+        tags: ['nightly']
     marts:
       +materialized: table
       tags: ['marts']
       data_eng:
         schema: mart_data_eng
-        tags: ['hourly']
+        tags: ['nightly']
       web_app:
         schema: mart_web_app
-        tags: ['hourly']
+        tags: ['nightly']
       release:
         schema: mart_release
         tags: ['nightly']

--- a/transform/mattermost-analytics/models/marts/web_app/platform/_platform__models.yml
+++ b/transform/mattermost-analytics/models/marts/web_app/platform/_platform__models.yml
@@ -11,10 +11,12 @@ models:
         tests:
           - accepted_values:
               values: ['int_mm_telemetry_rc_performance_events', 'int_mm_telemetry_prod_performance_events']
+              tags: [ 'slow' ]
       - name: id
         tests:
           - not_null
-          - unique
+          - unique:
+              tags: ['slow']
       - name: anonymous_id
       - name: received_at
       - name: sent_at


### PR DESCRIPTION
#### Summary

- [x] Adjust models to run nightly. 
- [x] Tag slow tests with a separate tag. This will allow decoupling slow test/nightly execution in the future.
- [x] Update nightly DAG to trigger nightly job.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51730