### PR TITLE
MM-51943: ignore records with invalid source

### DIFF
--- a/transform/snowflake-dbt/models/blapi/source.yml
+++ b/transform/snowflake-dbt/models/blapi/source.yml
@@ -42,6 +42,24 @@ sources:
       - name: usage_events
       - name: usage_events_version
       - name: contact_us_requests
+        columns:
+          - name: id
+          - name: created_at
+          - name: name
+          - name: email
+          - name: inquiry_type
+          - name: inquiry_issue
+          - name: comment
+          - name: customer_id
+          - name: source
+            tests:
+              - accepted_values:
+                  values: [ 'Portal', 'Cloud' ]
+          - name: zendesk_ticket_id
+          - name: campaign_member_sfid
+          - name: _sdc_extracted_at
+          - name: _sdc_batched_at
+          - name: _sdc_deleted_at
 
   - name: stripe
     database: ANALYTICS

--- a/transform/snowflake-dbt/models/hightouch/blapi/contact_us_campaign_fact.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/contact_us_campaign_fact.sql
@@ -79,3 +79,5 @@ where
     and facts.inquiry_issue != 'I want to cancel my Mattermost account'
     and facts.created_at >= '2021-08-23'
     and is_valid_email
+    -- Filter invalid sources
+    and facts.source in ('Portal', 'Cloud')


### PR DESCRIPTION
#### Summary

Two records exist with field source equal to `null`. The source field is used to identify whether the portal or cloud form was used. The email for both records is an internal mattermost and has the postfix `+TESTING` after the username (`user+TESTING@example.com`). 

This PR suggest to:

- [x] Skip records with invalid source value.
- [x] Add test to catch invalid source values.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51943
