### PR TITLE
MM-55026: refactor releaes model

### DIFF
--- a/transform/mattermost-analytics/models/marts/release/_release__models.yml
+++ b/transform/mattermost-analytics/models/marts/release/_release__models.yml
@@ -37,7 +37,10 @@ models:
           - not_null
 
   - name: dim_fix_versions
-    description: Fix versions for the given issue.
+    description: |
+      Fix versions for the given issue. Fix versions act as "tags" for each issue, essentially linking issues to the 
+      first release they will be part of. A common use case is for tagging which Cloud or Self-hosted release will 
+      contain a bug fix.
 
     columns:
       - name: issue_id
@@ -84,8 +87,10 @@ models:
               values: [ 'Mobile', 'Desktop', 'Playbooks', 'IR', 'Cloud', 'Apps', null ]
       - name: cloud_release_date
         description: The Cloud release date. Not null only when component is Cloud.
-      - name: planned_release_date
-        description: The date that the release in semver column is planned for. Applies only for Cloud/OnPrem.
+      - name: is_on_prem_release
+        description: Whether this fix version refers to an on prem release.
+      - name: is_cloud_release
+        description: Whether this fix version refers to a cloud release.
 
   - name: fct_issues_daily_snapshot
     description: Issues snapshot facts. Stores a snapshot of all issues, updated daily.
@@ -131,3 +136,33 @@ models:
               min_value: 0
               inclusive: true
 
+
+  - name: dim_releases
+    description: List of known releases.
+
+    columns:
+      - name: version
+        description: The semver string (`major.minor.patch` format).
+        tests:
+          - not_null
+          - unique
+      - name: short_version
+        description: The short format of the version, omitting patch (example `v6.3`).
+        tests:
+          - not_null
+      - name: version_major
+        description: The major version of the server at the time the event was submitted.
+      - name: version_minor
+        description: The minor version of the server at the time the event was submitted.
+      - name: version_patch
+        description: The patch version of the server at the time the event was submitted.
+      - name: planned_release_date
+        description: The planned date for the release.
+      - name: is_supported
+        description: Whether the version is supported or not.
+      - name: release_number
+        description: The issue's release number.
+      - name: actual_release_date
+        description: The date the release was actually cut.
+      - name: rc1_date
+        description: The date RC1 was cut.

--- a/transform/mattermost-analytics/models/marts/release/_release__models.yml
+++ b/transform/mattermost-analytics/models/marts/release/_release__models.yml
@@ -92,9 +92,10 @@ models:
       - name: is_cloud_release
         description: Whether this fix version refers to a cloud release.
     tests:
-      - dbt_utils.expression_is_true:
-          name: assert_either_on_prem_or_cloud_release
-          description: A fix version can only refer to a cloud release OR on an on-prem release, not both.
+      - name: assert_either_on_prem_or_cloud_release
+        description:
+          A fix version can only refer to a cloud release OR on an on-prem release, not both.
+        dbt_utils.expression_is_true:
           expression: "not (is_on_prem_release and is_cloud_release)"
 
 

--- a/transform/mattermost-analytics/models/marts/release/_release__models.yml
+++ b/transform/mattermost-analytics/models/marts/release/_release__models.yml
@@ -92,10 +92,9 @@ models:
       - name: is_cloud_release
         description: Whether this fix version refers to a cloud release.
     tests:
-      - name: assert_either_on_prem_or_cloud_release
-        description:
-          A fix version can only refer to a cloud release OR on an on-prem release, not both.
-        dbt_utils.expression_is_true:
+      -  dbt_utils.expression_is_true:
+          # A fix version can only refer to a cloud release OR on an on-prem release, not both.
+          name: assert_either_on_prem_or_cloud_release
           expression: "not (is_on_prem_release and is_cloud_release)"
 
 

--- a/transform/mattermost-analytics/models/marts/release/_release__models.yml
+++ b/transform/mattermost-analytics/models/marts/release/_release__models.yml
@@ -148,8 +148,6 @@ models:
           - unique
       - name: short_version
         description: The short format of the version, omitting patch (example `v6.3`).
