### PR TITLE
Chore: add missing exposures

### DIFF
--- a/transform/mattermost-analytics/models/marts/product/_product__exposures.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__exposures.yml
@@ -19,4 +19,4 @@ exposures:
       - ref('dim_server_info')
       - ref('dim_version')
       - ref('dim_excludable_servers')
-      - ref('rpt_teday_at_day_28')
+      - ref('rpt_tedau_at_day_28')

--- a/transform/mattermost-analytics/models/marts/product/_product__exposures.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__exposures.yml
@@ -1,0 +1,22 @@
+version: 2
+
+exposures:
+  - name: customer_journey_and_new_logo_exposure
+    type: dashboard
+    description: Customer Journey & New Logo dashboard in Looker.
+    url: https://mattermost.looker.com/dashboards/431
+    tags:
+      - looker
+    maturity: medium
+    owner:
+      name: Ioannis Foukarakis
+      email: ioannis.foukarakis@mattermost.com
+    depends_on:
+      - ref('fct_active_servers')
+      - ref('fct_active_users')
+      - ref('dim_daily_server_config')
+      - ref('dim_daily_server_info')
+      - ref('dim_server_info')
+      - ref('dim_version')
+      - ref('dim_excludable_servers')
+      - ref('rpt_teday_at_day_28')

--- a/transform/mattermost-analytics/models/marts/product/notifications/_notifications__exposures.yml
+++ b/transform/mattermost-analytics/models/marts/product/notifications/_notifications__exposures.yml
@@ -1,0 +1,15 @@
+version: 2
+
+exposures:
+  - name: notification_metrics_exposure
+    type: dashboard
+    description: Notification metrics explore available in Looker.
+    url: https://mattermost.looker.com/explore/product/fct_notification_stats
+    tags:
+      - looker
+    maturity: medium
+    owner:
+      name: Ioannis Foukarakis
+      email: ioannis.foukarakis@mattermost.com
+    depends_on:
+      - ref('fct_notification_stats')

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__exposures.yml
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__exposures.yml
@@ -1,0 +1,20 @@
+version: 2
+
+exposures:
+  - name: in_product_trial_request_sync_to_salesforce_exposure
+    type: application
+    description: |
+      Update Salesforce leads and campaign members with trial requests originating from the product. Combines trial
+      request data with Salesforce lead and campaign members to decide which data to push to Salesforce. The result is 
+      synced with Salesforce via a set of hightouch syncs.
+
+    url: https://app.hightouch.com/mattermost-com/syncs?search=In+App+Product+Trial+Request
+    tags:
+      - hightouch
+      - salesforce
+    maturity: medium
+    owner:
+      name: Ioannis Foukarakis
+      email: ioannis.foukarakis@mattermost.com
+    depends_on:
+      - ref('fct_in_product_trial_requests')


### PR DESCRIPTION
#### Summary

Add exposures that were created after the model's creations:
- [x] Customer Journey & New Logo
- [x] In Product Trial Request
- [x] Notification metrics 
