### PR TITLE
Hotfix: fix bearer prefix for hightouch authentication

### DIFF
--- a/dags/general/monitoring.py
+++ b/dags/general/monitoring.py
@@ -45,7 +45,7 @@ with DAG(
         http_conn_id="hightouch",
         method="GET",
         endpoint=Variable.get('hightouch_syncs_endpoint'),
-        headers={'Content-Type': 'application/json', 'Authorization': Variable.get('hightouch_secret')},
+        headers={'Content-Type': 'application/json', 'Authorization': f"Bearer {Variable.get('hightouch_secret')}"},
         xcom_push=True,
     )
     resolve_hightouch_status = PythonOperator(


### PR DESCRIPTION
#### Summary

Hightouch uses [bearer auth](https://hightouch.com/docs/api-reference#section/Authentication/bearerAuth). Current setup was pushing `Bearer ` prefix as part of the secret. Updating the code to make the need for this explicit and simplify secret management.