### PR TITLE
MM-51943: fix duplicate campaign member inserts on same batch

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/blapi/contact_us_campaignmember_to_insert_lead.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/contact_us_campaignmember_to_insert_lead.sql
@@ -7,5 +7,7 @@
 with campaignmembers_to_insert as (
     select * from {{ ref('contact_us_campaign_fact') }}
     where campaignmember_sfid is null and lead_exists
+    -- For each insert batch, keep the most recent record according to "request to contact us"
+    qualify row_number() over (partition by email order by request_to_contact_us_date desc) = 1
 )
 select * from campaignmembers_to_insert


### PR DESCRIPTION
#### Summary

Skip trying to add duplicates of the same campaign member on each sync's batch.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51943
