### PR TITLE
Chore: Deprecates user_28day_retention

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/hourly/user_28day_retention.sql
+++ b/transform/snowflake-dbt/models/mattermost/hourly/user_28day_retention.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "mattermost",
-    "tags": ["union", "nightly"],
+    "tags": ["union", "nightly", "deprecated"],
     "snowflake_warehouse": "transform_l",
     "unique_key":"id"
   })


### PR DESCRIPTION
Impact: user_28day_retention model is not used in Looker and this PR deprecates the dbt model.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

