### PR TITLE
MM-55026: move next release to release

### DIFF
--- a/transform/mattermost-analytics/models/marts/release/_release__models.yml
+++ b/transform/mattermost-analytics/models/marts/release/_release__models.yml
@@ -95,16 +95,7 @@ models:
         description: |
           Whether this fix version refers to a cloud release. Examples of Cloud fix versions are 
           `Cloud 02/09/23 -> v7.9` and `Cloud 4/27/22 -> v6.7 May'22`.
-      - name: previous_release_version
-        description: |
-          The version of the last release before the fix version's release. Patch versions are ignored. 
-          For example, let's assume that known versions are `7.8`, `7.9`, `7.10`, `8.0` and `8.1`. Previous version of
-          `7.9` is `7.8`, previous version of `8.0` is `7.10` etc.
-      - name: next_release_version
-        description: |
-          The version of the release following the fix version's release. Patch versions are ignored. For example, let's
-          assume that known versions are `7.8`, `7.9`, `7.10`, `8.0` and `8.1`. Next version of `7.8` is `7.9`, next 
-          version of `7.10` is `8.0` etc.
+
     tests:
       -  dbt_utils.expression_is_true:
           # A fix version can only refer to a cloud release OR on an on-prem release, not both.

--- a/transform/mattermost-analytics/models/marts/release/_release__models.yml
+++ b/transform/mattermost-analytics/models/marts/release/_release__models.yml
@@ -95,7 +95,6 @@ models:
         description: |
           Whether this fix version refers to a cloud release. Examples of Cloud fix versions are 
           `Cloud 02/09/23 -> v7.9` and `Cloud 4/27/22 -> v6.7 May'22`.
-
     tests:
       -  dbt_utils.expression_is_true:
           # A fix version can only refer to a cloud release OR on an on-prem release, not both.
@@ -175,3 +174,14 @@ models:
         description: The date the release was actually cut.
       - name: rc1_date
         description: The date RC1 was cut.
+      - name: previous_release_version
+        description: |
+          The short version (major and minor parts) of the last release before current release. Patch versions are
+          ignored. For example, let's assume that known release versions are `7.8.0`, `7.8.1`, `7.9.0`, `7.10.0`, 
+          `8.0.0` and `8.1.0`. Previous release version of `7.9.0` is `7.8.0`, previous version of `8.0.0` is `7.10.0`
+          etc.
+      - name: next_release_version
+        description: |
+          The short version (major and minor parts) of the release following the current release. Patch versions are 
+          ignored. For example, let's assume that known release versions are `7.8.0`, `7.8.1`, `7.9.0`, `7.10.0`,
+          `8.0.0` and `8.1.0`. Next release version of `7.8.0` is `7.9.0`, next  version of `7.10.0` is `8.0.0` etc.

--- a/transform/mattermost-analytics/models/marts/release/dim_fix_versions.sql
+++ b/transform/mattermost-analytics/models/marts/release/dim_fix_versions.sql
@@ -1,59 +1,32 @@
 {% set months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] %}
 
-with release_versions as (
-    select
-        short_version,
-        lag(short_version, 1) over(order by release_number asc) as previous_release_version,
-        lag(short_version, -1) over(order by release_number asc) as next_release_version
-    from
-         {{ ref('stg_mattermost__version_release_dates') }}
-    where
-        version_patch = 0
-), fix_versions as (
-    -- Implement filtering on this layer as it's only used here.
-    select
-        issue_id,
-        value:name::string as fix_version,
-        -- Break down different variations of target version
-        regexp_substr(fix_version, 'v\\d+\.\\d+') as semver,
-        regexp_substr(fix_version, 'v(\\d+)', 1, 1, 'e', 1)::int as version_major,
-        regexp_substr(fix_version, '\\.(\\d+)', 1, 1, 'e', 1)::int as version_minor,
-        regexp_substr(fix_version, '\\.(\\d+)', 1, 2, 'e', 1)::int as version_patch,
-        case
-            when fix_version ilike '%mobile%' then 'Mobile'
-            when fix_version ilike '%desktop%' then 'Desktop'
-            when fix_version ilike '%playbooks%' then 'Playbooks'
-            when fix_version ilike '%ir%' then 'IR'
-            when fix_version ilike '%cloud%' then 'Cloud'
-            when fix_version ilike '%apps%' then 'Apps'
-        end as component,
-        to_date(regexp_substr(fix_version, '\\d{2}/\\d{2}/\\d{2}'), 'mm/dd/yy') as cloud_release_date,
-        fix_version like any (
-            {%- for month in months %}
-                'v%({{month}}%)'{%- if not loop.last %},{% endif -%}
-            {% endfor %}
-        ) and component is null as is_on_prem_release,
-        fix_version like 'Cloud%v%' as is_cloud_release
-    from
-        {{ ref('stg_mattermost_jira__issues') }},
-        lateral flatten(input => fix_versions)
-    where
-        -- Keep only relevant fix versions - ones that contain a version in the form `v[major].[minor]`
-        regexp_like(fix_version, '.*v\\d+\.\\d+.*', 'i')
-)
+-- Implement filtering on this layer as it's only used here.
 select
