### PR TITLE
Hotfix: increase timeout for dbt nightly

### DIFF
--- a/dags/transformation/dbt_nightly.py
+++ b/dags/transformation/dbt_nightly.py
@@ -69,7 +69,7 @@ dbt_run_cloud_nightly = KubernetesPodOperator(
         SNOWFLAKE_TRANSFORM_SCHEMA,
         SSH_KEY,
     ],
-    env_vars={**env_vars, "DBT_JOB_TIMEOUT": "3600"},
+    env_vars={**env_vars, "DBT_JOB_TIMEOUT": "4200"},
     arguments=["python -m utils.run_dbt_cloud_job 19427 \"Airflow dbt nightly\""],
     dag=dag,
 )


### PR DESCRIPTION
#### Summary

DBT nightly in old project is taking a bit more than 1 hour. The job is succeeding, but airflow job polling for status timeouts in 1 hour, falsely reporting it as failed. Temporarily increasing timeout value to `1h 10m`.