### PR TITLE
MM-48577: deprecate unused upstream models

### DIFF
--- a/transform/snowflake-dbt/models/blapi/cloud_paid_subscriptions.sql
+++ b/transform/snowflake-dbt/models/blapi/cloud_paid_subscriptions.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "blapi",
     "unique_key":"id",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 -- cloud paid subscriptions (cloud professional and cloud enterprise)

--- a/transform/snowflake-dbt/models/blapi/cloud_subscriptions.sql
+++ b/transform/snowflake-dbt/models/blapi/cloud_subscriptions.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "blapi",
     "unique_key":"id",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/blapi/onprem_subscriptions.sql
+++ b/transform/snowflake-dbt/models/blapi/onprem_subscriptions.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "blapi",
     "unique_key":"id",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/blapi/payments.sql
+++ b/transform/snowflake-dbt/models/blapi/payments.sql
@@ -2,7 +2,7 @@
     "materialized": "incremental",
     "schema": "blapi",
     "unique_key":"id",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/cloud_signup_campaign.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/cloud_signup_campaign.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'table',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/cloud_signup_campaign_facts.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/cloud_signup_campaign_facts.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'table',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 


### PR DESCRIPTION
#### Summary

Deprecate upstream models that do not use 

- [x] Ensure models have no downstream models using DBT's lineage.
- [x] Ensure models are not used in looker.
- [x] Ensure models not used in hightouch.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48577
