### PR TITLE
Chore: replace blapi customer with fields from stripe customer

### DIFF
--- a/transform/snowflake-dbt/models/blapi/customers_with_cloud_paid_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_cloud_paid_subs.sql
@@ -25,8 +25,8 @@ with current_subscriptions AS(
                 current_subscriptions.id)
         AS opportunity_external_id,
         customers.email,
-        customers_blapi.first_name,
-        coalesce(NULLIF(TRIM(customers_blapi.last_name), ''), customers.email) as last_name,
+        customers.contactfirstname,
+        coalesce(NULLIF(TRIM(customers.contactlastname), ''), customers.email) as last_name,
         CASE WHEN SPLIT_PART(customers.email, '@', 2) = 'gmail.com' 
         THEN NULL        
         ELSE SPLIT_PART(customers.email, '@', 2) END as domain,
@@ -44,6 +44,5 @@ with current_subscriptions AS(
     FROM {{ source('stripe','customers') }} 
         JOIN current_subscriptions ON customers.id = current_subscriptions.customer
         LEFT JOIN {{ source('stripe', 'invoices') }} ON invoices.subscription = current_subscriptions.id
-        LEFT JOIN {{ source('blapi', 'customers') }} customers_blapi ON customers_blapi.stripe_id = customers.id
 )
 select * from customers_with_paid_subs where row_num = 1

--- a/transform/snowflake-dbt/models/stripe/customers.sql
+++ b/transform/snowflake-dbt/models/stripe/customers.sql
@@ -17,8 +17,8 @@ WITH customers AS (
         ,customers.id
         ,customers.invoice_prefix
         ,customers.livemode
-        ,customers.metadata:"contactfirstname"::varchar as contactfirstname
-        ,customers.metadata:"contactlastname"::varchar as contactlastname
+        ,customers.metadata:"ContactFirstName"::varchar as contactfirstname
+        ,customers.metadata:"ContactLastName"::varchar as contactlastname
         ,customers.metadata:"cws-customer"::varchar as cws_customer
         ,customers.sources
         ,customers.updated
@@ -30,7 +30,7 @@ WITH customers AS (
     FROM {{ source('stripe_raw','customers') }}
     {% if is_incremental() %}
 
-    WHERE customers.created::date >= (SELECT MAX(created::date) FROM {{ this }} )
+    WHERE customers.created >= (SELECT MAX(created::date) FROM {{ this }} )
 
     {% endif %}
 )


### PR DESCRIPTION
#### Summary

- [x] Fix bug in stripe model to properly read customer first and last name
- [x] Replace

Tested by comparing the new customer stripe model with existing blapi data. Only 16 cases where name is different exist, and in most of them it's extra tab at the end of string. Here's the query used for reference:
```

WITH customers AS (
    SELECT 
        customers.account_balance
        ,customers.created
        ,customers.default_source
        ,customers.delinquent
        ,customers.email
        ,customers.name
        ,customers.id
        ,customers.invoice_prefix
        ,customers.livemode
        ,customers.metadata:"ContactFirstName"::varchar as contactfirstname
        ,customers.metadata:"ContactLastName"::varchar as contactlastname
        ,customers.metadata:"cws-customer"::varchar as cws_customer
        ,customers.sources
        ,customers.updated
        ,customers.cards
        ,customers.currency
        ,replace(customers.metadata:"cws-first-purchase-intent-wire-transfer",'/','') as cws_first_purchase_intent_wire_transfer
        ,replace(customers.metadata:"cws-renewal-self-intent-wire-transfer",'/','') as cws_renewal_self_intent_wire_transfer
        ,replace(customers.metadata:"cws-monthly-sub-intent-wire-transfer",'/','') as cws_monthly_sub_intent_wire_transfer
    FROM ANALYTICS.stripe_raw.customers
        
)
select contactfirstname, contactlastname , bc.first_name, bc.last_name
from 
    customers c
    left join  RAW.blapi.customers bc on c.id = bc.stripe_id
where contactfirstname <> bc.first_name
;
```

Note that after merge, the stripe customer model must run in full refresh in order to fix existing records with incorrect first name/last name.