### PR TITLE
Hotfix: add proper tag to utilities

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -76,7 +76,7 @@ models:
     utilities:
       +materialized: table
       schema: utilities
-      tags: [ 'utilities' ]
+      tags: ['utilities', 'hourly']
 
   dbt_project_evaluator:
     schema:


### PR DESCRIPTION
#### Summary

`utilities` model directory didn't contain proper tag, so it wasn't picked for execution. This resulted in a failing nightly run.

Using tag `hourly` since `utilities` are 
- meant for things that are fast in regards of execution time,
- might be required by both hourly and nightly builds.