### PR TITLE
Chore: add tests to check that server info is available for all rows in facts

### DIFF
--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -27,6 +27,9 @@ models:
         description: The server's unique id.
         tests:
           - not_null
+          - relationships:
+              to: ref('dim_server_info')
+              field: server_id
       - name: daily_active_users
         description: The number of unique active users for the given server and date.
       - name: weekly_active_users
@@ -222,6 +225,9 @@ models:
         description: The server's unique id.
         tests:
           - not_null
+          - relationships:
+              to: ref('dim_server_info')
+              field: server_id
       - name: version_id
         description: The id of the server's version.
         tests:

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -8,7 +8,7 @@ with server_telemetry_summary as (
         min(activity_date) as first_activity_date,
         max(activity_date) as last_activity_date
     from
-         {{ ref('int_server_active_days_spined') }}
+        {{ ref('int_server_active_days_spined') }}
     group by
         server_id
 ), user_telemetry_summary as (
@@ -18,7 +18,7 @@ with server_telemetry_summary as (
         min(activity_date) as first_activity_date,
         max(activity_date) as last_activity_date
     from
-         {{ ref('int_user_active_days_spined') }}
+        {{ ref('int_user_active_days_spined') }}
     where
         is_active_today
     group by


### PR DESCRIPTION
#### Summary

Add extra tests to check that each row in active users/active server facts has a corresponding server info row.

