### PR TITLE
MM-56529: use renamed permifrost command

### DIFF
--- a/airflow/dags/mattermost_dags/general/snowflake_permissions.py
+++ b/airflow/dags/mattermost_dags/general/snowflake_permissions.py
@@ -26,7 +26,7 @@ default_args = {
 
 # Set the command for the container
 container_cmd = """
-    permifrost grant load/snowflake/roles.yaml
+    permifrost run load/snowflake/roles.yaml
 """
 
 # Create the DAG


### PR DESCRIPTION
#### Summary

Permifrost `grant` command has been renamed to `run` in version [0.9.0](https://gitlab.com/gitlab-data/permifrost/-/blob/master/CHANGELOG.md?ref_type=heads#090-2021-01-29). 

This PR adjusts the command.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-56529