### PR TITLE
Fixed incremental logic to use updated_at

### DIFF
--- a/transform/snowflake-dbt/models/blapi/subscriptions_blapi.sql
+++ b/transform/snowflake-dbt/models/blapi/subscriptions_blapi.sql
@@ -46,7 +46,7 @@ FROM subscriptions s
 
 {% if is_incremental() %}
 
-    WHERE s.created_at::date >= (SELECT MAX(created_at::date) FROM {{ this }})
+    WHERE s.updated_at::date >= (SELECT MAX(updated_at::date) FROM {{ this }})
 
 {% endif %}
 


### PR DESCRIPTION
Impact: Fixed incremental logic to use updated_at, currently it uses created_at which is always going to be the same for the workspace. If there is a change to the subscription it will be reflected by updated_at field, which should be used in the incremental logic

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

