### PR TITLE
MM-51943: fixes for contact us campaign lead inserts

### DIFF
--- a/transform/snowflake-dbt/macros/validators.sql
+++ b/transform/snowflake-dbt/macros/validators.sql
@@ -1,0 +1,9 @@
+{% macro validate_email(column) -%}
+    {%-
+        set invalid_chars = ['\\\\', '/', '(', ')', '&', '$', '^', '&', '!']
+    -%}
+    {{ column }} LIKE '%_@__%.__%' and {{ column }} not like '%@%@%'
+    {% for char in invalid_chars %}
+        and {{ column }} not like '%{{char}}%'
+    {%- endfor %}
+{%- endmacro%}

--- a/transform/snowflake-dbt/models/hightouch/blapi/contact_us_campaign_fact.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/contact_us_campaign_fact.sql
@@ -33,11 +33,15 @@ with existing_members as (
 )
 select
     facts.email,
+    {{ validate_email('facts.email') }} as is_valid_email,
+    -- Multiple contact forms for the same email might have be submitted. Add row number per email while ordering by
+    -- form creation date in order to get the order of the submissions.
+    ROW_NUMBER() OVER (PARTITION BY facts.email ORDER BY facts.created_at ASC) fact_row_number,
     'Sales Inquiry' as contact_us_inquiry_type,
     to_varchar(facts.created_at, 'YYYY-MM-DDTHH24:MI:SSZ') as request_to_contact_us_date,
     facts.comment as tell_us_more,
     facts.name as company,
-    lead.dwh_external_id__c is not null as lead_exists,
+    lead.sfid is not null as lead_exists,
     contact.dwh_external_id__c is not null as contact_exists,
     coalesce(campaignmember.dwh_external_id__c, UUID_STRING('78157189-82de-4f4d-9db3-88c601fbc22e', '7013p000001TxBuAAK' || facts.email)) AS campaignmember_external_id,
     coalesce(contact.dwh_external_id__c, UUID_STRING('78157189-82de-4f4d-9db3-88c601fbc22e', facts.email)) AS contact_external_id,

--- a/transform/snowflake-dbt/models/hightouch/blapi/contact_us_campaign_with_lead_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/contact_us_campaign_with_lead_insert.sql
@@ -7,5 +7,7 @@
 with campaign_with_leads as (
     select * from {{ ref('contact_us_campaign_fact') }}
     where not lead_exists and not contact_exists
+    -- Insert a new lead only for the first time there was a contact
+    and fact_row_number = 1
 )
 select * from campaign_with_leads

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/onprem_trial_request_inapp_facts.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/onprem_trial_request_inapp_facts.sql
@@ -29,7 +29,7 @@ with existing_members as (
 ), trial_facts as (
     select
         tr.email
-        , tr.email LIKE '%_@__%.__%' and tr.email not like '%@%@%' as is_valid_email
+        , {{ validate_email('tr.email') }} as is_valid_email
         , left(tr.email, 40) as first_name
         -- Keep leftmost part
         , left(split_part(tr.email, '@', 1), 40) as email_prefix

--- a/transform/snowflake-dbt/tests/data_quality/hightouch/blapi/test_contact_us_campaign_fact.sql
+++ b/transform/snowflake-dbt/tests/data_quality/hightouch/blapi/test_contact_us_campaign_fact.sql
@@ -1,0 +1,10 @@
+{{ config(
+    tags = ['data-quality']
+) }}
+
+select
+    *
+from
+    {{ ref('contact_us_campaign_fact') }}
+where
+    not is_valid_email


### PR DESCRIPTION
#### Summary

- [x] Add email validation. 
- [x] Stricter email validation as new cases were detected in the failing syncs.
- [x] Move email validation to a macro so that it's reusable and consistent.
- [x] Update logic for new records to check column `SFID` rather than `dwh_external_id__c` as the second may be null.
- [x] Try to insert only first record in case multiple contact form attempts from the same email exist. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51943

