### PR TITLE
MM - 52108 Updates airflow DAG to run once at 12am everyday

### DIFF
--- a/dags/general/snowflake_job.py
+++ b/dags/general/snowflake_job.py
@@ -29,7 +29,7 @@ default_args = {
 dag = DAG(
     "snowflake_job",
     default_args=default_args,
-    schedule_interval="*/5 * * * *",
+    schedule_interval="0 0 * * *",
     catchup=False,
     max_active_runs=1,  # Don't allow multiple concurrent dag executions
 )


### PR DESCRIPTION
Impact: Updates airflow DAG which runs the NPS category and subcategory update script to run once a day instead of every 5 mins.

https://mattermost.atlassian.net/browse/MM-52108

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

