### PR TITLE
Chore: Deprecate models with no matching syncs

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem_renewal.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem_renewal.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
@@ -1,9 +1,10 @@
-{{ config(
-    { "schema": "hightouch",
+{{
+  config({
+    "schema": "hightouch",
     "materialized": "view",
-    "tags" :["hourly","blapi"] }
-) }}
-
+    "tags":["hourly", "blapi"]
+  })
+}}
 WITH existing_contacts AS (
 
     SELECT

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -1,8 +1,10 @@
-{{ config(
-    { "schema": "hightouch",
+{{
+  config({
+    "schema": "hightouch",
     "materialized": "view",
-    "tags" :["hourly","blapi"] }
-) }}
+    "tags":["hourly", "blapi"]
+  })
+}}
 -- create contact
 WITH existing_leads AS (
 

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunity.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunity.sql
@@ -1,7 +1,8 @@
-{{config({
+{{
+  config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem_for_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem_for_insert.sql
@@ -1,7 +1,8 @@
-{{config({    
+{{
+  config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/operations/campaignmember_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/campaignmember_insert.sql
@@ -1,7 +1,8 @@
 {{
     config({
     "materialized": 'table',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags":["deprecated"]
     })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/operations/campaignmember_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/campaignmember_update.sql
@@ -1,7 +1,8 @@
 {{
     config({
-    "materialized": 'table',
-    "schema": "hightouch"
+      "materialized": 'table',
+      "schema": "hightouch",
+      "tags": ["deprecated"]
     })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/operations/contact_in_product_trial_request.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/contact_in_product_trial_request.sql
@@ -1,7 +1,8 @@
 {{
     config({
     "materialized": 'table',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags":["deprecated"]
     })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/operations/lead_external_id.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/lead_external_id.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/operations/lead_in_product_trial_request.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/lead_in_product_trial_request.sql
@@ -1,7 +1,8 @@
 {{
     config({
     "materialized": 'table',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags":["deprecated"]
     })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/operations/line_item_external_id.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/line_item_external_id.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/operations/opportunity_update_available_renewals.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/opportunity_update_available_renewals.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'table',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags":["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/cloud_signup_campaign_with_lead_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/cloud_signup_campaign_with_lead_insert.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'view',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/cloud_signup_campaignmember_to_insert_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/cloud_signup_campaignmember_to_insert_contact.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'view',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/cloud_signup_campaignmember_to_insert_lead.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/cloud_signup_campaignmember_to_insert_lead.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'view',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/onprem_trial_request_inapp_campaignmember_to_insert_lead.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/onprem_trial_request_inapp_campaignmember_to_insert_lead.sql
@@ -1,4 +1,4 @@
-{{config({
+\{{config({
     "materialized": 'view',
     "schema": "hightouch"
   })

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/updates/cloud_signup_campaign_with_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/updates/cloud_signup_campaign_with_contact_update.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'view',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/updates/cloud_signup_campaign_with_lead_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/updates/cloud_signup_campaign_with_lead_update.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'view',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/updates/cloud_signup_campaignmember_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/updates/cloud_signup_campaignmember_update.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'view',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 


### PR DESCRIPTION
#### Summary

- [x] Deprecate models with no matching active syncs.
- [x] Verify that the models are not used in any Looker views (thus not visible in explores).