### PR TITLE
MM-48421: fix bug with null being return in select in

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/servers/int_excludable_servers.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/int_excludable_servers.sql
@@ -15,8 +15,8 @@
 )
 select * from seed_file
 union all
-select * from {{ ref('int_excludable_servers_invalid_security_data') }}
+select * from {{ ref('int_excludable_servers_invalid_security_data') }} where server_id is not null
 union all
-select * from {{ ref('int_excludable_servers_cloud_installations') }}
+select * from {{ ref('int_excludable_servers_cloud_installations') }} where server_id is not null
 union all
-select * from {{ ref('int_excludable_servers_single_day_activity') }}
+select * from {{ ref('int_excludable_servers_single_day_activity') }} where server_id is not null

--- a/transform/mattermost-analytics/models/intermediate/product/servers/int_server_active_days_spined.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/int_server_active_days_spined.sql
@@ -7,7 +7,7 @@ with server_first_day_per_telemetry as (
         {{ ref('int_server_telemetry_legacy_latest_daily') }}
     where
         server_date >= '{{ var('telemetry_start_date')}}'
-        and server_id not in (select server_id from {{ ref('int_excludable_servers') }})
+        and server_id not in (select server_id from {{ ref('int_excludable_servers') }} where server_id is not null)
     group by
         server_id
 
@@ -21,7 +21,7 @@ with server_first_day_per_telemetry as (
         {{ ref('int_server_telemetry_latest_daily') }}
     where
         server_date >= '{{ var('telemetry_start_date')}}'
-        and server_id not in (select server_id from {{ ref('int_excludable_servers') }})
+        and server_id not in (select server_id from {{ ref('int_excludable_servers') }} where server_id is not null)
     group by
         server_id
 
@@ -35,7 +35,7 @@ with server_first_day_per_telemetry as (
         {{ ref('int_server_security_update_latest_daily') }}
     where
         server_date >= '{{ var('telemetry_start_date')}}'
-        and server_id not in (select server_id from {{ ref('int_excludable_servers') }})
+        and server_id not in (select server_id from {{ ref('int_excludable_servers') }} where server_id is not null)
     group by
         server_id
 ), server_first_active_day as (

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_server_info.sql
@@ -27,5 +27,5 @@ from
     {{ ref('int_server_active_days_spined') }}
 where
     server_id not in (
-        select server_id from {{ ref('int_excludable_servers') }}
+        select server_id from {{ ref('int_excludable_servers') }} where server_id is not null
     )


### PR DESCRIPTION
#### Summary

Intermediate table might contain `null` as server id, causing `WHERE id NOT IN (SELECT server_id FROM...)` to exclude all rows.


