### PR TITLE
MM-51752: do not update accounts without contacts

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
@@ -5,7 +5,20 @@
   })
 }}
 
-WITH customers_with_cloud_paid_subs as (
+WITH existing_contacts AS (
+    SELECT
+        contact.sfid,
+        contact.email,
+        contact.dwh_external_id__c,
+        contact.ownerid,
+        ROW_NUMBER() over (
+            PARTITION BY contact.email
+            ORDER BY
+                createddate DESC
+        ) AS row_num
+    FROM
+        {{ ref('contact') }}
+), customers_with_cloud_paid_subs as (
     SELECT
         customers_with_cloud_paid_subs.*,
         'Customer' as account_type
@@ -13,7 +26,11 @@ WITH customers_with_cloud_paid_subs as (
     LEFT JOIN {{ ref('account') }}
         ON customers_with_cloud_paid_subs.domain = account.cbit__clearbitdomain__c
             OR customers_with_cloud_paid_subs.account_external_id = account.dwh_external_id__c
+    LEFT JOIN existing_contacts
+        ON customers_with_cloud_paid_subs.email = existing_contacts.email
+        AND existing_contacts.row_num = 1
     WHERE account.id IS NOT NULL
+        AND existing_contacts.sfid IS NULL -- create account only when contact does not exist
     AND customers_with_cloud_paid_subs.hightouch_sync_eligible
     AND customers_with_cloud_paid_subs.status in ('canceled', 'active') 
     AND customers_with_cloud_paid_subs.SKU = 'Cloud Professional'


### PR DESCRIPTION
#### Summary

Opening this PR to trigger discussion, as I'm 3/5 on this solution.

This PR fixes the related broken sync. The reason that the sync fails is because it tries to update the salesforce `Account` object, but it fails to find it. The respective account are not there because it is only created if a `Contact` object exists ([source](https://github.com/mattermost/mattermost-data-warehouse/blob/master/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql#L55)). I couldn't clarify why this needs to happen.

There are two possible solutions:
- Don't update accounts without contacts. This is the solution proposed on this PR.
- Create accounts even if there is no contact. Perhaps contact object can also be added if missing.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51752

