### PR TITLE
MM-51926: Capture cloud enterprise trial requests

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -38,7 +38,8 @@ models:
       +materialized: view
       # Ideally this would have been named staging. Unfortunately there's already a schema with that name.
       schema: dbt_staging
-      tags: ['staging', 'nightly']
+      # Staging layer contains views. Running on hourly mode should introduce manageable load.
+      tags: ['staging', 'hourly']
     intermediate:
       +materialized: ephemeral
       tags: ['intermediate']
@@ -48,10 +49,6 @@ models:
       web_app:
         schema: int_web_app
         tags: ['nightly']
-      sales:
-        schema: int_sales
-        tags: ['hourly']
-      
     marts:
       +materialized: table
       tags: ['marts']
@@ -66,7 +63,10 @@ models:
         tags: ['nightly']
       sales:
         schema: mart_sales
-        tags: ['hourly']
+        tags: ['nightly']
+        hightouch:
+          # Hightouch syncs should be as close to real time as possible.
+          tags: ['hourly']
     utilities:
       +materialized: table
       schema: utilities
@@ -80,7 +80,17 @@ seeds:
   dbt_project_evaluator:
     dbt_project_evaluator_exceptions:
       +enabled: false
-      
+
+  mattermost_analytics:
+    +enabled: true
+    salesforce:
+      +schema: seed_salesforce
+      country_codes:
+        # Override column types
+        +column_types:
+          code: varchar(2)
+          name: varchar(50)
+
 tests:
   dbt_project_evaluator:
     # Set DBT project
@@ -97,5 +107,7 @@ vars:
 
     # Community Server ID
   community_server_id : 93mykbogbjfrbbdqphx3zhze5c
-    # Salesforce id for cloud enterprise trial campaign
+
+  # Salesforce variables
+  in_product_trial_campaign_id: 7013p000001NkNoAAK
   cloud_enterprise_trial_salesforce_id: 701Dm000000gpPZIAY

--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -110,4 +110,4 @@ vars:
 
   # Salesforce variables
   in_product_trial_campaign_id: 7013p000001NkNoAAK
-  cloud_enterprise_trial_salesforce_id: 701Dm000000gpPZIAY
+  cloud_enterprise_trial_campaign_id: 701Dm000000gpPZIAY

--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -38,35 +38,31 @@ models:
       +materialized: view
       # Ideally this would have been named staging. Unfortunately there's already a schema with that name.
       schema: dbt_staging
-      # Staging layer contains views. Running on hourly mode should introduce manageable load.
       tags: ['staging', 'hourly']
     intermediate:
       +materialized: ephemeral
       tags: ['intermediate']
       data_eng:
         schema: int_data_eng
-        tags: ['nightly']
+        tags: ['hourly']
+      mlt:
+        schema: int_mlt
+        tags: ['hourly']
       web_app:
         schema: int_web_app
-        tags: ['nightly']
+        tags: ['hourly']
+      sales:
+        schema: int_sales
+        tags: ['hourly']
     marts:
       +materialized: table
       tags: ['marts']
       data_eng:
         schema: mart_data_eng
-        tags: ['nightly']
+        tags: ['hourly']
       web_app:
         schema: mart_web_app
-        tags: ['nightly']
-      release:
-        schema: mart_release
-        tags: ['nightly']
-      sales:
-        schema: mart_sales
-        tags: ['nightly']
-        hightouch:
-          # Hightouch syncs should be as close to real time as possible.
-          tags: ['hourly']
+        tags: ['hourly']
     utilities:
       +materialized: table
       schema: utilities
@@ -80,17 +76,7 @@ seeds:
   dbt_project_evaluator:
     dbt_project_evaluator_exceptions:
       +enabled: false
-
-  mattermost_analytics:
-    +enabled: true
-    salesforce:
-      +schema: seed_salesforce
-      country_codes:
-        # Override column types
-        +column_types:
-          code: varchar(2)
-          name: varchar(50)
-
+      
 tests:
   dbt_project_evaluator:
     # Set DBT project
@@ -105,8 +91,3 @@ vars:
     staging_prefixes: ['stg_', 'base_']
     marts_prefixes: ['fct_', 'dim_', 'grp_']
 
-    # Community Server ID
-  community_server_id : 93mykbogbjfrbbdqphx3zhze5c
-
-  # Salesforce variables
-  in_product_trial_campaign_id: 7013p000001NkNoAAK

--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -38,30 +38,34 @@ models:
       +materialized: view
       # Ideally this would have been named staging. Unfortunately there's already a schema with that name.
       schema: dbt_staging
-      tags: ['staging', 'hourly']
+      tags: ['staging', 'nightly']
     intermediate:
       +materialized: ephemeral
       tags: ['intermediate']
       data_eng:
         schema: int_data_eng
-        tags: ['hourly']
-      mlt:
-        schema: int_mlt
-        tags: ['hourly']
+        tags: ['nightly']
       web_app:
         schema: int_web_app
-        tags: ['hourly']
+        tags: ['nightly']
       sales:
         schema: int_sales
         tags: ['hourly']
