### PR TITLE
Chore: increase timeout for new project nightly

### DIFF
--- a/dags/transformation/dbt_nightly.py
+++ b/dags/transformation/dbt_nightly.py
@@ -91,7 +91,8 @@ dbt_run_cloud_mattermost_analytics_nightly = KubernetesPodOperator(
         SNOWFLAKE_TRANSFORM_SCHEMA,
         SSH_KEY,
     ],
-    env_vars=env_vars,
+    # Set timeout to 2.5 hours
+    env_vars={**env_vars, "DBT_JOB_TIMEOUT": "9000"},
     arguments=["python -m  utils.run_dbt_cloud_job 254981 \"Mattermost Analytics DBT nightly\""],
     dag=dag,
 )


### PR DESCRIPTION
#### Summary

Running nightly for mattermost-analytics was configured to wait for 45 minutes. The run is succeeding, but only after ~ 2 hours 20 mins. This leads to a false alert being triggered. This PR adjusts the timeout in order to reduce false alerts.
