### PR TITLE
MM-52880: Exclude subscription overriden at salesforce from syncing

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem_renewal.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem_renewal.sql
@@ -29,3 +29,7 @@ WITH onprem_olis_to_sync AS (
     AND customers_with_onprem_subs.hightouch_sync_eligible
 )
 SELECT * FROM onprem_olis_to_sync
+WHERE
+    subscription_version_id not in (
+        '8kis7psj1jb5pqifnsr8dxf3ie'   -- See https://mattermost.atlassian.net/browse/MM-52880
+    )


### PR DESCRIPTION
#### Summary

Exclude specific subscription from creating a renewal opportunity line item. This subscription has been overridden in Salesforce.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52880