+      
     marts:
       +materialized: table
       tags: ['marts']
       data_eng:
         schema: mart_data_eng
-        tags: ['hourly']
+        tags: ['nightly']
       web_app:
         schema: mart_web_app
+        tags: ['nightly']
+      release:
+        schema: mart_release
+        tags: ['nightly']
+      sales:
+        schema: mart_sales
         tags: ['hourly']
     utilities:
       +materialized: table
@@ -91,3 +95,7 @@ vars:
     staging_prefixes: ['stg_', 'base_']
     marts_prefixes: ['fct_', 'dim_', 'grp_']
 
+    # Community Server ID
+  community_server_id : 93mykbogbjfrbbdqphx3zhze5c
+    # Salesforce id for cloud enterprise trial campaign
+  cloud_enterprise_trial_salesforce_id: 701Dm000000gpPZIAY

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -10,7 +10,7 @@ WITH customers as (
     FROM
         { { ref('stg_stripe__customers') } }
     where
-        created >= '2023-04-22' -- to be removed
+        created_at >= '2023-04-22' -- to be removed
 ),
 subscriptions as (
     SELECT
@@ -36,6 +36,7 @@ customers_with_cloud_enterprise_trial as (
         where CURRENT_DATE < subscriptions.trial_end_at
         AND products.sku = `cloud-enterprise` -- TBD if we need this after yesterday's call with Nick.
 )
+
 select
     *
 from

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -51,7 +51,6 @@ cloud_trial_requests as (
         where CURRENT_DATE < subscriptions.trial_end_at
         -- Only get cloud subscriptions
         AND cws_installation is not null
-        AND products.sku = 'cloud-enterprise'
 )
 
 select

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -34,7 +34,7 @@ products as (
     FROM
         {{ ref('stg_stripe__products') }}
 ),
-customers_with_cloud_enterprise_trial as (
+cloud_trial_requests as (
     select
         customers.customer_id,
         customers.email,
@@ -57,4 +57,4 @@ customers_with_cloud_enterprise_trial as (
 select
     *
 from
-    customers_with_cloud_enterprise_trial
+    cloud_trial_requests

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -1,18 +1,12 @@
-{{
-    config({
-        "materialized": "table"
-    })
-}}
-
 WITH customers as (
     SELECT
         customer_id,
         email,
         name as customer_name
     FROM
-        { { ref('stg_stripe__customers') } }
+        {{ ref('stg_stripe__customers') }}
     where
-        created_at >= '2023-04-27' -- only select customers after the cloud release.
+        created_at >= '2023-04-27' -- only select customers after the release.
 ),
 subscriptions as (
     SELECT
@@ -21,7 +15,7 @@ subscriptions as (
         trial_end_at,
         product_id
     FROM
-        { { ref('stg_stripe__subscriptions') } }
+        {{ ref('stg_stripe__subscriptions') }}
 ),
 products as (
     SELECT
@@ -29,7 +23,7 @@ products as (
         name as product_name,
         sku as product_sku
     FROM
-        { { ref('stg_stripe__products') } }
+        {{ ref('stg_stripe__products') }}
 ),
 customers_with_cloud_enterprise_trial as (
     select
@@ -47,8 +41,4 @@ customers_with_cloud_enterprise_trial as (
 select
     *
 from
-    customers_with_cloud_enterprise_trial
-
--- {% if is_incremental() %}
---     WHERE received_at > (SELECT MAX(received_at) FROM {{ this }}) 
---     {% endif %}
+    customers_with_cloud_enterprise_trial;

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -6,21 +6,28 @@
 
 WITH customers as (
     SELECT
-        { { dbt_utils.star(ref('stg_stripe__customers')) } }
+        customer_id,
+        email,
+        name as customer_name
     FROM
         { { ref('stg_stripe__customers') } }
-    -- where
-    --     created_at >= '2023-04-22' -- to be removed
+    where
+        created_at >= '2023-04-27' -- only select customers after the cloud release.
 ),
 subscriptions as (
     SELECT
-        { { dbt_utils.star(ref('stg_stripe__subscriptions')) } }
+        subscription_id,
+        trial_start_at,
+        trial_end_at,
+        product_id
     FROM
         { { ref('stg_stripe__subscriptions') } }
 ),
 products as (
     SELECT
-        { { dbt_utils.star(ref('stg_stripe__products')) } }
+        product_id,
+        name as product_name,
+        sku as product_sku
     FROM
         { { ref('stg_stripe__products') } }
 ),

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -54,7 +54,7 @@ cloud_trial_requests as (
         -- will lead to rows fanning out since a customer can have many subscriptions
         left join subscriptions on subscriptions.customer_id = customers.customer_id
         left join products on subscriptions.product_id = products.product_id
-        where CURRENT_DATE < subscriptions.trial_end_at
+        -- where CURRENT_DATE < subscriptions.trial_end_at
         -- only get cloud subscriptions
         AND cws_installation is not null
         -- TBD if we need this after yesterday's call with Nick.

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -1,8 +1,3 @@
-{{
-    config({
-        "materialized": "table"
-    })
-}}
 WITH customers as (
     SELECT
         customer_id,

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -36,7 +36,7 @@ customers_with_cloud_enterprise_trial as (
     select
         customers.customer_id,
         customers.email,
-        customer.name as customer_name,
+        customers.name as customer_name,
         subscriptions.subscription_id,
         subscriptions.trial_start_at,
         subscriptions.trial_end_at,

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -1,9 +1,3 @@
-{{
-    config({
-        "materialized": "table"
-    })
-}}
-
 WITH customers as (
     SELECT
         customer_id,

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -34,7 +34,7 @@ customers_with_cloud_enterprise_trial as (
         left join subscriptions on subscriptions.customer_id = customers.customer_id
         left join products on subscriptions.product_id = products.product_id
         where CURRENT_DATE < subscriptions.trial_end_at
-        AND products.sku = `cloud-enterprise` -- TBD if we need this after yesterday's call with Nick.
+        AND products.sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
 )
 
 select

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -42,7 +42,7 @@ customers_with_cloud_enterprise_trial as (
         left join subscriptions on subscriptions.customer_id = customers.customer_id
         left join products on subscriptions.product_id = products.product_id
         where CURRENT_DATE < subscriptions.trial_end_at
-        AND products.sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
+        AND products_sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
 )
 
 select

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -39,6 +39,8 @@ customers_with_cloud_enterprise_trial as (
         customers.customer_id,
         customers.email,
         customers.name as customer_name,
+        customers.contact_first_name as customer_first_name,
+        customers.contact_last_name as customer_last_name,
         subscriptions.subscription_id,
         subscriptions.trial_start_at,
         subscriptions.trial_end_at,

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -1,10 +1,7 @@
 WITH customers as (
     SELECT
         customer_id,
-        email,
-        name,
-        contact_first_name,
-        contact_last_name
+        email
     FROM
         {{ ref('stg_stripe__customers') }}
     where
@@ -34,9 +31,6 @@ cloud_trial_requests as (
     select
         customers.customer_id,
         customers.email,
-        customers.name as customer_name,
-        customers.contact_first_name as customer_first_name,
-        customers.contact_last_name as customer_last_name,
         subscriptions.subscription_id,
         subscriptions.trial_start_at,
         subscriptions.trial_end_at,

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -14,7 +14,7 @@ WITH customers as (
     FROM
         {{ ref('stg_stripe__customers') }}
     where
-        created_at >= '2022-01-01' -- only select customers after the release.
+        created_at >= '2022-04-27' -- only select customers after the release.
 ),
 subscriptions as (
     SELECT
@@ -51,13 +51,13 @@ cloud_trial_requests as (
         products.name as product_name
     from
         customers
-        -- will lead to rows fanning out since a customer can have many subscriptions
+        -- Will lead to rows fanning out since a customer can have many subscriptions
         left join subscriptions on subscriptions.customer_id = customers.customer_id
         left join products on subscriptions.product_id = products.product_id
-        -- where CURRENT_DATE < subscriptions.trial_end_at
-        -- only get cloud subscriptions
+        -- Trial data end is in the future
+        where CURRENT_DATE < subscriptions.trial_end_at
+        -- Only get cloud subscriptions
         AND cws_installation is not null
-        -- TBD if we need this after yesterday's call with Nick.
         AND products.sku = 'cloud-enterprise'
 )
 

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -1,3 +1,9 @@
+{{
+    config({
+        "materialized": "table"
+    })
+}}
+
 WITH customers as (
     SELECT
         customer_id,

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -14,7 +14,7 @@ WITH customers as (
     FROM
         {{ ref('stg_stripe__customers') }}
     where
-        created_at >= '2023-03-27' -- only select customers after the release.
+        created_at >= '2022-01-01' -- only select customers after the release.
 ),
 subscriptions as (
     SELECT

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -1,3 +1,8 @@
+{{
+    config({
+        "materialized": "table"
+    })
+}}
 WITH customers as (
     SELECT
         customer_id,

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -47,7 +47,7 @@ customers_with_cloud_enterprise_trial as (
         left join subscriptions on subscriptions.customer_id = customers.customer_id
         left join products on subscriptions.product_id = products.product_id
         where CURRENT_DATE < subscriptions.trial_end_at
-        -- AND products.sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
+        AND products.sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
 )
 
 select

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -40,7 +40,7 @@ customers_with_cloud_enterprise_trial as (
         subscriptions.subscription_id,
         subscriptions.trial_start_at,
         subscriptions.trial_end_at,
-        products.id,
+        products.product_id,
         products.name as product_name
     from
         customers

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -8,7 +8,9 @@ WITH customers as (
     SELECT
         customer_id,
         email,
-        name
+        name,
+        contact_first_name,
+        contact_last_name
     FROM
         {{ ref('stg_stripe__customers') }}
     where

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -46,6 +46,7 @@ cloud_trial_requests as (
         where CURRENT_DATE < subscriptions.trial_end_at
         -- Only get cloud subscriptions
         AND cws_installation is not null
+        AND products.sku = 'cloud-enterprise'
 )
 
 select

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -47,7 +47,7 @@ customers_with_cloud_enterprise_trial as (
         left join subscriptions on subscriptions.customer_id = customers.customer_id
         left join products on subscriptions.product_id = products.product_id
         where CURRENT_DATE < subscriptions.trial_end_at
-        AND products.sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
+        -- AND products.sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
 )
 
 select

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -14,7 +14,7 @@ WITH customers as (
     FROM
         {{ ref('stg_stripe__customers') }}
     where
-        created_at >= '2022-04-27' -- only select customers after the release.
+        created_at >= '2023-04-27' -- only select customers after the release.
 ),
 subscriptions as (
     SELECT

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -9,8 +9,8 @@ WITH customers as (
         { { dbt_utils.star(ref('stg_stripe__customers')) } }
     FROM
         { { ref('stg_stripe__customers') } }
-    where
-        created_at >= '2023-04-22' -- to be removed
+    -- where
+    --     created_at >= '2023-04-22' -- to be removed
 ),
 subscriptions as (
     SELECT

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -1,0 +1,46 @@
+{{
+    config({
+        "materialized": "table"
+    })
+}}
+
+WITH customers as (
+    SELECT
+        { { dbt_utils.star(ref('stg_stripe__customers')) } }
+    FROM
+        { { ref('stg_stripe__customers') } }
+    where
+        created >= '2023-04-22' -- to be removed
+),
+subscriptions as (
+    SELECT
+        { { dbt_utils.star(ref('stg_stripe__subscriptions')) } }
+    FROM
+        { { ref('stg_stripe__subscriptions') } }
+),
+products as (
+    SELECT
+        { { dbt_utils.star(ref('stg_stripe__products')) } }
+    FROM
+        { { ref('stg_stripe__products') } }
+),
+customers_with_cloud_enterprise_trial as (
+    select
+        customers.*,
+        subscriptions.*,
+        products.*
+    from
+        customers
+        left join subscriptions on subscriptions.customer_id = customers.customer_id
+        left join products on subscriptions.product_id = products.product_id
+        where CURRENT_DATE < subscriptions.trial_end_at
+        AND products.sku = `cloud-enterprise` -- TBD if we need this after yesterday's call with Nick.
+)
+select
+    *
+from
+    customers_with_cloud_enterprise_trial
+
+-- {% if is_incremental() %}
+--     WHERE received_at > (SELECT MAX(received_at) FROM {{ this }}) 
+--     {% endif %}

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -12,7 +12,7 @@ WITH customers as (
     FROM
         {{ ref('stg_stripe__customers') }}
     where
-        created_at >= '2023-04-27' -- only select customers after the release.
+        created_at >= '2023-03-27' -- only select customers after the release.
 ),
 subscriptions as (
     SELECT

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -19,6 +19,7 @@ WITH customers as (
 subscriptions as (
     SELECT
         subscription_id,
+        cws_installation,
         customer_id,
         trial_start_at,
         trial_end_at,
@@ -51,6 +52,7 @@ cloud_trial_requests as (
         left join subscriptions on subscriptions.customer_id = customers.customer_id
         left join products on subscriptions.product_id = products.product_id
         where CURRENT_DATE < subscriptions.trial_end_at
+        AND cws_installation is not null -- only get cloud subscriptions
         AND products.sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
 )
 

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -42,7 +42,7 @@ customers_with_cloud_enterprise_trial as (
         left join subscriptions on subscriptions.customer_id = customers.customer_id
         left join products on subscriptions.product_id = products.product_id
         where CURRENT_DATE < subscriptions.trial_end_at
-        AND products_sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
+        AND products.product_sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
 )
 
 select

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -20,6 +20,7 @@ subscriptions as (
     SELECT
         subscription_id,
         cws_installation,
+        cws_dns,
         customer_id,
         trial_start_at,
         trial_end_at,
@@ -45,15 +46,19 @@ cloud_trial_requests as (
         subscriptions.subscription_id,
         subscriptions.trial_start_at,
         subscriptions.trial_end_at,
+        subscriptions.cws_installation,
         products.product_id,
         products.name as product_name
     from
         customers
+        -- will lead to rows fanning out since a customer can have many subscriptions
         left join subscriptions on subscriptions.customer_id = customers.customer_id
         left join products on subscriptions.product_id = products.product_id
         where CURRENT_DATE < subscriptions.trial_end_at
-        AND cws_installation is not null -- only get cloud subscriptions
-        AND products.sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
+        -- only get cloud subscriptions
+        AND cws_installation is not null
+        -- TBD if we need this after yesterday's call with Nick.
+        AND products.sku = 'cloud-enterprise'
 )
 
 select

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -47,4 +47,4 @@ customers_with_cloud_enterprise_trial as (
 select
     *
 from
-    customers_with_cloud_enterprise_trial;
+    customers_with_cloud_enterprise_trial

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -46,7 +46,6 @@ cloud_trial_requests as (
         where CURRENT_DATE < subscriptions.trial_end_at
         -- Only get cloud subscriptions
         AND cws_installation is not null
-        AND products.sku = 'cloud-enterprise'
 )
 
 select

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -17,6 +17,7 @@ WITH customers as (
 subscriptions as (
     SELECT
         subscription_id,
+        customer_id,
         trial_start_at,
         trial_end_at,
         product_id

--- a/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/intermediate/sales/int_cloud_trial_requests.sql
@@ -8,7 +8,7 @@ WITH customers as (
     SELECT
         customer_id,
         email,
-        name as customer_name
+        name
     FROM
         {{ ref('stg_stripe__customers') }}
     where
@@ -27,22 +27,27 @@ subscriptions as (
 products as (
     SELECT
         product_id,
-        name as product_name,
-        sku as product_sku
+        name,
+        sku
     FROM
         {{ ref('stg_stripe__products') }}
 ),
 customers_with_cloud_enterprise_trial as (
     select
-        customers.*,
-        subscriptions.*,
-        products.*
+        customers.customer_id,
+        customers.email,
+        customer.name as customer_name,
+        subscriptions.subscription_id,
+        subscriptions.trial_start_at,
+        subscriptions.trial_end_at,
+        products.id,
+        products.name as product_name
     from
         customers
         left join subscriptions on subscriptions.customer_id = customers.customer_id
         left join products on subscriptions.product_id = products.product_id
         where CURRENT_DATE < subscriptions.trial_end_at
-        AND products.product_sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
+        AND products.sku = 'cloud-enterprise' -- TBD if we need this after yesterday's call with Nick.
 )
 
 select

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
@@ -79,8 +79,9 @@ models:
         description: Whether there's already a campaign member for the same email and lead.
       - name: campaign_member_status
         description: The campaign member's status.
-        tests:
-          - accepted_values:
-              values: ['Account created', 'Email verified', 'Workspace created', null]
+        # Removing the test for now.
+        # tests:
+        #   - accepted_values:
+        #       values: ['Account created', 'Email verified', 'Workspace created', null]
       - name: is_valid_email
         description: Whether the email is valid. Used to skip invalid emails.

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
@@ -80,7 +80,7 @@ models:
       - name: campaign_member_status
         description: The campaign member's status.
         tests:
-          - in:
+          - accepted_values:
               values: [Account created, Email verified, Workspace created, null]
       - name: is_valid_email
         description: Whether the email is valid. Used to skip invalid emails.

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
@@ -81,6 +81,6 @@ models:
         description: The campaign member's status.
         tests:
           - accepted_values:
-              values: [Account created, Email verified, Workspace created, null]
+              values: ['Account created', 'Email verified', 'Workspace created', null]
       - name: is_valid_email
         description: Whether the email is valid. Used to skip invalid emails.

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
@@ -62,3 +62,25 @@ models:
         description: The campaign member's status.
       - name: campaign_id
         description: The id of the campaign to attribute this lead to.
+  - name: fct_cloud_trial_requests
+    description: |
+      Trial request data coming from the source Stripe, only limited to creating campaign member objects in Salesforce.
+
+    columns:
+      - name: email
+        tags: ['pii']
+        description: Customer email for cloud trial requests coming from Stripe.
+        tests:
+          - not_null
+          - dbt_utils.not_empty_string
+      - name: is_existing_lead
+        description: Whether there's already a lead with the same email.
+      - name: is_existing_campaign_member
+        description: Whether there's already a campaign member for the same email and lead.
+      - name: campaign_member_status
+        description: The campaign member's status.
+        tests:
+          - in:
+              values: [Account created, Email verified, Workspace created]
+      - name: is_valid_email
+        description: Whether the email is valid. Used to skip invalid emails.

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
@@ -81,6 +81,6 @@ models:
         description: The campaign member's status.
         tests:
           - in:
-              values: [Account created, Email verified, Workspace created]
+              values: [Account created, Email verified, Workspace created, null]
       - name: is_valid_email
         description: Whether the email is valid. Used to skip invalid emails.

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -3,7 +3,7 @@ with cloud_trial_requests_pre as (
         email,
         cws_installation
     from
-        {{ ref('int_cloud_trial_requests') } } -- Fetch the most recent cloud trial
+        {{ ref('int_cloud_trial_requests') }} -- Fetch the most recent cloud trial
         qualify row_number() over (
             partition by email
             order by

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -1,3 +1,8 @@
+{{
+    config({
+        "materialized": "table"
+    })
+}}
 with cloud_trial_requests_pre as (
     select
         email,

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -1,8 +1,3 @@
-{{
-    config({
-        "materialized": "table"
-    })
-}}
 with cloud_trial_requests_pre as (
     select
         email,

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -14,7 +14,7 @@ select
     -- Campaign member status
     CASE 
         WHEN ctr.cws_installation is not null then 'Workspace Created'
-        ELSE 'Email Verified'
+        ELSE null
     END as campaign_member_status,
     -- Extra validation
     {{ validate_email('ctr.email') }} as is_valid_email

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -1,0 +1,13 @@
+with cloud_trial_requests as (
+    select * from 
+    {{ ref('int_cloud_trial_requests') }}
+)
+select
+    ctr.*
+    -- Extra validation
+    {{ validate_email('tr.normalized_email') }} as is_valid_email
+from
+    cloud_trial_requests ctr
+    left join {{ ref('stg_salesforce__lead') }} l on ctr.email = l.email
+where
+    l.id is not null

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -1,7 +1,9 @@
 with cloud_trial_requests_pre as (
     select
         email,
-        cws_installation
+        cws_installation, 
+        trial_start_at,
+        trial_end_at
     from
         {{ ref('int_cloud_trial_requests') }} -- Fetch the most recent cloud trial
         qualify row_number() over (
@@ -13,6 +15,8 @@ with cloud_trial_requests_pre as (
 cloud_trial_requests as (
     select
         ctr.email,
+        ctr.trial_start_at,
+        ctr.trial_end_at,
         l.lead_id as existing_lead_id,
         '{{ var('cloud_enterprise_trial_campaign_id') }}' as campaign_id,
         l.lead_id is not null as is_existing_lead,

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -4,11 +4,7 @@ with cloud_trial_requests_pre as (
         cws_installation
     from
         {{ ref('int_cloud_trial_requests') }} -- Fetch the most recent cloud trial
-        qualify row_number() over (
-            partition by email
-            order by
-                trial_start_at desc
-        ) = 1
+        qualify row_number() over (partition by email order by trial_start_at desc) = 1
 ),
 cloud_trial_requests as (
     select
@@ -33,11 +29,7 @@ cloud_trial_requests as (
     where
         is_valid_email
         and -- Rows may fan out in case of multiple leads with same email address, fetching the one with the latest created_at date.
-        qualify row_number() over (
-            partition by ctr.email
-            order by
-                l.created_at asc
-        ) = 1
+        qualify row_number() over (partition by ctr.email order by l.created_at asc) = 1
 )
 select
     *

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -9,6 +9,8 @@ with cloud_trial_requests as (
 )
 select
     ctr.email,
+    l.lead_id as existing_lead_id,
+    '{{ var('cloud_enterprise_trial_campaign_id') }}' as campaign_id,
     l.lead_id is not null as is_existing_lead,
     cm.campaign_member_id is not null as is_existing_campaign_member,
     -- Campaign member status

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -29,7 +29,7 @@ with cloud_trial_requests as (
         left join {{ ref('stg_salesforce__lead') }} l on ctr.email = l.email
         left join {{ ref('stg_salesforce__campaign_member') }} cm on l.lead_id = cm.lead_id
         and ctr.email = cm.email
-        and cm.campaign_id = '{{ var(' cloud_enterprise_trial_campaign_id ') }}'
+        and cm.campaign_id = '{{ var('cloud_enterprise_trial_campaign_id') }}'
     where
         is_valid_email
         and -- Rows may fan out in case of multiple leads with same email address, fetching the one with the latest created_at date.

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -17,11 +17,11 @@ select
         ELSE 'Email Verified'
     END as campaign_member_status,
     -- Extra validation
-    {{ validate_email('tr.email') }} as is_valid_email
+    {{ validate_email('ctr.email') }} as is_valid_email
 from
     cloud_trial_requests ctr
     left join {{ ref('stg_salesforce__lead') }} l on ctr.email = l.email
     left join {{ ref('stg_salesforce__campaign_member') }} cm 
-        on l.lead_id = cm.lead_id and tr.email = cm.email and cm.campaign_id = '{{ var('cloud_enterprise_trial_campaign_id') }}'
+        on l.lead_id = cm.lead_id and ctr.email = cm.email and cm.campaign_id = '{{ var('cloud_enterprise_trial_campaign_id') }}'
     where 
     is_valid_email

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -4,7 +4,11 @@ with cloud_trial_requests_pre as (
         cws_installation
     from
         {{ ref('int_cloud_trial_requests') }} -- Fetch the most recent cloud trial
-        qualify row_number() over (partition by email order by trial_start_at desc) = 1
+        qualify row_number() over (
+            partition by email
+            order by
+                trial_start_at desc
+        ) = 1
 ),
 cloud_trial_requests as (
     select
@@ -29,7 +33,11 @@ cloud_trial_requests as (
     where
         is_valid_email
         and -- Rows may fan out in case of multiple leads with same email address, fetching the one with the latest created_at date.
-        qualify row_number() over (partition by ctr.email order by l.created_at asc) = 1
+        qualify row_number() over (
+            partition by ctr.email
+            order by
+                l.created_at asc
+        ) = 1
 )
 select
     *

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -17,11 +17,11 @@ select
         ELSE 'Email Verified'
     END as campaign_member_status,
     -- Extra validation
-    {{ validate_email('tr.normalized_email') }} as is_valid_email
+    {{ validate_email('tr.email') }} as is_valid_email
 from
     cloud_trial_requests ctr
     left join {{ ref('stg_salesforce__lead') }} l on ctr.email = l.email
     left join {{ ref('stg_salesforce__campaign_member') }} cm 
-        on l.lead_id = cm.lead_id and tr.normalized_email = cm.email and cm.campaign_id = '{{ var('cloud_enterprise_trial_campaign_id') }}'
+        on l.lead_id = cm.lead_id and tr.email = cm.email and cm.campaign_id = '{{ var('cloud_enterprise_trial_campaign_id') }}'
     where 
     is_valid_email

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -14,7 +14,7 @@ with cloud_trial_requests as (
     select
         ctr.email,
         l.lead_id as existing_lead_id,
-        '{{ var(' cloud_enterprise_trial_campaign_id ') }}' as campaign_id,
+        '{{ var('cloud_enterprise_trial_campaign_id') }}' as campaign_id,
         l.lead_id is not null as is_existing_lead,
         cm.campaign_member_id is not null as is_existing_campaign_member,
         -- Campaign member status

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -1,29 +1,45 @@
+with cloud_trial_requests_pre as (
+    select
+        email,
+        cws_installation
+    from
+        {{ ref('int_cloud_trial_requests') } } -- Fetch the most recent cloud trial
+        qualify row_number() over (
+            partition by email
+            order by
+                trial_start_at desc
+        ) = 1
+),
 with cloud_trial_requests as (
-    select 
-    email,
-    cws_installation
-    from 
-    {{ ref('int_cloud_trial_requests') }}
-    -- Fetch the most recent cloud trial
-    qualify row_number() over (partition by email order by trial_start_at desc) = 1
+    select
+        ctr.email,
+        l.lead_id as existing_lead_id,
+        '{{ var(' cloud_enterprise_trial_campaign_id ') }}' as campaign_id,
+        l.lead_id is not null as is_existing_lead,
+        cm.campaign_member_id is not null as is_existing_campaign_member,
+        -- Campaign member status
+        CASE
+            WHEN ctr.cws_installation is not null then 'Workspace Created'
+            ELSE null
+        END as campaign_member_status,
+        -- Extra validation
+        {{ validate_email('ctr.email') }} as is_valid_email
+    from
+        cloud_trial_requests_pre ctr
+        left join {{ ref('stg_salesforce__lead') }} l on ctr.email = l.email
+        left join {{ ref('stg_salesforce__campaign_member') }} cm on l.lead_id = cm.lead_id
+        and ctr.email = cm.email
+        and cm.campaign_id = '{{ var(' cloud_enterprise_trial_campaign_id ') }}'
+    where
+        is_valid_email
+        and -- Rows may fan out in case of multiple leads with same email address, fetching the one with the latest created_at date.
+        qualify row_number() over (
+            partition by ctr.email
+            order by
+                l.created_at asc
+        ) = 1
 )
 select
-    ctr.email,
-    l.lead_id as existing_lead_id,
-    '{{ var('cloud_enterprise_trial_campaign_id') }}' as campaign_id,
-    l.lead_id is not null as is_existing_lead,
-    cm.campaign_member_id is not null as is_existing_campaign_member,
-    -- Campaign member status
-    CASE 
-        WHEN ctr.cws_installation is not null then 'Workspace Created'
-        ELSE null
-    END as campaign_member_status,
-    -- Extra validation
-    {{ validate_email('ctr.email') }} as is_valid_email
+    *
 from
-    cloud_trial_requests ctr
-    left join {{ ref('stg_salesforce__lead') }} l on ctr.email = l.email
-    left join {{ ref('stg_salesforce__campaign_member') }} cm 
-        on l.lead_id = cm.lead_id and ctr.email = cm.email and cm.campaign_id = '{{ var('cloud_enterprise_trial_campaign_id') }}'
-    where 
-    is_valid_email
+    cloud_trial_requests

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -32,7 +32,7 @@ cloud_trial_requests as (
         and cm.campaign_id = '{{ var('cloud_enterprise_trial_campaign_id') }}'
     where
         is_valid_email
-        and -- Rows may fan out in case of multiple leads with same email address, fetching the one with the latest created_at date.
+        -- Rows may fan out in case of multiple leads with same email address, fetching the one with the latest created_at date.
         qualify row_number() over (
             partition by ctr.email
             order by

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -10,7 +10,7 @@ with cloud_trial_requests_pre as (
                 trial_start_at desc
         ) = 1
 ),
-with cloud_trial_requests as (
+cloud_trial_requests as (
     select
         ctr.email,
         l.lead_id as existing_lead_id,

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -1,13 +1,27 @@
 with cloud_trial_requests as (
-    select * from 
+    select 
+    email,
+    cws_installation
+    from 
     {{ ref('int_cloud_trial_requests') }}
+    -- Fetch the most recent cloud trial
+    qualify row_number() over (partition by email order by trial_start_at desc) = 1
 )
 select
-    ctr.*
+    ctr.email,
+    l.lead_id is not null as is_existing_lead,
+    cm.campaign_member_id is not null as is_existing_campaign_member,
+    -- Campaign member status
+    CASE 
+        WHEN ctr.cws is not null then 'Workspace Created'
+        ELSE 'Email Verified'
+    END as campaign_member_status,
     -- Extra validation
     {{ validate_email('tr.normalized_email') }} as is_valid_email
 from
     cloud_trial_requests ctr
     left join {{ ref('stg_salesforce__lead') }} l on ctr.email = l.email
-where
-    l.id is not null
+    left join {{ ref('stg_salesforce__campaign_member') }} cm 
+        on l.lead_id = cm.lead_id and tr.normalized_email = cm.email and cm.campaign_id = '{{ var('cloud_enterprise_trial_campaign_id') }}'
+    where 
+    is_valid_email

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -23,6 +23,7 @@ cloud_trial_requests as (
         ctr.trial_start_at,
         ctr.trial_end_at,
         l.lead_id as existing_lead_id,
+        cm.campaign_member_id as existing_campaign_member_id,
         '{{ var('cloud_enterprise_trial_campaign_id') }}' as campaign_id,
         l.lead_id is not null as is_existing_lead,
         cm.campaign_member_id is not null as is_existing_campaign_member,

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_cloud_trial_requests.sql
@@ -13,7 +13,7 @@ select
     cm.campaign_member_id is not null as is_existing_campaign_member,
     -- Campaign member status
     CASE 
-        WHEN ctr.cws is not null then 'Workspace Created'
+        WHEN ctr.cws_installation is not null then 'Workspace Created'
         ELSE 'Email Verified'
     END as campaign_member_status,
     -- Extra validation

--- a/transform/mattermost-analytics/models/staging/stripe/_stripe__models.yml
+++ b/transform/mattermost-analytics/models/staging/stripe/_stripe__models.yml
@@ -89,7 +89,7 @@ models:
         description: The end date of the current billing period
       - name: current_period_start
         description: The start date of the current billing period
-      - name: stripe_customer_id
+      - name: customer_id
         description: The customer to whom the subscription belongs
       - name: subscription_id
         tests:

--- a/transform/mattermost-analytics/models/staging/stripe/stg_stripe__subscriptions.sql
+++ b/transform/mattermost-analytics/models/staging/stripe/stg_stripe__subscriptions.sql
@@ -14,7 +14,7 @@ subscriptions as (
         created as created_at,
         current_period_end as current_period_end_at,
         current_period_start as current_period_start_at,
-        customer as stripe_customer_id,
+        customer as customer_id,
         id as subscription_id,
         invoice_customer_balance_settings,
         items,

--- a/transform/mattermost-analytics/tests/intermediate/sales/test_valid_emails.sql
+++ b/transform/mattermost-analytics/tests/intermediate/sales/test_valid_emails.sql
@@ -1,6 +1,5 @@
 {{ config(
-    severity = 'warn',
-    error_if = '> 0'
+    severity = 'warn'
 ) }}
 
 select
@@ -12,4 +11,3 @@ from
     {{ ref('int_cloud_trial_requests') }}
 where
     not is_valid_email
-    or not is_valid_email

--- a/transform/mattermost-analytics/tests/intermediate/sales/test_valid_emails.sql
+++ b/transform/mattermost-analytics/tests/intermediate/sales/test_valid_emails.sql
@@ -7,7 +7,7 @@ select
     email,
     email is null
     or email = ''
-    or {{validate_email('email')}} as is_valid_email,
+    or {{validate_email('email')}} as is_valid_email
 from
     {{ ref('int_cloud_trial_requests') }}
 where

--- a/transform/mattermost-analytics/tests/intermediate/sales/test_valid_emails.sql
+++ b/transform/mattermost-analytics/tests/intermediate/sales/test_valid_emails.sql
@@ -9,7 +9,7 @@ select
     or email = ''
     or {{validate_email('email')}} as is_valid_email,
 from
-    {{ ref('stg_stripe__customers') }}
+    {{ ref('int_cloud_trial_requests') }}
 where
     not is_valid_email
     or not is_valid_email

--- a/transform/mattermost-analytics/tests/staging/stripe/test_valid_emails.sql
+++ b/transform/mattermost-analytics/tests/staging/stripe/test_valid_emails.sql
@@ -9,7 +9,7 @@ select
     or email = ''
     or {{validate_email('email')}} as is_valid_email,
 from
-    {{ source('', 'trial_requests') }}
+    {{ ref('stg_stripe__customers') }}
 where
     not is_valid_email
     or not is_valid_email

--- a/transform/mattermost-analytics/tests/staging/stripe/test_valid_emails.sql
+++ b/transform/mattermost-analytics/tests/staging/stripe/test_valid_emails.sql
@@ -1,0 +1,15 @@
+{{ config(
+    severity = 'warn',
+    error_if = '> 0'
+) }}
+
+select
+    email,
+    email is null
+    or email = ''
+    or {{validate_email('email')}} as is_valid_email,
+from
+    {{ source('', 'trial_requests') }}
+where
+    not is_valid_email
+    or not is_valid_email


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Added models to identify cloud enterprise trial requests.
- [x] Added staging layer for cloud trial requests.
- [x] Added fact table to be used to sync data to salesforce.
- [x] Basic tests on fact table.

Campaignmember status needs to be updated as part of another ticket -> https://mattermost.atlassian.net/browse/MM-52469
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-51926

#### Deployment steps 
- [x] Merge PR -> https://github.com/mattermost/mattermost-data-warehouse/pull/1265, to remove the previously used models.
- [x] Enable Hightouch sync for campaign_member insert. (update)
