### PR TITLE
Chore: exclude servers with invalid ids

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/servers/_excludable_servers/_int_servers__excludable_servers__models.yml
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/_excludable_servers/_int_servers__excludable_servers__models.yml
@@ -44,3 +44,11 @@ models:
         description: The server id.
       - name: reason
         description: The reason that this server is excluded.
+
+  - name: int_excludable_servers_invalid_server_id
+    description: List of servers with invalid ids (i.e. fake telemetry, uuids etc).
+    columns:
+      - name: server_id
+        description: The server id.
+      - name: reason
+        description: The reason that this server is excluded.

--- a/transform/mattermost-analytics/models/intermediate/product/servers/_excludable_servers/int_excludable_servers_invalid_server_id.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/_excludable_servers/int_excludable_servers_invalid_server_id.sql
@@ -1,0 +1,7 @@
+select
+    server_id,
+    'Invalid server id'
+from
+    {{ ref('int_server_summary') }}
+where
+    length(server_id) <> 26

--- a/transform/mattermost-analytics/models/intermediate/product/servers/int_excludable_servers.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/int_excludable_servers.sql
@@ -20,3 +20,5 @@ union all
 select * from {{ ref('int_excludable_servers_cloud_installations') }} where server_id is not null
 union all
 select * from {{ ref('int_excludable_servers_single_day_activity') }} where server_id is not null
+union all
+select * from {{ ref('int_excludable_servers_invalid_server_id')}} where server_id is not null


### PR DESCRIPTION
#### Summary

There are invalid server ids (i.e. uuids, long strings etc). Adding a new exclusion reason.