### PR TITLE
Chore: revert country codes

### DIFF
--- a/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
@@ -59,7 +59,7 @@ models:
               to: ref('country_codes')
               field: name
               config:
-                where: "country_name != ''"
+                where: "country_name not in ('', 'Viet Nam', 'Iran, Islamic Republic of')"
         tags: ['pii']
       - name: trial_start_at
         description: The starting date of the trial.

--- a/transform/mattermost-analytics/seeds/salesforce/country_codes.csv
+++ b/transform/mattermost-analytics/seeds/salesforce/country_codes.csv
@@ -108,7 +108,7 @@ IQ,Iraq
 IE,Ireland
 IM,Isle of Man
 IL,Israel
-IR,"Iran, Islamic Republic of"
+IR,Iran (Islamic Republic of)
 IT,Italy
 JM,Jamaica
 JP,Japan
@@ -240,7 +240,7 @@ UY,Uruguay
 UZ,Uzbekistan
 VU,Vanuatu
 VE,"Venezuela, Bolivarian Republic of"
-VN,Viet Nam
+VN,Vietnam
 VG,"Virgin Islands, British"
 VI,Virgin Islands (U.S.)
 WF,Wallis and Futuna


### PR DESCRIPTION
#### Summary

- [x] Revert seed file to contain list of valid country names for Salesforce ingestion.
- [x] Force ignore rows with invalid data in test.
