### PR TITLE
Hotfix: adjust permissions

### DIFF
--- a/load/snowflake/roles.yaml
+++ b/load/snowflake/roles.yaml
@@ -47,6 +47,7 @@ roles:
                     - analytics
                     - archive
                     - dev
+                    - snowflake
                 write:
                     - raw
                     - analytics
@@ -58,6 +59,7 @@ roles:
                     - analytics.*
                     - archive.*
                     - dev.*
+                    - snowflake.*
                 write:
                     - raw.*
                     - analytics.*
@@ -69,6 +71,7 @@ roles:
                     - analytics.*.*
                     - archive.*.*
                     - dev.*.*
+                    - snowflake.account_usage.*
                 write:
                     - raw.*.*
                     - analytics.*.*


### PR DESCRIPTION
#### Summary

Role `sysadmin` was stripped of its permissions for schema `snowflake.account_usage`. This fix ensures that proper permissions are enforced for that role. This is required for `permifrost` to run.
