### PR TITLE
MM-51752: fix empty account name for gmail users

### DIFF
--- a/transform/snowflake-dbt/dbt_project.yml
+++ b/transform/snowflake-dbt/dbt_project.yml
@@ -116,3 +116,4 @@ seeds:
 
 vars:
   salesforce_default_ownerid: "'0053p0000064nt8AAA'" #default value for salesforce ownerid
+  unknown_account_name: "Unknown Company from Product"

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_account.sql
@@ -8,7 +8,8 @@
 WITH cloud_accounts_to_sync as (
     SELECT
         customers_with_cloud_subs.*,
-        '0053p0000064nt8AAA' AS ownerid
+        '0053p0000064nt8AAA' AS ownerid,
+        COALESCE(customers_with_cloud_subs.domain, '{{ var('unknown_account_name') }}' ) AS account_name
     FROM {{ ref('customers_with_cloud_subs') }}
     LEFT JOIN {{ ref('account') }}
         ON customers_with_cloud_subs.domain = account.cbit__clearbitdomain__c


### PR DESCRIPTION
#### Summary

Use predefined string for account name when contact email is a gmail account.

Next step would be to update hightouch sync after the change has been merged and run.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51752
