### PR TITLE
Chore: move transform_m models to transform_l

### DIFF
--- a/transform/snowflake-dbt/models/events/hourly/mobile_events.sql
+++ b/transform/snowflake-dbt/models/events/hourly/mobile_events.sql
@@ -2,7 +2,7 @@
     "materialized": "incremental",
     "schema": "events",
     "tags":"preunion",
-    "snowflake_warehouse": "transform_m",
+    "snowflake_warehouse": "transform_l",
   })
 }}
 

--- a/transform/snowflake-dbt/models/events/hourly/rudder_webapp_events.sql
+++ b/transform/snowflake-dbt/models/events/hourly/rudder_webapp_events.sql
@@ -2,7 +2,7 @@
     "materialized": "incremental",
     "schema": "events",
     "tags":"preunion",
-    "snowflake_warehouse": "transform_m",
+    "snowflake_warehouse": "transform_l",
     "on_schema_change": "append_new_columns"
   })
 }}

--- a/transform/snowflake-dbt/models/events/hourly/segment_webapp_events.sql
+++ b/transform/snowflake-dbt/models/events/hourly/segment_webapp_events.sql
@@ -2,7 +2,7 @@
     "materialized": "incremental",
     "schema": "events",
     "tags":"preunion",
-    "snowflake_warehouse": "transform_m"
+    "snowflake_warehouse": "transform_l"
   })
 }}
 

--- a/transform/snowflake-dbt/models/mattermost/hourly/user_28day_retention.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/user_28day_retention.sql
@@ -2,7 +2,7 @@
     "materialized": "incremental",
     "schema": "mattermost",
     "tags":"union",
-    "snowflake_warehouse": "transform_m",
+    "snowflake_warehouse": "transform_l",
     "unique_key":"id"
   })
 }}


### PR DESCRIPTION
#### Summary

Only 4 models are using `transform_m`. Moving them to `transform_l` as part of effort for deprecating potential warehouses that are not needed.