### PR TITLE
Hotfix: fix reference to parse_qs function

### DIFF
--- a/transform/mattermost-analytics/models/staging/diagnostics/base/base_diagnostics__log_entries.sql
+++ b/transform/mattermost-analytics/models/staging/diagnostics/base/base_diagnostics__log_entries.sql
@@ -1,8 +1,3 @@
-{{config({
-    "materialized": "table",
-    "snowflake_warehouse": "transform_l"
-  })
-}}
 with source as (
 
     select * from {{ source('diagnostics', 'log_entries') }}

--- a/transform/mattermost-analytics/models/staging/diagnostics/base/base_diagnostics__log_entries.sql
+++ b/transform/mattermost-analytics/models/staging/diagnostics/base/base_diagnostics__log_entries.sql
@@ -10,7 +10,7 @@ renamed as (
         to_timestamp(logdate|| ' ' || logtime) as log_at,
         edge,
         cip as server_ip,
-        parse_qs(cs_uri_query) as _parsed_cs_uri_query,
+        mattermost_analytics.parse_qs(cs_uri_query) as _parsed_cs_uri_query,
         _parsed_cs_uri_query:id::varchar as server_id,
         _parsed_cs_uri_query:b::varchar as _security_build,
         split_part(_security_build, '.', 1) as version_major,

--- a/transform/mattermost-analytics/models/staging/diagnostics/base/base_diagnostics__log_entries.sql
+++ b/transform/mattermost-analytics/models/staging/diagnostics/base/base_diagnostics__log_entries.sql
@@ -1,3 +1,8 @@
+{{config({
+    "materialized": "table",
+    "snowflake_warehouse": "transform_l"
+  })
+}}
 with source as (
 
     select * from {{ source('diagnostics', 'log_entries') }}


### PR DESCRIPTION
#### Summary

Fix reference to `parse_qs`. This function is created in the default schema, thus it must be referenced using the correct schema name.
