### PR TITLE
Chore: run modified models on PR merge

### DIFF
--- a/transform/mattermost-analytics/selectors.yml
+++ b/transform/mattermost-analytics/selectors.yml
@@ -1,0 +1,17 @@
+selectors:
+  - name: skip_views_but_test_views
+    description: >
+      A default selector that will exclude materializing views without skipping tests on views. This is useful in
+      case views do not change that often (i.e. staging models). New and modified views can execute on a separate
+      job whenever they are merged to main branch.
+    default: true
+    definition:
+      union:
+        - union:
+          - method: path
+            value: "*"
+          - exclude:
+            - method: config.materialized
+              value: view
+        - method: resource_type
+          value: test


### PR DESCRIPTION
#### Summary

Introduces a selector to allow running tests on view without creating views. This will reduce the number of models build, helping avoid extra costs. There's currently a large number of views that are getting recreated. Based on [this blog post](https://www.getdbt.com/blog/staging-models-best-practices-and-limiting-view-runs).

In order for this to be deployed, it will require:
- Existing jobs to be modified so that the selector in this PR is used.
- A new "Merge job" to be introduced. This job will execute modified models upon merging, ensuring that views have already been created before running daily or nightly jobs.
