### PR TITLE
MM-51943: fix duplicate campaign member inserts on same batch

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/blapi/contact_us_campaignmember_to_insert_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/contact_us_campaignmember_to_insert_contact.sql
@@ -7,5 +7,7 @@
 with campaignmembers_to_insert as (
     select * from {{ ref('contact_us_campaign_fact') }}
     where campaignmember_sfid is null and not lead_exists and contact_exists
+    -- For each insert batch, keep the most recent record according to "request to contact us"
+    qualify row_number() over (partition by email order by request_to_contact_us_date desc) = 1
 )
 select * from campaignmembers_to_insert


### PR DESCRIPTION
#### Summary

Removes duplicate emails in the same batch. Keeps the row with the most recent request to contact time.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51943