### PR TITLE
Chore: align surrogate key definition

### DIFF
--- a/transform/mattermost-analytics/models/marts/product/fct_active_users.sql
+++ b/transform/mattermost-analytics/models/marts/product/fct_active_users.sql
@@ -9,7 +9,7 @@
 
 with metrics as (
     select
-        {{ dbt_utils.generate_surrogate_key(['activity_date', 'server_id']) }} AS daily_server_id
+        {{ dbt_utils.generate_surrogate_key(['server_id', 'activity_date']) }} AS daily_server_id
         , activity_date
         , server_id
     {% for metric, column in column_map.items() %}


### PR DESCRIPTION
#### Summary

Align surrogate key  definition in `fct_active_users` to be `<server id>, <date>` from `<date>, <server id>`. The reason for going with this approach is that all other models using this pair as surrogate key use  `<server id>, <date>` . 