### PR TITLE
MM-55026: document dashboard with exposure

### DIFF
--- a/transform/mattermost-analytics/models/marts/release/_release__exposures.yml
+++ b/transform/mattermost-analytics/models/marts/release/_release__exposures.yml
@@ -16,4 +16,4 @@ exposures:
       - ref('dim_labels')
       - ref('dim_projects')
       - ref('dim_releases')
-      - ref('fct_issues_daily_snapshots')
+      - ref('fct_issues_daily_snapshot')

--- a/transform/mattermost-analytics/models/marts/release/_release__exposures.yml
+++ b/transform/mattermost-analytics/models/marts/release/_release__exposures.yml
@@ -1,0 +1,19 @@
+version: 2
+
+exposures:
+  - name: release_quality_dashboard
+    type: dashboard
+    description: Release Quality Metrics dashboard available in Looker.
+    url: https://mattermost.looker.com/dashboards/410
+    tags:
+      - looker
+    maturity: low
+    owner:
+      name: Ioannis Foukarakis
+      email: ioannis.foukarakis@mattermost.com
+    depends_on:
+      - ref('dim_fix_versions')
+      - ref('dim_labels')
+      - ref('dim_projects')
+      - ref('dim_releases')
+      - ref('fct_issues_daily_snapshots')


### PR DESCRIPTION
### Summary

Add exposure for documenting the connection between models and the Release Quality Dashboard.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55026

