### PR TITLE
MM-51947: align filtering between opportunity & line items

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem.sql
@@ -24,6 +24,9 @@ WITH onprem_olis_to_sync AS (
     WHERE opportunity.id IS NULL AND opportunitylineitem.id IS NULL
     AND customers_with_onprem_subs.sfdc_migrated_opportunity_sfid IS NULL
     AND customers_with_onprem_subs.hightouch_sync_eligible
+    -- Same filters as in blapi_onprem_opportunity
     AND NOT customers_with_onprem_subs.is_renewed -- filtering out renewed from new subscriptions which are part of another model.
+    AND (customers_with_onprem_subs.account_sfid is null OR customers_with_onprem_subs.account_type not in ('Customer','Customer(Attrited)')) -- removing renewals which are part of another model
+
 )
 SELECT * FROM onprem_olis_to_sync

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem_renewal.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem_renewal.sql
@@ -21,7 +21,10 @@ WITH onprem_olis_to_sync AS (
     LEFT JOIN {{ ref('opportunitylineitem') }}
         ON customers_with_onprem_subs.subscription_version_id = opportunitylineitem.subs_version_id__c
     WHERE opportunitylineitem.id IS NULL
+    -- Same filters as in blapi_onprem_opportunity_renewal
     AND customers_with_onprem_subs.is_renewed
+    AND customers_with_onprem_subs.account_sfid is not null
+    AND customers_with_onprem_subs.account_type in ('Customer','Customer(Attrited)')
     AND customers_with_onprem_subs.opportunity_sfid is not null
     AND customers_with_onprem_subs.hightouch_sync_eligible
 )


### PR DESCRIPTION
#### Summary

An inconsistency on the way opportunity and opportunity line items are filtered in the final models to be synced was noticed. The filtering on which items are considered new and which renewals was different. This PR makes the necessary changes to have consistent filtering.

It can be verified by comparing the filters in 
- [blapi_onprem_opportynity.sql](https://github.com/mattermost/mattermost-data-warehouse/blob/master/transform/snowflake-dbt/models/hightouch/blapi/blapi_onprem_opportunity.sql) and `blapi_opportunitylineitem`.
- [blapi_onprem_opportunity_renewal](https://github.com/mattermost/mattermost-data-warehouse/blob/master/transform/snowflake-dbt/models/hightouch/blapi/blapi_onprem_opportunity_renewal.sql) and `blapi_opportunitylineitem_renewal`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51947