### PR TITLE
Hotfix: improve date filtering on active userbase report

### DIFF
--- a/transform/mattermost-analytics/models/reports/product/active_user_base/rpt_active_user_base.sql
+++ b/transform/mattermost-analytics/models/reports/product/active_user_base/rpt_active_user_base.sql
@@ -8,7 +8,6 @@ with last_known_server_info as (
         si.activity_date
     from
         {{ ref('dim_daily_server_info') }} si
-
     where
         si.server_ip is not null
     qualify row_number() over (partition by si.server_id order by si.activity_date desc) = 1
@@ -74,8 +73,11 @@ from
             on parse_ip(last_known_server_info.server_ip, 'INET', 1):ipv4 between l.ipv4_range_start and l.ipv4_range_end
     left join last_known_oauth_info oauth on fct_active_users.server_id = oauth.server_id
 where
-    -- Keep servers with at least one user reported on the previous day. This is the last day with full data.
-    fct_active_users.activity_date = dateadd(day, -1, current_date)
+    -- Keep servers with at least one user reported on the last couple of days. This is the last day with full data.
+    -- Note that as telemetry might be send over the date, last date for a server might be either today or yesterday.
+    fct_active_users.activity_date >=  dateadd(day, -1, current_date)
     and (fct_active_users.server_monthly_active_users ) > 0
     -- Exclusion reasons - any server with any exclusion reason is excluded by default
     and dim_excludable_servers.server_id is null
+-- Keep only latest row
+qualify row_number() over (partition by fct_active_users.server_id order by fct_active_users.activity_date desc) = 1


### PR DESCRIPTION
#### Summary

Active user base was considering servers where the last server date was yesterday. However, since the latest date is considered, servers with last day equal to today may exist. Adjusting the date filter to be more flexible.