### PR TITLE
Hotfix: ignore invalid ids

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/web_app/platform/int_mm_telemetry_prod_performance_events.sql
+++ b/transform/mattermost-analytics/models/intermediate/web_app/platform/int_mm_telemetry_prod_performance_events.sql
@@ -6,9 +6,15 @@
     })
 }}
 
-SELECT {{ dbt_utils.star(ref('stg_mm_telemetry_prod__performance_events')) }} FROM 
-{{ ref('stg_mm_telemetry_prod__performance_events') }}
-
+SELECT
+    {{ dbt_utils.star(ref('stg_mm_telemetry_prod__performance_events')) }}
+FROM
+    {{ ref('stg_mm_telemetry_prod__performance_events') }}
+WHERE
+    id not in (
+        'd\';waitfor/**/delay\'0:0:0\'/**/--/**/',
+        's\');waitfor/**/delay\'0:0:0\'/**/--/**/'
+    )
 {% if is_incremental() %}
-    WHERE received_at > (SELECT MAX(received_at) FROM {{ this }}) 
-    {% endif %}
+    and received_at > (SELECT MAX(received_at) FROM {{ this }})
+{% endif %}


### PR DESCRIPTION
#### Summary

Ignore duplicate ids. These ids are malformed. 

Note that this is a quick fix. An improvement would be to clean performance data before making them available downstream.

A full refresh might be required to fix the issue.