### PR TITLE
MM-54964: add first and last server edition

### DIFF
--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -290,6 +290,16 @@ models:
         description: |
           The last date that this server was active."Active server" is defined as either telemetry or security update 
           check data are available for that date.
+      - name: first_binary_edition
+        description: The first ever reported "flavour" of the server binary.
+        tests:
+          - accepted_values:
+              values: ['TE', 'E0', 'Unknown']
+      - name: last_binary_edition
+        description: The last reported "flavour" of the server binary.
+        tests:
+          - accepted_values:
+              values: ['TE', 'E0', 'Unknown']
 
   - name: dim_daily_server_config
     description: Daily server configuration.

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -1,12 +1,14 @@
 with server_telemetry_summary as (
     select
         server_id,
-        min(activity_date) as first_activity_date,
-        max(activity_date) as last_activity_date
+        min(activity_date) over (partition by server_id) as first_activity_date,
+        max(activity_date) over (partition by server_id ) as last_activity_date,
+        first_value(binary_edition) over (partition by server_id order by activity_date asc) as first_binary_edition,
+        first_value(binary_edition) over (partition by server_id order by activity_date asc) as last_binary_edition
     from
         {{ ref('int_server_active_days_spined') }}
-    group by
-        server_id
+    -- Keep only one row per server as the current query creates duplicates
+    qualify row_number() over (partition by server_id order by server_id) = 1
 ), user_telemetry_summary as (
     select
         server_id,
@@ -30,7 +32,9 @@ with server_telemetry_summary as (
            when st.last_activity_date is null then ut.last_activity_date
            when ut.last_activity_date is null then st.last_activity_date
            else greatest(st.last_activity_date, ut.last_activity_date)
-        end as last_activity_date
+        end as last_activity_date,
+       st.first_binary_edition as first_binary_edition,
+       st.last_binary_edition as last_binary_edition
     from
         server_telemetry_summary st
         full outer join user_telemetry_summary ut on st.server_id = ut.server_id
@@ -41,7 +45,9 @@ select
     ht.installation_id,
     ht.cloud_hostname,
     si.first_activity_date,
-    si.last_activity_date
+    si.last_activity_date,
+    si.first_binary_edition,
+    si.last_binary_edition
 from
     server_info si
     left join {{ ref('int_server_hosting_type') }} ht on si.server_id = ht.server_id

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -4,7 +4,7 @@ with server_telemetry_summary as (
         min(activity_date) over (partition by server_id) as first_activity_date,
         max(activity_date) over (partition by server_id ) as last_activity_date,
         first_value(binary_edition) over (partition by server_id order by activity_date asc) as first_binary_edition,
-        last_value() over ()binary_edition) over (partition by server_id order by activity_date asc) as last_binary_edition
+        last_value(binary_edition) over (partition by server_id order by activity_date asc) as last_binary_edition
     from
         {{ ref('int_server_active_days_spined') }}
     -- Keep only one row per server as the current query creates duplicates

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -4,7 +4,7 @@ with server_telemetry_summary as (
         min(activity_date) over (partition by server_id) as first_activity_date,
         max(activity_date) over (partition by server_id ) as last_activity_date,
         first_value(binary_edition) over (partition by server_id order by activity_date asc) as first_binary_edition,
-        first_value(binary_edition) over (partition by server_id order by activity_date asc) as last_binary_edition
+        last_value() over ()binary_edition) over (partition by server_id order by activity_date asc) as last_binary_edition
     from
         {{ ref('int_server_active_days_spined') }}
     -- Keep only one row per server as the current query creates duplicates


### PR DESCRIPTION
#### Summary

Add first and last server edition. This is required for FY24/FY25 scorecards as server counts are pivoted by first server edition.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54964

