### PR TITLE
MM-51947: ignore cloud products for onprem subscriptions

### DIFF
--- a/transform/snowflake-dbt/models/blapi/onprem_subscriptions.sql
+++ b/transform/snowflake-dbt/models/blapi/onprem_subscriptions.sql
@@ -29,6 +29,7 @@ WITH latest_payment AS (
         AND p.name != 'Cloud Enterprise'
         AND p.name != 'Cloud Starter'
         AND p.name != 'Cloud Professional'
+        AND p.name NOT ILIKE '%cloud%'
 )
 SELECT * FROM subscriptions
 WHERE row_num = 1


### PR DESCRIPTION
#### Summary

Exclude cloud related products from on prem subscriptions. Fixes an issue that causes downstream models to fail due to division by zero. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51947