-        tests:
-          - not_null
       - name: version_major
         description: The major version of the server at the time the event was submitted.
       - name: version_minor

--- a/transform/mattermost-analytics/models/marts/release/_release__models.yml
+++ b/transform/mattermost-analytics/models/marts/release/_release__models.yml
@@ -88,9 +88,13 @@ models:
       - name: cloud_release_date
         description: The Cloud release date. Not null only when component is Cloud.
       - name: is_on_prem_release
-        description: Whether this fix version refers to an on prem release.
+        description: |
+          Whether this fix version refers to an on prem release. Examples of on prem fix versions are
+          `v5.15 (Sept 2019)` and `v9.0 (September 2023)`.
       - name: is_cloud_release
-        description: Whether this fix version refers to a cloud release.
+        description: |
+          Whether this fix version refers to a cloud release. Examples of Cloud fix versions are 
+          `Cloud 02/09/23 -> v7.9` and `Cloud 4/27/22 -> v6.7 May'22`.
     tests:
       -  dbt_utils.expression_is_true:
           # A fix version can only refer to a cloud release OR on an on-prem release, not both.

--- a/transform/mattermost-analytics/models/marts/release/_release__models.yml
+++ b/transform/mattermost-analytics/models/marts/release/_release__models.yml
@@ -91,6 +91,12 @@ models:
         description: Whether this fix version refers to an on prem release.
       - name: is_cloud_release
         description: Whether this fix version refers to a cloud release.
+    tests:
+      - dbt_utils.expression_is_true:
+          name: assert_either_on_prem_or_cloud_release
+          description: A fix version can only refer to a cloud release OR on an on-prem release, not both.
+          expression: "not (is_on_prem_release and is_cloud_release)"
+
 
   - name: fct_issues_daily_snapshot
     description: Issues snapshot facts. Stores a snapshot of all issues, updated daily.

--- a/transform/mattermost-analytics/models/marts/release/dim_fix_versions.sql
+++ b/transform/mattermost-analytics/models/marts/release/dim_fix_versions.sql
@@ -3,12 +3,12 @@
 -- Implement filtering on this layer as it's only used here.
 select
     issue_id,
-    value:name::string as fix_version_name,
+    value:name::string as fix_version,
     -- Break down different variations of target version
-    regexp_substr(fix_version_name, 'v\\d+\.\\d+') as semver,
-    regexp_substr(fix_version_name, 'v(\\d+)', 1, 1, 'e', 1)::int as version_major,
-    regexp_substr(fix_version_name, '\\.(\\d+)', 1, 1, 'e', 1)::int as version_minor,
-    regexp_substr(fix_version_name, '\\.(\\d+)', 1, 2, 'e', 1)::int as version_patch,
+    regexp_substr(fix_version, 'v\\d+\.\\d+') as semver,
+    regexp_substr(fix_version, 'v(\\d+)', 1, 1, 'e', 1)::int as version_major,
+    regexp_substr(fix_version, '\\.(\\d+)', 1, 1, 'e', 1)::int as version_minor,
+    regexp_substr(fix_version, '\\.(\\d+)', 1, 2, 'e', 1)::int as version_patch,
     case
         when fix_version_name ilike '%mobile%' then 'Mobile'
         when fix_version_name ilike '%desktop%' then 'Desktop'
@@ -18,15 +18,15 @@ select
         when fix_version_name ilike '%apps%' then 'Apps'
     end as component,
     to_date(regexp_substr(fix_version_name, '\\d{2}/\\d{2}/\\d{2}'), 'mm/dd/yy') as cloud_release_date,
