### PR TITLE
Hotfix: fix binary version

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/servers/int_server_active_days_spined.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/int_server_active_days_spined.sql
@@ -80,8 +80,8 @@ select
     coalesce(t.database_version, l.database_version) as database_version,
     coalesce(t.edition, l.edition, d.is_enterprise_ready) as is_enterprise_ready,
     case
-        when is_enterprise_ready = true then 'E0'
-        when is_enterprise_ready = false then 'TE'
+        when coalesce(t.edition, l.edition, d.is_enterprise_ready) = true then 'E0'
+        when coalesce(t.edition, l.edition, d.is_enterprise_ready) = false then 'TE'
         else 'Unknown'
     end as binary_edition,
     t.installation_id,


### PR DESCRIPTION
#### Summary

Case statement is returning wrong result due to explicit alias of `is_enterprise_ready` from table `d` having higher priority. More on https://community.snowflake.com/s/article/Beware-with-Column-Aliases-in-Joins.