### PR TITLE
Chore: remove mobile from TEDAU

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/active_users/_int_active_users__models.yml
+++ b/transform/mattermost-analytics/models/intermediate/product/active_users/_int_active_users__models.yml
@@ -66,7 +66,7 @@ models:
 
   - name: int_user_active_days_spined
     description: |
-      Contains record per user per day since the user's first active date. Uses data from new & old servers, as well as 
+      Contains record per user per day since the user's first active date. Uses data from Rudderstack & Segment, but not
       from mobile. Performs deduplication for servers that sent data both via Rudderstack and Segment.
 
     columns:
@@ -96,16 +96,6 @@ models:
         description: |
           Indicates whether the user was active on the specific date and previous 29 days, and for the specific server.
           Only for new (>= 5.23.0) servers.
-      - name: is_mobile_today
-        description: Indicates whether the user was active on the specific date and server. Only for mobile users.
-      - name: is_mobile-last_7_days
-        description: |
-          Indicates whether the user was active on the specific date and previous 6 days, and for the specific server.
-          Only for mobile users.
-      - name: is_mobile_last_30_days
-        description: |
-          Indicates whether the user was active on the specific date and previous 29 days, and for the specific server.
-          Only for mobile users.
       - name: is_old_server_today
         description: Indicates whether the user was active on the specific date and server. Only for old (<= 5.25.0) servers.
       - name: is_old_server_last_7_days

--- a/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_spined.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_spined.sql
@@ -7,22 +7,20 @@
     })
 }}
 
-{% set metrics = ['is_active', 'is_desktop_or_server', 'is_mobile', 'is_old_server'] %}
+{% set metrics = ['is_active', 'is_desktop_or_server', 'is_old_server'] %}
 
 with user_active_days as (
-    -- Merge mobile with server data
+    -- Merge Rudderstack and segment
     select
         -- Load only required columns
-        coalesce(s.activity_date, m.activity_date, l.activity_date) as activity_date,
-        coalesce(s.server_id, m.server_id, l.server_id) as server_id,
-        coalesce(s.user_id, m.user_id, l.user_id) as user_id,
-        coalesce(s.is_active, m.is_active, l.is_active) as is_active,
+        coalesce(s.activity_date, l.activity_date) as activity_date,
+        coalesce(s.server_id, l.server_id) as server_id,
+        coalesce(s.user_id, l.user_id) as user_id,
+        coalesce(s.is_active, l.is_active) as is_active,
         s.server_id is not null as is_desktop_or_server,
-        m.server_id is not null as is_mobile,
         l.server_id is not null as is_old_server
     from
         {{ ref('int_user_active_days_server_telemetry') }} s
-        full outer join {{ ref('int_user_active_days_mobile_telemetry') }} m on s.daily_user_id = m.daily_user_id
         full outer join {{ ref('int_user_active_days_legacy_telemetry') }} l on s.daily_user_id = l.daily_user_id
 ), user_first_active_day as (
     select

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -7,7 +7,6 @@ models:
       Telemetry data are used to identify user activity.
       
       Also offers:
-      - Mobile only DAU/WAU/MAU. 
       - Desktop/server DAU/WAU/MAU. Includes all telemetry from within the app, plus any user telemetry that might be originating from server side, excluding old servers (pre 5.23.0).
       - Legacy DAU/WAU/MAU. Same as desktop/server, but includes telemetry up to 5.25.0.
       
@@ -34,20 +33,12 @@ models:
         description: The number of unique active users for the given server and date.
       - name: weekly_active_users
         description: The number of unique active users for the date and previous 6 days.
-      - name: monthly_active_users
-        description: The number of unique active users for the date and previous 29 days.
       - name: daily_desktop_active_users
         description: The number of unique desktop active users for the given server and date.
       - name: weekly_desktop_active_users
         description: The number of unique desktop active users for the date and previous 6 days.
       - name: monthly_desktop_active_users
         description: The number of unique desktop active users for the date and previous 29 days.
-      - name: daily_mobile_active_users
-        description: The number of unique mobile active users for the given server and date.
-      - name: weekly_mobile_active_users
-        description: The number of unique mobile active users for the date and previous 6 days.
-      - name: monthly_mobile_active_users
-        description: The number of unique mobile active users for the date and previous 29 days.
       - name: daily_legacy_active_users
         description: The number of unique legacy active users for the given server and date.
       - name: weekly_legacy_active_users

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -31,6 +31,8 @@ models:
               field: server_id
       - name: daily_active_users
         description: The number of unique active users for the given server and date.
+      - name: monthly_active_users
+        description: The number of unique active users for the date and previous 29 days.
       - name: weekly_active_users
         description: The number of unique active users for the date and previous 6 days.
       - name: daily_desktop_active_users

--- a/transform/mattermost-analytics/models/marts/product/fct_active_users.sql
+++ b/transform/mattermost-analytics/models/marts/product/fct_active_users.sql
@@ -2,7 +2,6 @@
     set column_map = {
         'is_active': 'active_users',
         'is_desktop_or_server': 'desktop_active_users',
-        'is_mobile': 'mobile_active_users',
         'is_old_server': 'legacy_active_users'
     }
 %}


### PR DESCRIPTION
#### Summary

Remove mobile data from TEDAU since mobile telemetry has been deprecated.

Note that merging this PR requires a full refresh for the related models, as well as update of the related looker model to reflect removal of columns.