### PR TITLE
Chore: Add freshness checks

### DIFF
--- a/transform/mattermost-analytics/models/staging/mattermost2/_mattermost2__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mattermost2/_mattermost2__sources.yml
@@ -12,6 +12,11 @@ sources:
     tags:
       - segment
 
+    freshness: # Check that telemetry data have been received in the past 24 hours
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    loaded_at_field: received_at
+
     tables:
       - name: activity
       - name: channel_moderation
@@ -44,6 +49,7 @@ sources:
       - name: config_privacy
       - name: config_rate
       - name: config_rupport
+        freshness: null # do not check freshness for this table - contains a single row
       - name: config_saml
       - name: config_service
       - name: config_sql
@@ -55,6 +61,7 @@ sources:
       - name: elasticsearch
       - name: event
       - name: event_mobile
+        freshness: null # No new events for the past few years
       - name: groups
       - name: identifies
       - name: license
@@ -62,6 +69,9 @@ sources:
       - name: permissions_general
       - name: permissions_system_scheme
       - name: permissions_team_schemes
+        freshness: # Events are more sparse
+          warn_after: { count: 24, period: hour }
+          error_after: { count: 48, period: hour }
       - name: plugins
       - name: server
       - name: tracks

--- a/transform/mattermost-analytics/models/staging/mm_calls_test_go/_mm_calls_test_go__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mm_calls_test_go/_mm_calls_test_go__sources.yml
@@ -12,9 +12,15 @@ sources:
       
     tags: [ 'rudderstack' ]
 
+    freshness: # Check that telemetry data have been received in the past 24 hours
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    loaded_at_field: received_at
+
     # Omitting tables with 20 or less rows.
     tables:
       - name: call_notify_admin
+        freshness: null # No new events since 2023-01
       - name: call_ended
       - name: call_started
       - name: call_user_joined
@@ -29,6 +35,7 @@ sources:
       - name: user_share_screen
       - name: user_start_recording
       - name: user_stop_recording
+        freshness: null # Events are really sparse
       - name: user_unshare_screen
 
       - name: tracks

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/_mm_telemetry_prod__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/_mm_telemetry_prod__sources.yml
@@ -15,6 +15,12 @@ sources:
       [Webapp source](https://github.com/mattermost/mattermost-webapp/blob/master/packages/mattermost-redux/src/client/rudder.ts)
     tags: [ 'rudderstack' ]
 
+    freshness: # Check that telemetry data have been received in the past 24 hours
+      warn_after: { count: 12, period: hour }
+      error_after: { count: 24, period: hour }
+    loaded_at_field: received_at
+
+
     # Omitting tables with 20 or less rows.
     tables:
       - name: _groups
@@ -25,13 +31,16 @@ sources:
           slash commands, api calls, bot accounts, etc.
 
       - name: blocks
+        freshness: null # do not check freshness for this table - contains only a few records
 
       - name: boards
+        freshness: null # do not check freshness for this table - contains only a few records
 
       - name: channel_moderation
         description: Contains raw server-level channel data as a single row per server per timestamp.
 
       - name: config
+        freshness: null # do not check freshness for this table - contains only a few records
 
       - name: config_analytics
         description: The raw Server analytics configuration data sent to Mattermost by Telemetry-Enabled Servers.
@@ -197,6 +206,7 @@ sources:
         description: Daily server data
 
       - name: teams
+        freshness: null # do not check freshness for this table - contains only a few records
 
       - name: track_invite_email_resend
 


### PR DESCRIPTION
#### Summary

Add freshness checks for telemetry (main rudderstack, segment and calls). Checks that all telemetry source tables have ingested events in the past 12 hours (warn) or 24 hours (error and break build if not). 

This check can be added as part of the nightly build. 

It already helped identify some source tables that can be deprecated. 