### PR TITLE
MM-51752: Fix incorrect match of subscription to accounts

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
@@ -11,7 +11,7 @@ WITH customers_with_cloud_paid_subs as (
         'Customer' as account_type,
         -- Metadata to be used for selecting proper external id
         external_id_account.id as dwh_id_account_id,
-        external_id_account.id is not null as has_external_id_match,
+        external_id_account.id is not null as has_dwh_id_account_id,
         external_id_account.dwh_external_id__c as dwh_id_account_external_id,
 
         contact.accountid as contact_account_id,
@@ -62,13 +62,13 @@ SELECT
     --  3. account from lead
     --  4. account with matching domain
     case
-        when has_external_id_match then 'existing external id'
+        when has_dwh_id_account_id then 'existing external id'
         when has_contact_match then 'contact'
         when has_lead_match then 'lead'
         else 'domain'
     end as external_id_from,
     case
-        when has_external_id_match then dwh_id_account_external_id
+        when has_dwh_id_account_id then dwh_id_account_external_id
         when has_contact_match then contact_account_external_id
         when has_lead_match then lead_account_external_id
         else domain_account_external_id
@@ -78,7 +78,7 @@ FROM customers_with_cloud_paid_subs
 -- Remove duplicates by prioritizing over external id, contact, lead and finally domain.
 qualify row_number() over(
     partition by email
-    order by has_external_id_match desc,
+    order by has_dwh_id_account_id desc,
              has_contact_match desc,
              has_lead_match desc,
              has_domain_match desc

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
@@ -8,14 +8,78 @@
 WITH customers_with_cloud_paid_subs as (
     SELECT
         customers_with_cloud_paid_subs.*,
-        'Customer' as account_type
+        'Customer' as account_type,
+        -- Metadata to be used for selecting proper external id
+        external_id_account.id as dwh_id_account_id,
+        external_id_account.id is not null as has_external_id_match,
+        external_id_account.dwh_external_id__c as dwh_id_account_external_id,
+
+        contact.accountid as contact_account_id,
+        contact.accountid is not null as has_contact_match,
+        contact_account.dwh_external_id__c as contact_account_external_id,
+
+        lead.existing_account__c is not null as has_lead_match,
+        lead.existing_account__c as lead_account_id,
+        lead_account.dwh_external_id__c as lead_account_external_id,
+
+        domain_account.id is not null as has_domain_match,
+        domain_account.id as domain_account_id,
+        domain_account.dwh_external_id__c as domain_account_external_id
+
     FROM {{ ref('customers_with_cloud_paid_subs') }}
-    LEFT JOIN {{ ref('account') }}
-        ON customers_with_cloud_paid_subs.domain = account.cbit__clearbitdomain__c
-            OR customers_with_cloud_paid_subs.account_external_id = account.dwh_external_id__c
-    WHERE account.id IS NOT NULL
-    AND customers_with_cloud_paid_subs.hightouch_sync_eligible
+       -- Case 1: matching account from external_id
+        LEFT JOIN {{ ref('account') }} external_id_account ON customers_with_cloud_paid_subs.account_external_id = external_id_account.dwh_external_id__c
+        -- Case 2: matching account from contact
+        LEFT JOIN {{ ref('contact') }} ON customers_with_cloud_paid_subs.email = contact.email and contact.accountid is not null
+        LEFT JOIN {{ ref('account') }} contact_account ON contact.accountid = contact_account.id
+        -- Case 3: matching account from lead
+        LEFT JOIN {{ ref('lead') }} on customers_with_cloud_paid_subs.email = lead.email and lead.existing_account__c is not null
+        LEFT JOIN {{ ref('account') }} lead_account ON lead.existing_account__c = lead_account.id
+        -- Case 4: matching account from domain
+        LEFT JOIN {{ ref('account') }} domain_account ON customers_with_cloud_paid_subs.domain = domain_account.cbit__clearbitdomain__c
+
+
+    WHERE
+    customers_with_cloud_paid_subs.hightouch_sync_eligible
     AND customers_with_cloud_paid_subs.status in ('canceled', 'active') 
     AND customers_with_cloud_paid_subs.SKU = 'Cloud Professional'
 )
-SELECT * FROM customers_with_cloud_paid_subs
+SELECT
+    -- Data for debugging
+    email,
+    dwh_id_account_id,
+    dwh_id_account_external_id,
+    contact_account_id,
+    contact_account_external_id,
+    lead_account_id,
+    lead_account_external_id,
+    domain_account_id,
+    domain_account_external_id,
+    -- Data to be updated
+    -- Select account id based on priority:
+    --  1. external id match
+    --  2. account from contact
+    --  3. account from lead
+    --  4. account with matching domain
+    case
+        when has_external_id_match then 'existing external id'
+        when has_contact_match then 'contact'
+        when has_lead_match then 'lead'
+        else 'domain'
+    end as external_id_from,
+    case
+        when has_external_id_match then dwh_id_account_external_id
+        when has_contact_match then contact_account_external_id
+        when has_lead_match then lead_account_external_id
+        else domain_account_external_id
+    end as account_external_id,
+    account_type
+FROM customers_with_cloud_paid_subs
+-- Remove duplicates by prioritizing over external id, contact, lead and finally domain.
+qualify row_number() over(
+    partition by email
+    order by has_external_id_match desc,
+             has_contact_match desc,
+             has_lead_match desc,
+             has_domain_match desc
+) = 1


### PR DESCRIPTION
#### Summary

The current model tries to locate an account either via external id match or domain match. This introduces the following errors:
- If multiple accounts with the same domain exist, then all of them are matched because of the join. 
- If the domain has not been set for the account, no match occurs.

The solution proposed in this PR is to make matching a bit more solid. To do so, the following priority is used for matching accounts:
- Account with same existing `dwh_external_id__c` (if any).
- Account from a contact matching the same email (if any).
- Account from a lead matching the same email (if any).
- Account from domain match (if any). 

In case of multiple matches due to:
- multiple accounts sharing the same domain or
- multiple contacts/leads sharing the same email,

then the items are sorted by the different matches, with the most matches appearing first. The first row is only picked.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51752