### PR TITLE
MM - 56610 Add missing context_user_agent in webpp performance_events

### DIFF
--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/_mm_telemetry_prod__models.yml
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/_mm_telemetry_prod__models.yml
@@ -48,7 +48,7 @@ models:
       - name: user_actual_role
       - name: context_app_build
       - name: context_library_version
-      - name: context_useragent
+      - name: context_user_agent
       - name: context_app_name
       - name: context_locale
       - name: context_screen_density

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__performance_events.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__performance_events.sql
@@ -1,27 +1,20 @@
+{%- set include_columns = [ "channel", "context_app_namespace", "user_actual_id"
+, "context_library_name", "type", "context_app_version" , "user_actual_role" 
+, "context_app_build" , "context_library_version", "context_app_name"
+, "context_locale", "context_screen_density" 
+, "category" , "duration" , "num_of_request", "max_api_resource_size"
+, "longest_api_resource_duration" , "user_id", "count", "request_count"] -%}
+        
 WITH performance_events AS (
-    SELECT channel as channel
-      , context_app_namespace as context_app_namespace
-      , user_actual_id as user_actual_id
-      , context_library_name as context_library_name
-      , type as type
-      , context_app_version as context_app_version
-      , user_actual_role as user_actual_role
-      , context_app_build as context_app_build
-      , context_library_version as context_library_version
-      , coalesce(context_useragent, context_user_agent) as context_user_agent
-      , context_app_name as context_app_name
-      , context_locale as context_locale
-      , context_screen_density as context_screen_density
-      , category as category 
-      , duration as duration 
-      , num_of_request as num_of_request 
-      , max_api_resource_size as max_api_resource_size
-      , longest_api_resource_duration as longest_api_resource_duration 
-      , user_id as user_id
-      , count as count
-      , request_count as request_count
-      , timestamp::date as event_date
-      , received_at::date as received_at_date
+    SELECT
+      {{ get_rudderstack_columns() }}
+        , {% for column in include_columns %}
+        {{ column }} AS {{ column }}
+        {% if not loop.last %},{% endif %}
+    {% endfor %}
+    , coalesce(context_useragent, context_user_agent) as context_user_agent
+    , timestamp::date as event_date
+    , received_at::date as received_at_date
     FROM
       {{ source('mm_telemetry_prod', 'event') }}
     WHERE CATEGORY = 'performance'

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__performance_events.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__performance_events.sql
@@ -22,8 +22,6 @@ WITH performance_events AS (
       , request_count as request_count
       , timestamp::date as event_date
       , received_at::date as received_at_date
-      , timestamp::date as event_date
-      , received_at::date as received_at_date
     FROM
       {{ source('mm_telemetry_prod', 'event') }}
     WHERE CATEGORY = 'performance'

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__performance_events.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__performance_events.sql
@@ -1,19 +1,29 @@
-{%- set include_columns = [ "channel", "context_app_namespace", "user_actual_id"
-, "context_library_name", "type", "context_app_version" , "user_actual_role" 
-, "context_app_build" , "context_library_version"
-, "context_useragent", "context_app_name", "context_locale", "context_screen_density" 
-, "category" , "duration" , "num_of_request", "max_api_resource_size"
-, "longest_api_resource_duration" , "user_id", "count", "request_count"] -%}
-        
 WITH performance_events AS (
-    SELECT
-      {{ get_rudderstack_columns() }}
-        , {% for column in include_columns %}
-        {{ column }} AS {{ column }}
-        {% if not loop.last %},{% endif %}
-    {% endfor %}
-    , timestamp::date as event_date
-    , received_at::date as received_at_date
+    SELECT channel as channel
+      , context_app_namespace as context_app_namespace
+      , user_actual_id as user_actual_id
+      , context_library_name as context_library_name
+      , type as type
+      , context_app_version as context_app_version
+      , user_actual_role as user_actual_role
+      , context_app_build as context_app_build
+      , context_library_version as context_library_version
+      , coalesce(context_useragent, context_user_agent) as context_user_agent
+      , context_app_name as context_app_name
+      , context_locale as context_locale
+      , context_screen_density as context_screen_density
+      , category as category 
+      , duration as duration 
+      , num_of_request as num_of_request 
+      , max_api_resource_size as max_api_resource_size
+      , longest_api_resource_duration as longest_api_resource_duration 
+      , user_id as user_id
+      , count as count
+      , request_count as request_count
+      , timestamp::date as event_date
+      , received_at::date as received_at_date
+      , timestamp::date as event_date
+      , received_at::date as received_at_date
     FROM
       {{ source('mm_telemetry_prod', 'event') }}
     WHERE CATEGORY = 'performance'

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_rc/_mm_telemetry_rc__models.yml
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_rc/_mm_telemetry_rc__models.yml
@@ -49,7 +49,7 @@ models:
       - name: user_actual_role
       - name: context_app_build
       - name: context_library_version
-      - name: context_useragent
+      - name: context_user_agent
       - name: context_app_name
       - name: context_locale
       - name: context_screen_density

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_rc/stg_mm_telemetry_rc__performance_events.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_rc/stg_mm_telemetry_rc__performance_events.sql
@@ -1,19 +1,29 @@
-{%- set include_columns = ["channel", "context_app_namespace", "user_actual_id"
-, "context_library_name", "type", "context_app_version" , "user_actual_role" 
-, "context_app_build" , "context_library_version"
-, "context_useragent", "context_app_name", "context_locale", "context_screen_density" 
-, "category" , "duration" , "num_of_request", "max_api_resource_size"
-, "longest_api_resource_duration" , "user_id", "count", "request_count"] -%}
-
 WITH performance_events AS (
-    SELECT
-      {{ get_rudderstack_columns() }}
-        , {% for column in include_columns %}
-        {{ column }} AS {{ column }}
-        {% if not loop.last %},{% endif %}
-    {% endfor %}
-    , timestamp::date as event_date
-    , received_at::date as received_at_date
+    SELECT channel as channel
+      , context_app_namespace as context_app_namespace
+      , user_actual_id as user_actual_id
+      , context_library_name as context_library_name
+      , type as type
+      , context_app_version as context_app_version
+      , user_actual_role as user_actual_role
+      , context_app_build as context_app_build
+      , context_library_version as context_library_version
+      , coalesce(context_useragent, context_user_agent) as context_user_agent
+      , context_app_name as context_app_name
+      , context_locale as context_locale
+      , context_screen_density as context_screen_density
+      , category as category 
+      , duration as duration 
+      , num_of_request as num_of_request 
+      , max_api_resource_size as max_api_resource_size
+      , longest_api_resource_duration as longest_api_resource_duration 
+      , user_id as user_id
+      , count as count
+      , request_count as request_count
+      , timestamp::date as event_date
+      , received_at::date as received_at_date
+      , timestamp::date as event_date
+      , received_at::date as received_at_date
     FROM
       {{ source('mm_telemetry_rc', 'event') }}
     WHERE CATEGORY = 'performance'

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_rc/stg_mm_telemetry_rc__performance_events.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_rc/stg_mm_telemetry_rc__performance_events.sql
@@ -22,8 +22,6 @@ WITH performance_events AS (
       , request_count as request_count
       , timestamp::date as event_date
       , received_at::date as received_at_date
-      , timestamp::date as event_date
-      , received_at::date as received_at_date
     FROM
       {{ source('mm_telemetry_rc', 'event') }}
     WHERE CATEGORY = 'performance'

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_rc/stg_mm_telemetry_rc__performance_events.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_rc/stg_mm_telemetry_rc__performance_events.sql
@@ -1,27 +1,20 @@
+{%- set include_columns = [ "channel", "context_app_namespace", "user_actual_id"
+, "context_library_name", "type", "context_app_version" , "user_actual_role" 
+, "context_app_build" , "context_library_version", "context_app_name"
+, "context_locale", "context_screen_density" 
+, "category" , "duration" , "num_of_request", "max_api_resource_size"
+, "longest_api_resource_duration" , "user_id", "count", "request_count"] -%}
+        
 WITH performance_events AS (
-    SELECT channel as channel
-      , context_app_namespace as context_app_namespace
-      , user_actual_id as user_actual_id
-      , context_library_name as context_library_name
-      , type as type
-      , context_app_version as context_app_version
-      , user_actual_role as user_actual_role
-      , context_app_build as context_app_build
-      , context_library_version as context_library_version
-      , coalesce(context_useragent, context_user_agent) as context_user_agent
-      , context_app_name as context_app_name
-      , context_locale as context_locale
-      , context_screen_density as context_screen_density
-      , category as category 
-      , duration as duration 
-      , num_of_request as num_of_request 
-      , max_api_resource_size as max_api_resource_size
-      , longest_api_resource_duration as longest_api_resource_duration 
-      , user_id as user_id
-      , count as count
-      , request_count as request_count
-      , timestamp::date as event_date
-      , received_at::date as received_at_date
+    SELECT
+      {{ get_rudderstack_columns() }}
+        , {% for column in include_columns %}
+        {{ column }} AS {{ column }}
+        {% if not loop.last %},{% endif %}
+    {% endfor %}
+    , coalesce(context_useragent, context_user_agent) as context_user_agent
+    , timestamp::date as event_date
+    , received_at::date as received_at_date
     FROM
       {{ source('mm_telemetry_rc', 'event') }}
     WHERE CATEGORY = 'performance'


### PR DESCRIPTION
Impact: The context_user_agent is missing in the dashboard of webapp performance events
We need to add a graph that will show the distribution (percentage) of user agents for events that are over the p99 duration. 

This PR adds the missing context_user_agent field.


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