-    fv.issue_id,
-    fv.fix_version,
-    fv.semver,
-    fv.version_major,
-    fv.version_minor,
-    fv.version_patch,
-    fv.component,
-    fv.cloud_release_date,
-    fv.is_on_prem_release,
-    fv.is_cloud_release,
-    rv.previous_release_version,
-    rv.next_release_version
+    issue_id,
+    value:name::string as fix_version,
+    -- Break down different variations of target version
+    regexp_substr(fix_version, 'v\\d+\.\\d+') as semver,
+    regexp_substr(fix_version, 'v(\\d+)', 1, 1, 'e', 1)::int as version_major,
+    regexp_substr(fix_version, '\\.(\\d+)', 1, 1, 'e', 1)::int as version_minor,
+    regexp_substr(fix_version, '\\.(\\d+)', 1, 2, 'e', 1)::int as version_patch,
+    case
+        when fix_version ilike '%mobile%' then 'Mobile'
+        when fix_version ilike '%desktop%' then 'Desktop'
+        when fix_version ilike '%playbooks%' then 'Playbooks'
+        when fix_version ilike '%ir%' then 'IR'
+        when fix_version ilike '%cloud%' then 'Cloud'
+        when fix_version ilike '%apps%' then 'Apps'
+    end as component,
+    to_date(regexp_substr(fix_version, '\\d{2}/\\d{2}/\\d{2}'), 'mm/dd/yy') as cloud_release_date,
+    fix_version like any (
+        {%- for month in months %}
+            'v%({{month}}%)'{%- if not loop.last %},{% endif -%}
+        {% endfor %}
+    ) and component is null as is_on_prem_release,
+    fix_version like 'Cloud%v%' as is_cloud_release
 from
-    fix_versions fv
-    left join release_versions rv on fv.semver = rv.short_version and (fv. is_on_prem_release or fv.is_cloud_release)
+    {{ ref('stg_mattermost_jira__issues') }},
+    lateral flatten(input => fix_versions)
+where
+    -- Keep only relevant fix versions - ones that contain a version in the form `v[major].[minor]`
+    regexp_like(fix_version, '.*v\\d+\.\\d+.*', 'i')

--- a/transform/mattermost-analytics/models/marts/release/dim_releases.sql
+++ b/transform/mattermost-analytics/models/marts/release/dim_releases.sql
@@ -1,4 +1,17 @@
+with release_versions as (
+    select
+        short_version,
+        lag(short_version, 1) over(order by release_number asc) as previous_release_version,
+        lag(short_version, -1) over(order by release_number asc) as next_release_version
+    from
+        {{ ref('stg_mattermost__version_release_dates') }}
+    where
+        rc1_date is not null
+)
 select
-    {{ dbt_utils.star(ref('stg_mattermost__version_release_dates'))}}
+    {{ dbt_utils.star(ref('stg_mattermost__version_release_dates'))}},
+    rv.previous_release_version,
+    rv.next_release_version
 from
-    {{ ref('stg_mattermost__version_release_dates') }}
+    {{ ref('stg_mattermost__version_release_dates') }} rd
+    join release_versions rv on rd.short_version = rv.short_verion


### PR DESCRIPTION
#### Summary

Moving the logic for next/previous release to `dim_release` as it seems it's the part of the query that's needed.
Also handling patch versions for detecting next short version (major and minor), ignoring patch releases.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55026