### PR TITLE
MM-54964: add server age in dim_daily_server_info

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/servers/_int_servers__models.yml
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/_int_servers__models.yml
@@ -61,6 +61,8 @@ models:
         description: |
           Total number of active registered users. Calculated as 
           `count_registered_users - count_registered_deactivated_users`.
+      - name: age_in_days
+        description: Number of days since the first telemetry received from the server.
       - name: has_telemetry_data
         description: Whether there were telemetry data reported for this server on the given date.
       - name: has_legacy_telemetry_data

--- a/transform/mattermost-analytics/models/intermediate/product/servers/_int_servers__models.yml
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/_int_servers__models.yml
@@ -63,6 +63,14 @@ models:
           `count_registered_users - count_registered_deactivated_users`.
       - name: age_in_days
         description: Number of days since the first telemetry received from the server.
+        tests:
+          # Value must be incremental and minimum value must be 0
+          - dbt_utils.sequential_values:
+              interval: 1
+              group_by_columns: ['server_id']
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
       - name: has_telemetry_data
         description: Whether there were telemetry data reported for this server on the given date.
       - name: has_legacy_telemetry_data

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -139,6 +139,8 @@ models:
               min_value: 1
               inclusive: true
               where: "has_telemetry_data or has_legacy_telemetry_data or has_diagnostics_data"
+      - name: age_in_days
+        description: The number of days since the first time the server reported telemetry.
       - name: has_telemetry_data
         description: Whether there were telemetry data reported for this server on the given date.
       - name: has_legacy_telemetry_data

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_server_info.sql
@@ -16,6 +16,7 @@ select
     server_ip,
     installation_type,
     count_reported_versions,
+    age_in_days,
     has_telemetry_data,
     has_legacy_telemetry_data,
     has_diagnostics_data


### PR DESCRIPTION
#### Summary

Add server age on daily info. It is required as part of filtering for `New monthly TEDAU` calculation.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54964