### PR TITLE
MM-48577: deprecate models derived from BLAPI data

### DIFF
--- a/transform/snowflake-dbt/models/blapi/customers_with_cloud_paid_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_cloud_paid_subs.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "unique_key":"id",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 -- customer info along with current paid subscriptions

--- a/transform/snowflake-dbt/models/blapi/customers_with_cloud_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_cloud_subs.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "unique_key":"id",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/blapi/customers_with_freemium_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_freemium_subs.sql
@@ -1,7 +1,8 @@
-{{config({
+{{
+  config({
     "schema": "hightouch",
-    "unique_key":"id",
-    "tags":["hourly","blapi"]
+    "materialized": "view",
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/blapi/customers_with_freemium_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_freemium_subs.sql
@@ -1,7 +1,7 @@
 {{
   config({
     "schema": "hightouch",
-    "materialized": "view",
+    "unique_key":"id",
     "tags": ["hourly", "blapi", "deprecated"]
   })
 }}

--- a/transform/snowflake-dbt/models/blapi/customers_with_onprem_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_onprem_subs.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "unique_key":"id",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/blapi/freemium_subscriptions.sql
+++ b/transform/snowflake-dbt/models/blapi/freemium_subscriptions.sql
@@ -1,7 +1,8 @@
-{{config({
-    "schema": "blapi",
-    "unique_key":"id",
-    "tags":["hourly","blapi"]
+{{
+  config({
+    "schema": "hightouch",
+    "materialized": "view",
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/blapi/freemium_subscriptions.sql
+++ b/transform/snowflake-dbt/models/blapi/freemium_subscriptions.sql
@@ -1,7 +1,7 @@
 {{
   config({
-    "schema": "hightouch",
-    "materialized": "view",
+    "schema": "blapi",
+    "unique_key":"id",
     "tags": ["hourly", "blapi", "deprecated"]
   })
 }}

--- a/transform/snowflake-dbt/models/data_quality_layer/hightouch/subscriptions/dq_cloud_professional.sql
+++ b/transform/snowflake-dbt/models/data_quality_layer/hightouch/subscriptions/dq_cloud_professional.sql
@@ -1,7 +1,7 @@
 {{ config(
     { "materialized": "table",
     "schema": "data_quality",
-    "tags": "data-quality" }
+    "tags": ["data-quality", "deprecated"] }
 ) }}
 
 WITH cloud_professional_subscriptions AS (

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_account.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly","blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_account.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_contact.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_opportunity.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_opportunity.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_opportunitycontactrole.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_opportunitycontactrole.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_opportunitylineitem.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_opportunitylineitem.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_opportunitylineitem_for_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_opportunitylineitem_for_insert.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_opportunitylineitem_for_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_cloud_opportunitylineitem_for_update.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_contact.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly","blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_onprem_opportunity.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_onprem_opportunity.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_onprem_opportunity_renewal.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_onprem_opportunity_renewal.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitycontactrole.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitycontactrole.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem_to_delete.sql
+++ b/transform/snowflake-dbt/models/hightouch/blapi/blapi_opportunitylineitem_to_delete.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/blapi/exposures.yml
+++ b/transform/snowflake-dbt/models/hightouch/blapi/exposures.yml
@@ -39,6 +39,7 @@ exposures:
     tags:
       - hightouch
       - salesforce
+      - deprecated
     maturity: low
     owner:
       name: Ioannis Foukarakis

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/cancelled_account_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/cancelled_account_update.sql
@@ -1,7 +1,8 @@
-{{config({
+{{
+  config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/cancelled_update_opportunity.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/cancelled_update_opportunity.sql
@@ -1,7 +1,8 @@
-{{config({
+{{
+  config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account.sql
@@ -2,7 +2,7 @@
   config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly", "blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 WITH existing_contacts AS (

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_account_update.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact.sql
@@ -2,7 +2,7 @@
   config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly", "blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 -- create contact

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_contact_update.sql
@@ -1,8 +1,9 @@
-{{ config(
-    { "schema": "hightouch",
+{{config({
+    "schema": "hightouch",
     "materialized": "view",
-    "tags" :["hourly","blapi"] }
-) }}
+    "tags": ["hourly", "blapi", "deprecated"]
+  })
+}}
 -- lead or contact already exists
 WITH existing_leads AS (
 

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem_for_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem_for_insert.sql
@@ -1,8 +1,7 @@
-{{
-  config({
+{{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly", "blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem_for_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem_for_update.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
-    "materialized": "view",
-    "tags":["hourly","blapi"]
+    "unique_key":"id",
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem_for_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/freemium/professional_subscription/freemium_opportunitylineitem_for_update.sql
@@ -1,6 +1,6 @@
 {{config({
     "schema": "hightouch",
-    "unique_key":"id",
+    "materialized": "view",
     "tags": ["hourly", "blapi", "deprecated"]
   })
 }}

--- a/transform/snowflake-dbt/models/hightouch/operations/account_external_id.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/account_external_id.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/operations/contact_external_id.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/contact_external_id.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly","blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/operations/opportunity_external_id.sql
+++ b/transform/snowflake-dbt/models/hightouch/operations/opportunity_external_id.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "materialized": "view",
-    "tags":["hourly","blapi"]
+    "tags":["hourly","blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/tests/data_quality/hightouch/subscriptions/test_cloud_professional.sql
+++ b/transform/snowflake-dbt/tests/data_quality/hightouch/subscriptions/test_cloud_professional.sql
@@ -1,11 +1,11 @@
 {{ config(
-    tags = ['data-quality']
+    tags = ["data-quality", "deprecated"]
 ) }}
 
 SELECT
     *
 FROM
-    {{ ref('dq_cloud_professional') }}
+    {{ ref("dq_cloud_professional') }}
 WHERE
     -- Fetch all opportunities/contacts/accounts not synced into salesforce.
     (

--- a/transform/snowflake-dbt/tests/data_quality/hightouch/subscriptions/test_cloud_professional.sql
+++ b/transform/snowflake-dbt/tests/data_quality/hightouch/subscriptions/test_cloud_professional.sql
@@ -5,7 +5,7 @@
 SELECT
     *
 FROM
-    {{ ref("dq_cloud_professional') }}
+    {{ ref('dq_cloud_professional') }}
 WHERE
     -- Fetch all opportunities/contacts/accounts not synced into salesforce.
     (


### PR DESCRIPTION
#### Summary
- [x] Deprecate fremium.
- [x] Deprecate on prem blapi subscriptions and related models.
- [x] Deprecate cloud blapi subscriptions and related models.
- [x] Deprecate syncs that have never run in the past two years (external id related).
- [x] Deprecate models used only by the deprecated models.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48577
