### PR TITLE
MM-57113: use proper region

### DIFF
--- a/airflow/dags/mattermost_dags/extract/push_proxy_new.py
+++ b/airflow/dags/mattermost_dags/extract/push_proxy_new.py
@@ -71,7 +71,7 @@ def push_proxy_loader():
         env_vars={},
         arguments=[
             "push_proxy PUSH_PROXY_LOGS_TEST_NEW LOGS_TEST_NEW "
-            " --prefix /AWSLogs/{{ var.value.push_proxy_aws_account_id }}/elasticloadbalancing/{{ var.value.push_proxy_aws_region }}"
+            " --prefix /AWSLogs/{{ var.value.push_proxy_aws_account_id }}/elasticloadbalancing/{{ var.value.push_proxy_aws_region_eu }}"
             " -s {{ var.value.push_proxy_target_schema }}"
             " -a ${SNOWFLAKE_ACCOUNT}"
             " -d ${SNOWFLAKE_LOAD_DATABASE}"


### PR DESCRIPTION
#### Summary

AWS EU region is used in the prefix of the S3 keys used. Use the correct region from env var.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57113
