### PR TITLE
Remove transform_l from grp_community_tracks

### DIFF
--- a/transform/mattermost-analytics/models/marts/web_app/community/grp_community_tracks.sql
+++ b/transform/mattermost-analytics/models/marts/web_app/community/grp_community_tracks.sql
@@ -2,9 +2,8 @@
     config({
         "materialized": "incremental",
         "cluster_by": ['event_date'],
-        "incremental_strategy": "append",
-        "snowflake_warehouse": "transform_l"
-    })
+        "incremental_strategy": "append"
+        })
 }}
 
 WITH community_prod AS (


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Impact: Updates grp_community_tracks to use warehouse `TRANSFORM_XS`. The larger warehouse was used when we were initially creating the table and it was taking a long time. We no longer require the large warehouse as we only perform incremental loading.


#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-52176

