### PR TITLE
Hotfix: Ignore invalid record

### DIFF
--- a/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
+++ b/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
@@ -87,5 +87,6 @@ where
         's8j1frxu57bfx8x775ijabsnya',
         'zka8qtk33pfopdh99fwrie6qth',
         'fuyjomkuw389ux6mq19g7eiw3c',
-        '54mw3kph3iffzcyu7zxjfchgte'
+        '54mw3kph3iffzcyu7zxjfchgte',
+        'o8bg9yck93dodbc5wdj8masmba'
     )


### PR DESCRIPTION
#### Summary

Ignores a record where company size is invalid (`10`) and server id looks suspicious (`asdasd34dwfdsf`).

