### PR TITLE
MM-51946: keep email prefix to use as first name

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/onprem_trial_request_inapp_facts.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/onprem_trial_request_inapp_facts.sql
@@ -30,6 +30,8 @@ with existing_members as (
     select
         tr.email
         , left(tr.email, 40) as first_name
+        -- Keep leftmost part
+        , left(split_part(tr.email, '@', 1), 40) as email_prefix
         , tr.site_url
         , tr.license_id
         , tr.sfid


### PR DESCRIPTION
#### Summary

Email is used as first name. Based on discussion with the team, the email's prefix (part before `@`) shall be used.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51946

