### PR TITLE
Chore: Deprecates user_events_by_date_agg

### DIFF
--- a/transform/snowflake-dbt/models/events/nightly/user_events_by_date_agg.sql
+++ b/transform/snowflake-dbt/models/events/nightly/user_events_by_date_agg.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'incremental',
     "unique_key": 'id',
+    "tags": ["deprecated"],
     "schema": "events"
   })
 }}


### PR DESCRIPTION
Impact: Deprecates `user_events_by_date_agg` model as its not used anywhere in Looker. There are no looks or dashboards using this model.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

