### PR TITLE
MM-51085: fix empty name or company name

### DIFF
--- a/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
@@ -18,19 +18,28 @@ models:
           - not_null
           - dbt_utils.not_empty_string
       - name: first_name
-        description: The user's first name.
+        description: | 
+          The user's first name. This value may originate from:
+            - First name (if directly provided).
+            - By splitting the name string on first space and keeping the first part.
+            - If none of the above are available, the first 40 characters of the "username" part of the email.
         tests:
           - dbt_utils.not_empty_string
         tags: ['pii']
       - name: last_name
-        description: The user's last name.
+        description: | 
+          The user's last name. This value may originate from:
+            - Last name (if directly provided).
+            - By splitting the name string on first space and keeping the second part.
+            - If none of the above are available, the first 40 characters of the "username" part of the email.
         tests:
           - dbt_utils.not_empty_string
         tags: ['pii']
       - name: company_size
         description: The lower bound of the company size bucket.
       - name: company_name
-        description: The company's name.
+        description: |
+          The company's name. If not provided, `Unknown` is used.
         tests:
           - dbt_utils.not_empty_string
       - name: normalized_email

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
@@ -19,14 +19,20 @@ models:
           - dbt_utils.not_empty_string
       - name: first_name
         description: The user's first name.
+        tests:
+          - dbt_utils.not_empty_string
         tags: ['pii']
       - name: last_name
         description: The user's last name.
+        tests:
+          - dbt_utils.not_empty_string
         tags: ['pii']
       - name: company_size
         description: The lower bound of the company size bucket.
       - name: company_name
         description: The company's name.
+        tests:
+          - dbt_utils.not_empty_string
       - name: normalized_email
         tags: ['pii']
         description: |

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_in_product_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_in_product_trial_requests.sql
@@ -21,12 +21,12 @@ with trial_requests as (
         left(split_part(normalized_email, '@', 1), 40) as email_prefix, -- To be used in case name is missing.
         coalesce(
             first_name,
-            split_part(name, ' ', 1),
+            case when extracted_first_name = '' then null else extracted_first_name end,
             email_prefix
         ) as first_name,                                        -- Mapped to field first_name of lead
         coalesce(
             last_name,
-            case when split_part(name, ' ', 2) != '' then split_part(name, ' ', 2) else email_prefix end
+            case when extracted_last_name = '' then null else extracted_last_name end,
         ) as last_name,         -- Mapped to field last_name of lead
         case
         {% for bucket, size_lower in size_buckets.items() -%}

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_in_product_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_in_product_trial_requests.sql
@@ -27,6 +27,7 @@ with trial_requests as (
         coalesce(
             last_name,
             case when extracted_last_name = '' then null else extracted_last_name end,
+            email_prefix
         ) as last_name,         -- Mapped to field last_name of lead
         case
         {% for bucket, size_lower in size_buckets.items() -%}

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_in_product_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_in_product_trial_requests.sql
@@ -16,14 +16,15 @@ with trial_requests as (
             name,
             left(email, 40)
         ) as name,                                          -- Mapped to field name of lead
-        first_name,                                         -- Mapped to field first_name of lead
-        last_name,                                          -- Mapped to field last_name of lead
+        left(split_part(tr.email, '@', 1), 40) as email_prefix -- To be used in case name is missing.
+        coalesce(first_name, email_prefix) as first_name,   -- Mapped to field first_name of lead
+        coalesce(last_name, email_prefix) as last_name,     -- Mapped to field last_name of lead
         case
         {% for bucket, size_lower in size_buckets.items() -%}
             when company_size_bucket = '{{bucket}}' then {{size_lower}}
         {% endfor -%}
         end as company_size,                                -- Mapping lower threshold
-        company_name,                                       -- Mapped to field company of lead
+        coalesce(company_name, 'Unknown') as company_name,  -- Mapped to field company of lead
         -- Salesforce lowercases email
         lower(coalesce(contact_email, email)) as normalized_email, -- Mapped to field email of lead
         case

--- a/transform/mattermost-analytics/models/staging/cws/_cws__models.yml
+++ b/transform/mattermost-analytics/models/staging/cws/_cws__models.yml
@@ -26,6 +26,12 @@ models:
       - name: last_name
         description: Contact's last name.
         tags: ['pii']
+      - name: extracted_first_name
+        description: Contact's first name, as extracted from column name.
+        tags: ['pii']
+      - name: extracted_last_name
+        description: Contact's last name, as extracted from column name.
+        tags: ['pii']
       - name: email
         description: The user's email (TBD).
         tags: ['pii']

--- a/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
+++ b/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
@@ -23,6 +23,9 @@ renamed as (
             when contactlastname = '' then null
             else contactlastname
         end as last_name,
+        -- Attempt to extract first and last name from name.
+        trim(substring(name, 1, charindex(' ', name) - 1)) as extracted_first_name,
+        trim(substring(name, charindex(' ', name) + 1, len(name) - CHARINDEX(' ', name))) as extracted_last_name,
         email,
         case
             when contactemail = '' then null

--- a/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
+++ b/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
@@ -24,8 +24,23 @@ renamed as (
             else contactlastname
         end as last_name,
         -- Attempt to extract first and last name from name.
-        trim(substring(name, 1, charindex(' ', name) - 1)) as extracted_first_name,
-        trim(substring(name, charindex(' ', name) + 1, len(name) - CHARINDEX(' ', name))) as extracted_last_name,
+        trim(name) as _name,
+        case
+            -- Empty string
+            when _name = '' then null
+            -- A whitespace exists in the string, split it
+            when charindex(' ', _name) > 0 then substring(name, 1, charindex(' ', name) - 1)
+            -- No whitespace, return the full string
+            else _name
+        end as extracted_first_name,
+        case
+            -- Empty string
+            when _name = '' then null
+            -- A whitespace exists
+            when charindex(' ', _name) > 0 then substring(name, charindex(' ', name) + 1, len(name) - charindex(' ', name))
+            -- No whitespace, can't find it
+            else null
+        end as extracted_last_name,
         email,
         case
             when contactemail = '' then null

--- a/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
+++ b/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
@@ -15,8 +15,14 @@ renamed as (
             when name = '' then null
             else name
         end as name,
-        contactfirstname as first_name,
-        contactlastname as last_name,
+        case
+            when contactfirstname = '' then null
+            else contactfirstname
+        end as first_name,
+        case
+            when contactlastname = '' then null
+            else contactlastname
+        end as last_name,
         email,
         case
             when contactemail = '' then null
@@ -25,7 +31,10 @@ renamed as (
 
         -- Company info
         companycountry as country_name,
-        companyname as company_name,
+        case
+            when companyname = '' then null
+            else companyname
+        end as company_name,
         companysize as company_size_bucket,
 
         -- Installation info


### PR DESCRIPTION
#### Summary

- [x] Extract first name and last name from `name` (if they exist).
- [x] Use email for first/last name if they are missing.
- [x] Use `Unknown` in case the company name is not provided in the form.

| Name        | Email            | Resulting First Name | Resulting Last Name | Description                            |
|-------------|------------------|----------------------|---------------------|----------------------------------------|
| Jane Doe    | user@example.com | Jane                 | Doe                 | Name contains both first and last name |
| Jane        | user@example.com | Jane                 | user                | Only first name present                |
| Jane A. Doe | user@example.com | Jane                 | A. Doe              | First name determined by first space   |
| <empty>     | user@example.com | user                 | user                | Name is empty                          |

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51085