### PR TITLE
MM-51085: update tags to reflect hourly

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -38,7 +38,8 @@ models:
       +materialized: view
       # Ideally this would have been named staging. Unfortunately there's already a schema with that name.
       schema: dbt_staging
-      tags: ['staging', 'nightly']
+      # Staging layer contains views. Running on hourly mode should introduce manageable load.
+      tags: ['staging', 'hourly']
     intermediate:
       +materialized: ephemeral
       tags: ['intermediate']
@@ -62,7 +63,10 @@ models:
         tags: ['nightly']
       sales:
         schema: mart_sales
-        tags: ['hourly']
+        tags: ['nightly']
+        hightouch:
+          # Hightouch syncs should be as close to real time as possible.
+          tags: ['hourly']
     utilities:
       +materialized: table
       schema: utilities


### PR DESCRIPTION
#### Summary

- [x] Changing staging models to run hourly. Since this will only modify views (if needed), the load in the database shouldn't be a lot. It is also required so that staging models to exist when downstream hourly models run for the first time.
- [x] Becoming more specific about hourly models.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51085

