### PR TITLE
Hotfix: Ignore record with invalid data

### DIFF
--- a/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
+++ b/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
@@ -73,4 +73,12 @@ renamed as (
 
 )
 
-select * from renamed
+select
+    *
+from
+    renamed
+where
+    trial_request_id not in (
+        -- Invalid records
+        'uu6zjmatt38wzmhphs57rsbbro'
+    )

--- a/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
+++ b/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
@@ -80,5 +80,11 @@ from
 where
     trial_request_id not in (
         -- Invalid records
-        'uu6zjmatt38wzmhphs57rsbbro'
+        'qzd5g81daibrxqfbppoeg1mezo',
+        'uu6zjmatt38wzmhphs57rsbbro',
+        'xchakhn3gfrdmq88m3apa7ht9r',
+        'nx6boyf3zjbctdkdpmdqyqtzeo',
+        's8j1frxu57bfx8x775ijabsnya',
+        'zka8qtk33pfopdh99fwrie6qth',
+        'fuyjomkuw389ux6mq19g7eiw3c'
     )


### PR DESCRIPTION
#### Summary

These records seems to be from a security researcher. Values are strange. For example first name is `contact_first_name<img/src=c>` and last name is `contact_last_name`, while company size is equal to `100,000,000`.

Manually ignoring those records for now.
