### PR TITLE
Chore: adjust memory request size

### DIFF
--- a/airflow/dags/mattermost_dags/airflow_utils.py
+++ b/airflow/dags/mattermost_dags/airflow_utils.py
@@ -28,8 +28,8 @@ pod_defaults = {
     "cmds": ["/bin/bash", "-c"],
     "container_resources": k8s.V1ResourceRequirements(
         requests={
-            "cpu": "250m",
-            "memory": "250Mi",
+            "cpu": "50m",
+            "memory": "100Mi",
         },
         limits={
             "cpu": "500m",


### PR DESCRIPTION
#### Summary

Pods are currently randomly failing due to failure to be scheduled.  This PR reduces the initial request size for the command line utilities. This is required to test whether the failure happens due to relatively big initial request size vs not enough resources on cluster.
