### PR TITLE
Chore: Adds participant_id to staging model

### DIFF
--- a/transform/mattermost-analytics/models/staging/mm_calls_test_go/_mm_calls_test_go__models.yml
+++ b/transform/mattermost-analytics/models/staging/mm_calls_test_go/_mm_calls_test_go__models.yml
@@ -13,7 +13,9 @@ models:
       - name: event_table
         description: The name of the event table.
       - name: user_id
-        description: The ID of the user that sent the event.
+        description: |
+          The ID of the user that sent the event. 
+          The user_id is participant_id in server side event tables and actual_user_id in client side event tables, this is handled using coalesce.
       - name: server_id
         description: The ID of the server the event originated from.
       - name: received_at

--- a/transform/mattermost-analytics/models/staging/mm_calls_test_go/base/base_mm_calls_test_go__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_calls_test_go/base/base_mm_calls_test_go__tracks.sql
@@ -1,4 +1,4 @@
-{%- set include_columns = ["actual_user_id", "server_version", "plugin_build", "plugin_version"] -%}
+{%- set include_columns = ["actual_user_id", "server_version", "plugin_build", "plugin_version", "participant_id"] -%}
 
 {%- set relations = get_event_relations('mm_calls_test_go', database='RAW') -%}
 

--- a/transform/mattermost-analytics/models/staging/mm_calls_test_go/stg_mm_calls_test_go__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_calls_test_go/stg_mm_calls_test_go__tracks.sql
@@ -2,7 +2,7 @@ SELECT
     id AS event_id
     , event_text AS event_name
     , event AS event_table
-    , actual_user_id AS user_id
+    , coalesce(actual_user_id, participant_id) AS user_id
     , user_id AS server_id
     , received_at AS received_at
     , timestamp  AS timestamp


### PR DESCRIPTION
Impact: Calls data in `RAW` tables contains `user_id` as `participant_id` in some and `actual_user_id` in other tables. The last PR which created models for calls didn't include `participant_id` which skews Active user metric calculations in Looker. This PR adds the missing field from the source tables.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

