### PR TITLE
MM-52595: deprecate blapi trial requests

### DIFF
--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/onprem_trial_request_inapp_campaignmember_to_insert_contact.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/onprem_trial_request_inapp_campaignmember_to_insert_contact.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'view',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/onprem_trial_request_inapp_campaignmember_to_insert_lead.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/onprem_trial_request_inapp_campaignmember_to_insert_lead.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'view',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/onprem_trial_request_inapp_lead_insert.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/inserts/onprem_trial_request_inapp_lead_insert.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'view',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/onprem_trial_request_inapp_facts.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/onprem_trial_request_inapp_facts.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'table',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/hightouch/product_campaigns/updates/onprem_trial_request_inapp_contact_update.sql
+++ b/transform/snowflake-dbt/models/hightouch/product_campaigns/updates/onprem_trial_request_inapp_contact_update.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'view',
-    "schema": "hightouch"
+    "schema": "hightouch",
+    "tags": ["deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/tests/data_quality/hightouch/product_campaigns/test_onprem_trial_request_inapp_facts.sql
+++ b/transform/snowflake-dbt/tests/data_quality/hightouch/product_campaigns/test_onprem_trial_request_inapp_facts.sql
@@ -1,5 +1,5 @@
 {{ config(
-    tags = ['data-quality']
+    tags = ['data-quality', 'deprecated']
 ) }}
 
 select


### PR DESCRIPTION
#### Summary

Deprecate models used in hightouch syncs that use BLAPI trial request data. These models are no longer needed, since BLAPI has been deprecated.

- [x] Deprecate models used in hightouch syncs.
- [x] Deprecate related upstream and test models that are no longer needed.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52595
