### PR TITLE
MM-51750: Missing enterprise trial records in salesforce

### DIFF
--- a/transform/snowflake-dbt/models/blapi/cloud_free_subscriptions.sql
+++ b/transform/snowflake-dbt/models/blapi/cloud_free_subscriptions.sql
@@ -15,6 +15,6 @@ with subscriptions AS (
     FROM {{ source('stripe', 'subscriptions')}} 
     JOIN {{ source('stripe', 'products') }} on products.id = coalesce(subscriptions.plan:"product"::varchar, subscriptions.metadata:"current_product_id"::varchar)
     WHERE subscriptions.cws_dns is not null
-    AND products.cws_sku_name in ('cloud-professional', 'cloud-starter')
+    AND products.cws_sku_name in ('cloud-enterprise', 'cloud-starter')
 )
 SELECT * FROM subscriptions

--- a/transform/snowflake-dbt/models/blapi/cloud_free_subscriptions.sql
+++ b/transform/snowflake-dbt/models/blapi/cloud_free_subscriptions.sql
@@ -9,11 +9,12 @@ with subscriptions AS (
     SELECT
         subscriptions.*,
         products.name,
+        products.cws_sku_name as product_sku,
         INITCAP(SPLIT_PART(replace(cws_dns, '-', ' '), '.', 1)) as company,
         ROW_NUMBER() OVER (PARTITION BY subscriptions.customer ORDER BY subscriptions.created DESC) as row_num
     FROM {{ source('stripe', 'subscriptions')}} 
     JOIN {{ source('stripe', 'products') }} on products.id = coalesce(subscriptions.plan:"product"::varchar, subscriptions.metadata:"current_product_id"::varchar)
     WHERE subscriptions.cws_dns is not null
-    AND products.name in ('Cloud Starter', 'Cloud Enterprise') 
+    AND products.cws_sku_name in ('cloud-professional', 'cloud-starter')
 )
 SELECT * FROM subscriptions

--- a/transform/snowflake-dbt/models/blapi/customers_with_cloud_free_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_cloud_free_subs.sql
@@ -20,7 +20,7 @@ with current_subscriptions AS(
 ), previous_subscriptions AS (
     SELECT 
         current_subscription_id, 
-        products.name as previous_sku
+        products.cws_sku_name as previous_product_sku
     FROM 
         previous_subscriptions_pre
         JOIN {{ source('stripe', 'products') }} on products.id = previous_product_id
@@ -33,8 +33,8 @@ with current_subscriptions AS(
         SPLIT_PART(customers.email, '@', 2) as domain,
         current_subscriptions.id as subscription_id,
         current_subscriptions.cws_dns as cloud_dns,
-        current_subscriptions.name as sku,
-        previous_subscriptions.previous_sku,
+        current_subscriptions.product_sku,
+        previous_subscriptions.previous_product_sku,
         left(coalesce(current_subscriptions.company, customers.email), 40) as company_name,
         current_subscriptions.status,
         current_subscriptions.created >= '2022-06-14' as hightouch_sync_eligible

--- a/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_campaignmember_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_campaignmember_insert.sql
@@ -54,8 +54,8 @@ with existing_members as (
     LEFT JOIN existing_contacts ON customers_with_free_subs.email = existing_contacts.email
     WHERE (existing_leads.sfid is not null or existing_contacts.sfid is not null) -- either contact or lead exists
     AND existing_members.sfid is null -- not member of campaign either
-    AND sku = 'Cloud Enterprise' 
-    AND previous_sku = 'Cloud Starter'
+    AND product_sku = 'cloud-enterprise' 
+    AND previous_product_sku = 'cloud-starter'
     AND customers_with_free_subs.status = 'trialing'
     AND customers_with_free_subs.hightouch_sync_eligible
 )

--- a/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_contact_update.sql
@@ -30,8 +30,8 @@ WITH existing_lead AS (
     LEFT JOIN existing_lead ON customers_with_free_subs.email = existing_lead.email
     LEFT JOIN {{ ref('contact') }} ON customers_with_free_subs.email = contact.email
     WHERE contact.sfid is not null -- contact exists in salesforce
-    AND sku = 'Cloud Enterprise' 
-    AND previous_sku = 'Cloud Starter'
+    AND product_sku = 'cloud-enterprise' 
+    AND previous_product_sku = 'cloud-starter'
     AND customers_with_free_subs.status = 'trialing'
     AND customers_with_free_subs.hightouch_sync_eligible
 )

--- a/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_lead_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_lead_insert.sql
@@ -27,8 +27,8 @@ WITH existing_lead AS (
     FROM {{ ref('customers_with_cloud_free_subs') }} as customers_with_free_subs
     LEFT JOIN existing_lead ON customers_with_free_subs.email = existing_lead.email
     WHERE existing_lead.id is null
-    AND sku = 'Cloud Enterprise' 
-    AND previous_sku = 'Cloud Starter'
+    AND product_sku = 'cloud-enterprise' 
+    AND previous_product_sku = 'cloud-starter'
     AND status = 'trialing'
     AND customers_with_free_subs.hightouch_sync_eligible
     AND customers_with_free_subs.email not in  -- only insert leads that are not inserted by cs campaign

--- a/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_lead_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/enterprise_trial_requests/etr_lead_update.sql
@@ -28,8 +28,8 @@ WITH existing_lead AS (
     FROM {{ ref('customers_with_cloud_free_subs') }} as customers_with_free_subs
     LEFT JOIN existing_lead ON customers_with_free_subs.email = existing_lead.email
     WHERE existing_lead.id is not null -- lead exists in salesforce
-    AND sku = 'Cloud Enterprise' 
-    AND previous_sku = 'Cloud Starter'
+    AND product_sku = 'cloud-enterprise' 
+    AND previous_product_sku = 'cloud-starter'
     AND status = 'trialing'
     AND customers_with_free_subs.hightouch_sync_eligible
 )


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Product name in stripe was changed from `Cloud Starter` to `Cloud Free`. Our models syncing `Enterprise trial requests` into salesforce were using reference to string value `Cloud Starter` coming from stripe. Thus leading to records getting filtered out.

- [x] Updated reference to product sku instead of product name.
- [x] Validations pasted in jira.
- [x] Backfill not required.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-51750