### PR TITLE
MM-54964: add server info for servers where only front end telemetry …

### DIFF
--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -28,8 +28,16 @@ with server_telemetry_summary as (
        coalesce(st.server_id, ut.server_id) as server_id,
        coalesce(st.count_is_cloud_days, 0) as count_is_cloud_days,
        coalesce(st.count_not_is_cloud_days, 0) as count_not_is_cloud_days,
-       least(st.first_activity_date, ut.first_activity_date) as first_activity_date,
-       greatest(st.last_activity_date, ut.last_activity_date) as last_activity_date
+       case
+           when st.first_activity_date is null then ut.first_activity_date
+           when ut.first_activity_date is null then st.first_activity_date
+           else least(st.first_activity_date, ut.first_activity_date)
+        end as first_activity_date,
+       case
+           when st.last_activity_date is null then ut.last_activity_date
+           when ut.last_activity_date is null then st.last_activity_date
+           else greatest(st.last_activity_date, ut.last_activity_date)
+        end as last_activity_date
     from
         server_telemetry_summary st
         full outer join user_telemetry_summary ut on st.server_id = ut.server_id

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -74,5 +74,5 @@ select
     si.last_activity_date
 from
     server_info si
-    join latest_values l on si.server_id = l.server_id
+    left join latest_values l on si.server_id = l.server_id
     left join latest_cloud_subscription s on l.installation_id = s.installation_id

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -1,5 +1,5 @@
-with server_info as (
-    -- Summarize server hosting type information
+with server_telemetry_summary as (
+    -- Summarize server hosting type information based on server-sent info
     select
         server_id,
         -- Aggregate is cloud in order to validate whether the server is cloud or not
@@ -11,6 +11,28 @@ with server_info as (
          {{ ref('int_server_active_days_spined') }}
     group by
         server_id
+), user_telemetry_summary as (
+    select
+        server_id,
+        -- No information about the type of the server from user telemetry
+        min(activity_date) as first_activity_date,
+        max(activity_date) as last_activity_date
+    from
+         {{ ref('int_user_active_days_spined') }}
+    where
+        is_active_today
+    group by
+        server_id
+), server_info as (
+   select
+       coalesce(st.server_id, ut.server_id) as server_id,
+       coalesce(st.count_is_cloud_days, 0) as count_is_cloud_days,
+       coalesce(st.count_not_is_cloud_days, 0) as count_not_is_cloud_days,
+       least(st.first_activity_date, ut.first_activity_date) as first_activity_date,
+       greatest(st.last_activity_date, ut.last_activity_date) as last_activity_date
+    from
+        server_telemetry_summary st
+        full outer join user_telemetry_summary ut on st.server_id = ut.server_id
 ), latest_values as (
     -- Get latest values for installation id (if exists) and full version string
     select


### PR DESCRIPTION
…exists
#### Summary

Servers with front-end only telemetry are not appearing in server info. This PR adds them. A few things to note:
- Since these servers have front-end only telemetry, it's currently impossible to know whether they are cloud or self hosted (most likely self-hosted). They should be reported as `Unknown` for now.
- If both front-end and back-end telemetry is available, the minimum activity date of the two telemetries will be used for first activity date. Similarly, the greatest value of the two telemetries will be used for last activity date.

> This PR is required in order to have a conformed server_info dimensions. A different approach would be to have a common spine for server and user telemetry activity. This however would require a heavier refactoring. It might however simplify the intermediate layer a bit. My suggestion is to go with this PR as a quick fix in order to handlle nulls that might appear in `hosting_type` when exploring active users. We can then investigate the common spine when we have a bit more time.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54964