### PR TITLE
Hotfix: use old column name

### DIFF
--- a/transform/snowflake-dbt/models/blapi/customers_with_cloud_paid_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_cloud_paid_subs.sql
@@ -25,7 +25,7 @@ with current_subscriptions AS(
                 current_subscriptions.id)
         AS opportunity_external_id,
         customers.email,
-        customers.contactfirstname,
+        customers.contactfirstname as first_name,
         coalesce(NULLIF(TRIM(customers.contactlastname), ''), customers.email) as last_name,
         CASE WHEN SPLIT_PART(customers.email, '@', 2) = 'gmail.com' 
         THEN NULL        


### PR DESCRIPTION
#### Summary

Reverts column name to the one originally used from the blapi table.

Fixes following errors:
```
12:37:34  Database Error in model freemium_contact (models/hightouch/freemium/professional_subscription/freemium_contact.sql)
12:37:34    000904 (42000): SQL compilation error: error line 24 at position 8
12:37:34    invalid identifier 'CUSTOMERS_WITH_CLOUD_PAID_SUBS.FIRST_NAME'
12:37:34    compiled SQL at target/run/mm_snowflake/models/hightouch/freemium/professional_subscription/freemium_contact.sql
12:37:34  
12:37:34  Database Error in model freemium_contact_update (models/hightouch/freemium/professional_subscription/freemium_contact_update.sql)
12:37:34    000904 (42000): SQL compilation error: error line 24 at position 8
12:37:34    invalid identifier 'CUSTOMERS_WITH_CLOUD_PAID_SUBS.FIRST_NAME'
12:37:34    compiled SQL at target/run/mm_snowflake/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
````