### PR TITLE
Chore: convert user_28day_retention to nightly

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/hourly/user_28day_retention.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/user_28day_retention.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "mattermost",
-    "tags":"union",
+    "tags": ["union", "nightly"],
     "snowflake_warehouse": "transform_l",
     "unique_key":"id"
   })


### PR DESCRIPTION
#### Summary

`user_28day_retention` model is a model using data from `user_events_telemetry`. `user_events_telemetry` is run nightly, so running `user_28day_retention` on hourly cadence doesn't change data.