-    fix_version_name like any (
+    fix_version like any (
         {%- for month in months %}
             'v%({{month}}%)'{%- if not loop.last %},{% endif -%}
         {% endfor %}
     ) as is_on_prem_release,
-    fix_version_name like 'Cloud%v%' as is_cloud_release
+    fix_version like 'Cloud%v%' as is_cloud_release
 from
     {{ ref('stg_mattermost_jira__issues') }},
     lateral flatten(input => fix_versions)
 where
     -- Keep only relevant fix versions - ones that contain a version in the form `v[major].[minor]`
-    regexp_like(fix_version_name, '.*v\\d+\.\\d+.*', 'i')
+    regexp_like(fix_version, '.*v\\d+\.\\d+.*', 'i')

--- a/transform/mattermost-analytics/models/marts/release/dim_fix_versions.sql
+++ b/transform/mattermost-analytics/models/marts/release/dim_fix_versions.sql
@@ -22,7 +22,7 @@ select
         {%- for month in months %}
             'v%({{month}}%)'{%- if not loop.last %},{% endif -%}
         {% endfor %}
-    ) as is_on_prem_release,
+    ) and component is null as is_on_prem_release,
     fix_version like 'Cloud%v%' as is_cloud_release
 from
     {{ ref('stg_mattermost_jira__issues') }},

--- a/transform/mattermost-analytics/models/marts/release/dim_fix_versions.sql
+++ b/transform/mattermost-analytics/models/marts/release/dim_fix_versions.sql
@@ -1,42 +1,32 @@
+{% set months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] %}
 
-WITH unparsed_fix_versions AS (
-    -- Implement filtering on this layer as it's only used here.
-    SELECT
-        issue_id,
-        value:name::string as fix_version_name,
-        -- Break down different variations of target version
-        REGEXP_SUBSTR(fix_version_name, 'v\\d+\.\\d+') AS semver,
-        REGEXP_SUBSTR(fix_version_name, 'v(\\d+)', 1, 1, 'e', 1)::int AS version_major,
-        REGEXP_SUBSTR(fix_version_name, '\\.(\\d+)', 1, 1, 'e', 1)::int AS version_minor,
-        REGEXP_SUBSTR(fix_version_name, '\\.(\\d+)', 1, 2, 'e', 1)::int AS version_patch,
-        CASE
-            WHEN fix_version_name ILIKE '%mobile%' THEN 'Mobile'
-            WHEN fix_version_name ILIKE '%desktop%' THEN 'Desktop'
-            WHEN fix_version_name ILIKE '%playbooks%' THEN 'Playbooks'
-            WHEN fix_version_name ILIKE '%ir%' THEN 'IR'
-            WHEN fix_version_name ILIKE '%cloud%' THEN 'Cloud'
-            WHEN fix_version_name ILIKE '%apps%' THEN 'Apps'
-        END AS component,
-        TO_DATE(REGEXP_SUBSTR(fix_version_name, '\\d{2}/\\d{2}/\\d{2}'), 'mm/dd/yy') AS cloud_release_date
-    FROM
-        {{ ref('stg_mattermost_jira__issues') }},
-        LATERAL FLATTEN(INPUT => fix_versions)
-    WHERE
-        -- Keep only relevant fix versions - ones that contain a version in the form `v[major].[minor]`
-        REGEXP_LIKE(fix_version_name, '.*v\\d+\.\\d+.*', 'i')
-)
-SELECT
-    fv.issue_id,
-    fv.fix_version_name AS fix_version,
-    fv.semver,
-    fv.version_major,
-    fv.version_minor,
-    fv.version_patch,
-    fv.component,
-    fv.cloud_release_date,
-    rd.planned_release_date
-FROM
-    unparsed_fix_versions fv
-    -- Add planned release date by looking up dates ONLY for Cloud and On Prem releases)
-    LEFT JOIN {{ ref('stg_mattermost__version_release_dates') }} rd
-        ON fv.semver = rd.short_version AND (fv.component IS NULL OR fv.component = 'Cloud')
+-- Implement filtering on this layer as it's only used here.
+select
+    issue_id,
+    value:name::string as fix_version_name,
+    -- Break down different variations of target version
+    regexp_substr(fix_version_name, 'v\\d+\.\\d+') as semver,
+    regexp_substr(fix_version_name, 'v(\\d+)', 1, 1, 'e', 1)::int as version_major,
+    regexp_substr(fix_version_name, '\\.(\\d+)', 1, 1, 'e', 1)::int as version_minor,
+    regexp_substr(fix_version_name, '\\.(\\d+)', 1, 2, 'e', 1)::int as version_patch,
+    case
+        when fix_version_name ilike '%mobile%' then 'Mobile'
+        when fix_version_name ilike '%desktop%' then 'Desktop'
+        when fix_version_name ilike '%playbooks%' then 'Playbooks'
+        when fix_version_name ilike '%ir%' then 'IR'
+        when fix_version_name ilike '%cloud%' then 'Cloud'
+        when fix_version_name ilike '%apps%' then 'Apps'
+    end as component,
+    to_date(regexp_substr(fix_version_name, '\\d{2}/\\d{2}/\\d{2}'), 'mm/dd/yy') as cloud_release_date,
+    fix_version_name like any (
+        {%- for month in months %}
+            'v%({{month}}%)'{%- if not loop.last %},{% endif -%}
+        {% endfor %}
+    ) as is_on_prem_release,
+    fix_version_name like 'Cloud%v%' as is_cloud_release
+from
+    {{ ref('stg_mattermost_jira__issues') }},
+    lateral flatten(input => fix_versions)
+where
+    -- Keep only relevant fix versions - ones that contain a version in the form `v[major].[minor]`
+    regexp_like(fix_version_name, '.*v\\d+\.\\d+.*', 'i')

