### PR TITLE
MM-54964: remove early condition for excludable servers

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/servers/_int_servers__models.yml
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/_int_servers__models.yml
@@ -34,6 +34,11 @@ models:
         description: The version of the database.
       - name: is_enterprise_ready
         description: Whether this server is an enterprise-ready build.
+      - name: binary_edition
+        description: |
+          There are two "flavours" of the server binary:
+          - TE = Team Edition (fully open source and contains no Mattermost proprietary code).
+          - E0 = Enterprise Edition (TE + Mattermost proprietary code, and with features activated with a license).
       - name: is_cloud
         description: Whether this server is a cloud installation or not.
       - name: server_ip

--- a/transform/mattermost-analytics/models/intermediate/product/servers/int_server_active_days_spined.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/int_server_active_days_spined.sql
@@ -78,6 +78,11 @@ select
     coalesce(t.database_type, l.database_type, d.database_type) as database_type,
     coalesce(t.database_version, l.database_version) as database_version,
     coalesce(t.edition, l.edition, d.is_enterprise_ready) as is_enterprise_ready,
+    case
+        when is_enterprise_ready = true then 'E0'
+        when is_enterprise_ready = false then 'TE'
+        else 'Unknown'
+    end as binary_edition,
     t.installation_id,
     case
         when t.server_id is not null and t.installation_id is not null then true

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -90,7 +90,7 @@ models:
   - name: dim_daily_server_info
     description: |
       Daily information about the server based on telemetry data. In case of multiple values in a day, the latest
-      value is kept. Does not contain servers marked for exclusion.
+      value is kept.
     columns:
       - name: daily_server_id
         description: A unique id for each server and date

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -116,10 +116,20 @@ models:
       - name: database_version
         description: The version of the database.
       - name: is_enterprise_ready
-        description: Whether this server is an enterprise-ready build.
+        description: |
+          Whether this server is running an enterprise-ready build.
         tests:
           - not_null:
+              # A few examples return edition equal null. These examples are caught in excludable servers.
               where: "has_telemetry_data = true"
+              config:
+                severity: "warn"
+                error_if: '> 140'
+      - name: binary_edition
+        description: |
+          There are two "flavours" of the server binary:
+          - TE = Team Edition (fully open source and contains no Mattermost proprietary code).
+          - E0 = Enterprise Edition (TE + Mattermost proprietary code, and with features activated with a license).
       - name: reported_versions
         description: The unique versions reported from the server for that date.
       - name: count_reported_versions

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_server_info.sql
@@ -11,6 +11,11 @@ select
     database_type,
     database_version,
     is_enterprise_ready,
+    case
+        when is_enterprise_ready = true then 'E0'
+        when is_enterprise_ready = false then 'TE'
+        else 'Unknown'
+    end as binary_edition,
     installation_id,
     server_ip,
     installation_type,

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_server_info.sql
@@ -20,7 +20,3 @@ select
     has_diagnostics_data
 from
     {{ ref('int_server_active_days_spined') }}
-where
-    server_id not in (
-        select server_id from {{ ref('int_excludable_servers') }} where server_id is not null
-    )

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_server_info.sql
@@ -11,11 +11,7 @@ select
     database_type,
     database_version,
     is_enterprise_ready,
-    case
-        when is_enterprise_ready = true then 'E0'
-        when is_enterprise_ready = false then 'TE'
-        else 'Unknown'
-    end as binary_edition,
+    binary_edition,
     installation_id,
     server_ip,
     installation_type,


### PR DESCRIPTION
### Summary

- [x] Remove exclusion of excludable servers from `dim_daily_server_info`, as it should be performed by joining with `dim_excludable_servers`.
- [x] Label server `E0` and `TE`.
- [x] Document `E0` and `TE`.

Note that `E0`/`TE` labels are applied in the intermediate label as we might need this information to calculate the first and current server's binary edition.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54964