### PR TITLE
Chore: Adding timeout to dbt hourly

### DIFF
--- a/dags/transformation/dbt.py
+++ b/dags/transformation/dbt.py
@@ -29,6 +29,7 @@ default_args = {
     "retry_delay": timedelta(minutes=1),
     "sla": timedelta(hours=8),
     "start_date": datetime(2019, 1, 1, 0, 0, 0),
+    "default_timeout": timedelta(hours=1),
 }
 
 # Create the DAG


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adding a timeout of 1 hour to dbt dag to prevent task instance getting stuck on `running` state.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
N/A