--- a/transform/mattermost-analytics/models/marts/release/dim_fix_versions.sql
+++ b/transform/mattermost-analytics/models/marts/release/dim_fix_versions.sql
@@ -10,14 +10,14 @@ select
     regexp_substr(fix_version, '\\.(\\d+)', 1, 1, 'e', 1)::int as version_minor,
     regexp_substr(fix_version, '\\.(\\d+)', 1, 2, 'e', 1)::int as version_patch,
     case
-        when fix_version_name ilike '%mobile%' then 'Mobile'
-        when fix_version_name ilike '%desktop%' then 'Desktop'
-        when fix_version_name ilike '%playbooks%' then 'Playbooks'
-        when fix_version_name ilike '%ir%' then 'IR'
-        when fix_version_name ilike '%cloud%' then 'Cloud'
-        when fix_version_name ilike '%apps%' then 'Apps'
+        when fix_version ilike '%mobile%' then 'Mobile'
+        when fix_version ilike '%desktop%' then 'Desktop'
+        when fix_version ilike '%playbooks%' then 'Playbooks'
+        when fix_version ilike '%ir%' then 'IR'
+        when fix_version ilike '%cloud%' then 'Cloud'
+        when fix_version ilike '%apps%' then 'Apps'
     end as component,
-    to_date(regexp_substr(fix_version_name, '\\d{2}/\\d{2}/\\d{2}'), 'mm/dd/yy') as cloud_release_date,
+    to_date(regexp_substr(fix_version, '\\d{2}/\\d{2}/\\d{2}'), 'mm/dd/yy') as cloud_release_date,
     fix_version like any (
         {%- for month in months %}
             'v%({{month}}%)'{%- if not loop.last %},{% endif -%}

--- a/transform/mattermost-analytics/models/marts/release/dim_labels.sql
+++ b/transform/mattermost-analytics/models/marts/release/dim_labels.sql
@@ -1,6 +1,6 @@
-SELECT
+select
      issue_id,
      value::string as label
-FROM
+from
     {{ ref('stg_mattermost_jira__issues') }},
-    LATERAL FLATTEN(INPUT => labels)
+    lateral FLATTEN(INPUT => labels)

--- a/transform/mattermost-analytics/models/marts/release/dim_projects.sql
+++ b/transform/mattermost-analytics/models/marts/release/dim_projects.sql
@@ -1,4 +1,4 @@
-SELECT
+select
     {{ dbt_utils.star(ref('stg_mattermost_jira__projects')) }}
-FROM
+from
     {{ ref('stg_mattermost_jira__projects') }}

--- a/transform/mattermost-analytics/models/marts/release/dim_releases.sql
+++ b/transform/mattermost-analytics/models/marts/release/dim_releases.sql
@@ -1,0 +1,4 @@
+select
+    {{ dbt_utils.star(ref('stg_mattermost__version_release_dates'))}}
+from
+    {{ ref('stg_mattermost__version_release_dates') }}

--- a/transform/mattermost-analytics/models/marts/release/fct_issues_daily_snapshot.sql
+++ b/transform/mattermost-analytics/models/marts/release/fct_issues_daily_snapshot.sql
@@ -1,14 +1,14 @@
-SELECT
+select
     issue_id,
     issue_key,
     project_id,
     created_at,
-    CASE
-        WHEN status_name IN ('Closed', 'Done') THEN updated_at
-    END AS closed_at,
-    issue_type_name AS issue_type,
-    status_name AS status,
-    resolution_name AS resolution,
-    {{ datediff("created_at", "closed_at", "day") }} AS lead_time_in_days
-FROM
+    case
+        when status_name in ('Closed', 'Done') then updated_at
+    end as closed_at,
+    issue_type_name as issue_type,
+    status_name as status,
+    resolution_name as resolution,
+    {{ datediff("created_at", "closed_at", "day") }} as lead_time_in_days
+from
     {{ ref('stg_mattermost_jira__issues') }}

--- a/transform/mattermost-analytics/models/staging/mattermost/_mattermost__models.yml
+++ b/transform/mattermost-analytics/models/staging/mattermost/_mattermost__models.yml
@@ -15,6 +15,12 @@ models:
         description: The short format of the version, omitting patch (example `v6.3`).
         tests:
           - not_null
+      - name: version_major
+        description: The major version of the server at the time the event was submitted.
+      - name: version_minor
+        description: The minor version of the server at the time the event was submitted.
+      - name: version_patch
+        description: The patch version of the server at the time the event was submitted.
       - name: planned_release_date
         description: The planned date for the release.
         tests:
@@ -27,3 +33,7 @@ models:
         description: The issue's release number.
         tests:
           - not_null
+      - name: actual_release_date
+        description: The date the release was actually cut.
+      - name: rc1_date
+        description: The date RC1 was cut.

--- a/transform/mattermost-analytics/models/staging/mattermost/_mattermost__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mattermost/_mattermost__sources.yml
@@ -36,6 +36,8 @@ sources:
             description: The date RC1 was cut for current version.
         tests:
           - dbt_utils.expression_is_true:
+              name: assert_rc1_cut_before_release
+              description: Release date must be cut before release.
               expression: "release_date > rc1_date"
               config:
                 where: "rc1_date is not null"

--- a/transform/mattermost-analytics/models/staging/mattermost/_mattermost__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mattermost/_mattermost__sources.yml
@@ -12,11 +12,31 @@ sources:
 
     tables:
       - name: version_release_dates
+        description: |
+          List of release dates per version. Also includes extra metadata.
+          
+          > Note that this is not a real source, but a reference to the seed file in `snowflake-dbt` project. It is
+          > configured this way in order to avoid replicating and maintaining the seed file in two projects.
         columns:
           - name: version
+            description: The semantic version of the release.
             tests:
               - unique
               - not_null
           - name: release_date
+            description: The planned date for the release.
           - name: supported
+            description: Whether the release is currently supported.
           - name: release_number
+            tests:
+              - unique
+              - not_null
+          - name: actual_release_date
+            description: The date that the release happened. If empty it's the same date as `release_date`.
+          - name: rc1_date
+            description: The date RC1 was cut for current version.
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: "release_date > rc1_date"
+              config:
+                where: "rc1_date is not null"

--- a/transform/mattermost-analytics/models/staging/mattermost/_mattermost__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mattermost/_mattermost__sources.yml
@@ -35,10 +35,8 @@ sources:
           - name: rc1_date
             description: The date RC1 was cut for current version.
         tests:
-          - name: assert_rc1_cut_before_release
-            description:
-              Release date must be cut before release.
-            dbt_utils.expression_is_true:
+          - dbt_utils.expression_is_true:
+              name: assert_rc1_cut_before_release
               expression: "release_date > rc1_date"
               config:
                 where: "rc1_date is not null"

--- a/transform/mattermost-analytics/models/staging/mattermost/_mattermost__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mattermost/_mattermost__sources.yml
@@ -35,9 +35,10 @@ sources:
           - name: rc1_date
             description: The date RC1 was cut for current version.
         tests:
-          - dbt_utils.expression_is_true:
-              name: assert_rc1_cut_before_release
-              description: Release date must be cut before release.
+          - name: assert_rc1_cut_before_release
+            description:
+              Release date must be cut before release.
+            dbt_utils.expression_is_true:
               expression: "release_date > rc1_date"
               config:
                 where: "rc1_date is not null"

--- a/transform/mattermost-analytics/models/staging/mattermost/_mattermost__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mattermost/_mattermost__sources.yml
@@ -29,7 +29,6 @@ sources:
             description: Whether the release is currently supported.
           - name: release_number
             tests:
-              - unique
               - not_null
           - name: actual_release_date
             description: The date that the release happened. If empty it's the same date as `release_date`.

--- a/transform/mattermost-analytics/models/staging/mattermost/stg_mattermost__version_release_dates.sql
+++ b/transform/mattermost-analytics/models/staging/mattermost/stg_mattermost__version_release_dates.sql
@@ -1,14 +1,19 @@
-WITH rd AS (
-    SELECT
+with rd as (
+    select
         *
-    FROM
+    from
         {{ source('mattermost', 'version_release_dates') }}
 )
-SELECT
-    version AS version,
-    'v' || REGEXP_SUBSTR(version, '^\\d+\\.\\d+') AS short_version,
-    release_date::DATE AS planned_release_date,
-    supported::BOOLEAN AS is_supported,
-    release_number::INT AS release_number
-FROM
+select
+    version,
+    'v' || REGEXP_SUBSTR(version, '^\\d+\\.\\d+') as short_version,
+    split_part(version, '.', 1) as version_major,
+    split_part(version, '.', 2) as version_minor,
+    split_part(version, '.', 3) as version_patch,
+    release_date::date as planned_release_date,
+    supported::boolean as is_supported,
+    release_number::int as release_number,
+    coalesce(actual_release_date::date, planned_release_date) as actual_release_date,
+    rc1_date::date as rc1_date
+from
     rd

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/_mm_telemetry_prod__models.yml
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/_mm_telemetry_prod__models.yml
@@ -86,9 +86,9 @@ models:
       - name: version_full
         description: The full version string of the server's semver.
       - name: version_major
-        description: The major version of the server at the time the event was submitted/
+        description: The major version of the server at the time the event was submitted.
       - name: version_minor
-        description: The minor version of the server at the time the event was submitted/
+        description: The minor version of the server at the time the event was submitted.
       - name: version_patch
         description: The patch version of the server at the time the event was submitted.
       - name: installation_id


### PR DESCRIPTION
#### Summary

Refactor release model. 
- [x] Split release from fix version dimension. The main reason is that a lot of reports rely on the release (and its metadata) rather than the fix version. Also release has a different granularity than fix version.
- [x] Tag fix version based on their text pattern in order to identify if it's a self-hosted (AKA on-prem) fix version or cloud version.
- [x] Release dimension contains extra metadata.
- [x] Minor adjustments to match recommended style. 
- [x] Extra tests for conventions on values.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55026
