### PR TITLE
MM-57699 Adds client_type to staging models

### DIFF
--- a/transform/mattermost-analytics/models/staging/mattermost2/base/base_mattermost2__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mattermost2/base/base_mattermost2__tracks.sql
@@ -1,10 +1,11 @@
+{%- set include_columns = ["context_user_agent"] -%}
 
 {%- set relations = get_event_relations('mattermost2', database='RAW') -%}
 
 {{
     dbt_utils.union_relations(
         relations=relations,
-        include=get_base_event_columns(),
+        include=get_base_event_columns() + include_columns,
         source_column_name=None
     )
 }}

--- a/transform/mattermost-analytics/models/staging/mattermost2/stg_mattermost2__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mattermost2/stg_mattermost2__tracks.sql
@@ -15,4 +15,5 @@ SELECT
      , user_actual_id AS user_id
      , received_at    AS received_at
      , timestamp      AS timestamp
+     , CASE WHEN LOWER(context_user_agent) LIKE '%electron%' THEN 'desktop' ELSE 'web_app' END AS client_type
 FROM tracks

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_mm_telemetry_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_mm_telemetry_prod__tracks.sql
@@ -1,10 +1,11 @@
+{%- set include_columns = ["context_user_agent", "context_useragent"] -%}
 
 {%- set relations = get_event_relations('mm_telemetry_prod', database='RAW') -%}
 
 {{
     dbt_utils.union_relations(
         relations=relations,
-        include=get_base_event_columns(),
+        include=get_base_event_columns() + include_columns,
         source_column_name=None
     )
 }}

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__tracks.sql
@@ -15,4 +15,5 @@ SELECT
      , user_actual_id AS user_id
      , received_at    AS received_at
      , timestamp      AS timestamp
+    , CASE WHEN LOWER(coalesce(context_useragent, context_user_agent)) LIKE '%electron%' THEN 'desktop' ELSE 'web_app' END AS client_type
 FROM tracks


### PR DESCRIPTION
Impact: We need to split the active users marts model by the client type cohort (Desktop/Webapp/Mobile). Desktop vs. Webapp split is currently not available in the models and needs to be added.


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-57699
