### PR TITLE
Chore: Update dependencies to latest version

### DIFF
--- a/transform/mattermost-analytics/packages.yml
+++ b/transform/mattermost-analytics/packages.yml
@@ -1,7 +1,7 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 1.0.0
+    version: 1.1.1
   - package: dbt-labs/codegen
-    version: 0.9.0
+    version: 0.10.0
   - package: dbt-labs/dbt_project_evaluator
-    version: 0.4.1
+    version: 0.6.2


### PR DESCRIPTION
#### Summary

Dependencies of `mattermost-analytics` were getting outdated. This PR brings all dependencies to latest version.