### PR TITLE
MM-54964: add report table for 28-day TEDAU

### DIFF
--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -325,3 +325,26 @@ models:
         description: Whether OpenID with Gitlab OAuth is enabled
       - name: is_openid_office365_enabled
         description: Whether OpenID with Office365 OAuth is enabled
+
+
+  - name: rpt_tedau_at_day_28
+    description: Reporting table for calculating 28 TEDAU to server ratio
+    columns:
+      - name: server_id
+        description: The server's unique id.
+        tests:
+          - not_null
+          - unique
+      - name: active_since_date
+        description: The date the server was first reported as active.
+      - name: is_active_at_day_28
+        description: Whether the server is still active on day 28.
+      - name: daily_active_users
+        description: |
+          The number of unique active users for the given server on day 28 of the server's lifecycle. If there is no 
+          information about the specific date (i.e. server inactive or server hasn't reported telemetry), then it's 0.
+      - name: server_daily_active_users
+        description: |
+          Total number of active users for the past 24 hours prior to the timestamp of the event.
+          Bots and deleted users are excluded. Reported by mattermost server. If there is no 
+          information about the specific date (i.e. server inactive or server hasn't reported telemetry), then it's 0.

--- a/transform/mattermost-analytics/models/marts/product/rpt_tedau_at_day_28.sql
+++ b/transform/mattermost-analytics/models/marts/product/rpt_tedau_at_day_28.sql
@@ -6,7 +6,6 @@
     from
         {{ ref('fct_active_users') }} fct
         join {{ ref('dim_daily_server_info') }} dsi on fct.daily_server_id = dsi.daily_server_id and dsi.age_in_days = 28
-        left join {{ ref('dim_server_info') }} si on fct.server_id = si.server_id
   )
   select
       si.server_id,

--- a/transform/mattermost-analytics/models/marts/product/rpt_tedau_at_day_28.sql
+++ b/transform/mattermost-analytics/models/marts/product/rpt_tedau_at_day_28.sql
@@ -5,7 +5,7 @@
         fct.server_daily_active_users
     from
         {{ ref('fct_active_users') }} fct
-        join {{ ref('dim_daily_server_info') }} on fct.daily_server_id = dsi.daily_server_id and dsi.age_in_days = 28
+        join {{ ref('dim_daily_server_info') }} dsi on fct.daily_server_id = dsi.daily_server_id and dsi.age_in_days = 28
         left join {{ ref('dim_server_info') }} si on fct.server_id = si.server_id
   )
   select

--- a/transform/mattermost-analytics/models/marts/product/rpt_tedau_at_day_28.sql
+++ b/transform/mattermost-analytics/models/marts/product/rpt_tedau_at_day_28.sql
@@ -1,0 +1,19 @@
+  with retention_at_28 as (
+    select
+        fct.server_id,
+        fct.daily_active_users,
+        fct.server_daily_active_users
+    from
+        {{ ref('fct_active_users') }} fct
+        join {{ ref('dim_daily_server_info') }} on fct.daily_server_id = dsi.daily_server_id and dsi.age_in_days = 28
+        left join {{ ref('dim_server_info') }} si on fct.server_id = si.server_id
+  )
+  select
+      si.server_id,
+      si.first_activity_date as active_since_date,
+      r.daily_active_users is not null as is_active_at_day_28,
+      coalesce(r.daily_active_users, 0) as daily_active_users,
+      coalesce(r.server_daily_active_users, 0) as server_daily_active_users
+  from
+      {{ ref('dim_server_info') }} si
+      left join retention_at_28 r on si.server_id = r.server_id


### PR DESCRIPTION
#### Summary

Report table for calculating 28 day TEDAU to server ratio. 

> ⚠️ This PR contains a suggestion. It introduces a "report" table. This table is meant to join dimensions and fact tables together with mionimal filters and aggreagations. The suggestion is to introduce these tables whenever there are metrics that are too specific and can become challenging to implement in looker.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54964