### PR TITLE
Chore: add tags per directory

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -63,7 +63,7 @@ models:
         tags: ['nightly', 'product']
       web_app:
         schema: mart_web_app
-        tags: ['nightly', 'webapp'']
+        tags: ['nightly', 'webapp']
       release:
         schema: mart_release
         tags: ['nightly', 'release']

--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -57,25 +57,25 @@ models:
       tags: ['marts']
       data_eng:
         schema: mart_data_eng
-        tags: ['nightly']
+        tags: ['nightly', 'data-eng']
       product:
         schema: mart_product
-        tags: ['nightly']
+        tags: ['nightly', 'product']
       web_app:
         schema: mart_web_app
-        tags: ['nightly']
+        tags: ['nightly', 'webapp'']
       release:
         schema: mart_release
-        tags: ['nightly']
+        tags: ['nightly', 'release']
       sales:
         schema: mart_sales
-        tags: ['nightly']
+        tags: ['nightly', 'sales']
         hightouch:
           # Hightouch syncs should be as close to real time as possible.
-          tags: ['hourly']
+          tags: ['hourly', 'hightouch']
       marketing:
         schema: mart_marketing
-        tags: ['nightly']
+        tags: ['nightly', 'marketing']
     utilities:
       +materialized: table
       schema: utilities


### PR DESCRIPTION
#### Summary

Add tags to mart models. This will allow referring to mart items using `tag:<directory name>`. There are some benefits of this approach, including
- Easier to reference the output of data products. 
- Easier search in DBT docs.
- Can be used for full refresh on specific data products.
- Easier to show the full lineage of the data product. With the current tags, each individual mart model must be added in the selector string.

Gitlab is also doing [something similar](https://about.gitlab.com/handbook/business-technology/data-team/platform/dbt-guide/#tags).