### PR TITLE
MM-48577: deprecate unused cloud free models

### DIFF
--- a/transform/snowflake-dbt/models/blapi/cloud_free_subscriptions.sql
+++ b/transform/snowflake-dbt/models/blapi/cloud_free_subscriptions.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "blapi",
     "unique_key":"id",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 -- cloud subscriptions that do not need any payment i.e cloud starter and cloud enterprise trial(30 days)

--- a/transform/snowflake-dbt/models/blapi/customers_with_cloud_free_subs.sql
+++ b/transform/snowflake-dbt/models/blapi/customers_with_cloud_free_subs.sql
@@ -1,7 +1,7 @@
 {{config({
     "schema": "hightouch",
     "unique_key":"id",
-    "tags":["hourly","blapi"]
+    "tags": ["hourly", "blapi", "deprecated"]
   })
 }}
 -- customer info along with current subscriptions and previous subscriptions


### PR DESCRIPTION
#### Summary

Deprecated cloud free models parent models. These models are no longer used by downstream models.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48577