### PR TITLE
Chore: add segment events to event registry

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/_int_event_registry__models.yml
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/_int_event_registry__models.yml
@@ -328,7 +328,7 @@ models:
         tests:
           - not_null
       - name: source
-        description: The source of the event. Always `Telemetry Prod` for events of this table..
+        description: The source of the event. Always `Telemetry Prod - Segment` for events of this table..
       - name: event_table
         description: The table this event was read from.
       - name: event_name

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/_int_event_registry__models.yml
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/_int_event_registry__models.yml
@@ -180,7 +180,7 @@ models:
         description: The number of events with specified name, category, type etc for date in `received_at_date`.
 
   - name: int_mm_telemetry_prod_aggregated_to_date
-    description: Telemetry Prod events, aggregated by date.
+    description: Telemetry Prod events, aggregated by date. Contains events originating from Rudderstack.
 
     columns:
       - name: event_id
@@ -296,6 +296,39 @@ models:
           - not_null
       - name: source
         description: The source of the event.
+      - name: event_table
+        description: The table this event was read from.
+      - name: event_name
+        description: The name of the event.
+      - name: category
+        description: The event's category.
+      - name: event_type
+        description: The event's type.
+      - name: event_count
+        description: The number of events with specified name, category, type etc for date in `received_at_date`.
+
+
+  - name: int_mattermost2_aggregated_to_date
+    description: Telemetry Prod events, aggregated by date. Contains events originating from Segment.
+
+    columns:
+      - name: event_id
+        description: Surrogate key representing a group of events with specific name, category, type.
+        tests:
+          - not_null
+      - name: daily_event_id
+        description: |
+          Surrogate key representing a group of events with specific name, category, type for a specific date.
+          Multiple `daily_event_id`'s may exist for the same event id.
+        tests:
+          - not_null
+          - unique
+      - name: received_at_date
+        description: the date that the event was ingested at.
+        tests:
+          - not_null
+      - name: source
+        description: The source of the event. Always `Telemetry Prod` for events of this table..
       - name: event_table
         description: The table this event was read from.
       - name: event_name

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_events_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_events_aggregated_to_date.sql
@@ -9,6 +9,7 @@
             ref('int_mm_plugin_prod_aggregated_to_date'),
             ref('int_mm_telemetry_prod_aggregated_to_date'),
             ref('int_mm_telemetry_rc_aggregated_to_date'),
+            ref('int_mattermost2_aggregated_to_date'),
             ref('int_portal_prod_aggregated_to_date'),
         ],
         source_column_name=None

--- a/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mattermost2_aggregated_to_date.sql
+++ b/transform/mattermost-analytics/models/intermediate/data_eng/event_registry/int_mattermost2_aggregated_to_date.sql
@@ -1,0 +1,18 @@
+{{
+    config({
+        "materialized": "incremental",
+        "incremental_strategy": "merge",
+        "unique_key": ['daily_event_id'],
+        "merge_update_columns": ['event_count'],
+        "cluster_by": ['received_at_date'],
+        "snowflake_warehouse": "transform_l"
+    })
+}}
+
+{{
+    rudder_daily_event_count(
+        ref('stg_mattermost2__tracks'),
+        by_columns=['event_table', 'event_name', 'category', 'event_type'],
+        source_name='Telemetry Prod - Segment'
+    )
+}}


### PR DESCRIPTION
#### Summary

Adds events originating from Segment to event registry.

Note that the new events are marked as having a source of `Telemetry Prod - Segment`. The Rudderstack events use `Telemetry Prod`. 3/5 we could rename `Telemetry Prod` and `Telemetry RC` to indicate that the telemetry is originating from Rudderstack. This would require running a full refresh of the models.