### PR TITLE
Add subscription history model

### DIFF
--- a/transform/mattermost-analytics/models/marts/sales/_sales__models.yml
+++ b/transform/mattermost-analytics/models/marts/sales/_sales__models.yml
@@ -1,0 +1,17 @@
+version: 2
+
+
+models:
+  - name: fct_subscription_history
+    description: |
+      Cloud subscription seat history data.
+    columns:
+    - name: subscription_history_id
+      description: The subscription history's ID.
+    - name: subscription_id
+      description: The subscription's ID.
+    - name: licensed_seats
+      description: The number of licensed seats active at the time of this event.
+    - name: created_at
+      description: The creation timestamp of this subscription history event
+

--- a/transform/mattermost-analytics/models/marts/sales/fct_subscription_history.sql
+++ b/transform/mattermost-analytics/models/marts/sales/fct_subscription_history.sql
@@ -1,0 +1,11 @@
+with subscription_history as (
+    select 
+        subscription_history_event_id
+        ,  subscription_id
+        ,  licensed_seats
+        , created_at
+
+    from {{ ref('stg_cws__subscription_history') }}
+)
+
+select * from subscription_history

--- a/transform/mattermost-analytics/models/staging/cws/_cws__models.yml
+++ b/transform/mattermost-analytics/models/staging/cws/_cws__models.yml
@@ -159,3 +159,20 @@ models:
         description: Unique Identifier for licenses.
       - name: trial_request_id
         description: The trial request's ID.
+
+  - name: stg_cws__subscription_history
+    description: |
+      CWS subscription active seat history.
+
+    columns:
+      - name: subscription_history_event_id
+        description: Unique Identifier for subscription history.
+        tests:
+          - not_null
+          - unique
+      - name: subscription_id
+        description: The Stripe subscription ID
+      - name: licensed_seats
+        description: The maximum number of active seats on the subscription
+      - name: created_at
+        description: The date at which this subscription history event was created - also known as the date that the given seats value was reached.

--- a/transform/mattermost-analytics/models/staging/cws/_cws__sources.yml
+++ b/transform/mattermost-analytics/models/staging/cws/_cws__sources.yml
@@ -83,6 +83,20 @@ sources:
           - name: _sdc_sequence
           - name: _sdc_table_version
           - name: __sdc_primary_key
+      
+      - name: subscriptionhistory
+        columns:
+          - name: id
+            description: A unique identifier for this subscription history event
+            tests:
+              - unique
+              - not_null
+          - name: subscriptionid
+            description: The Stripe subscription ID
+          - name: seats
+            description: The maximum number of active seats on the subscription
+          - name: createat
+            description: The date at which this subscription history event was created - also known as the date that the given seats value was reached.
 
       - name: license
         columns:

--- a/transform/mattermost-analytics/models/staging/cws/stg_cws__subscription_history.sql
+++ b/transform/mattermost-analytics/models/staging/cws/stg_cws__subscription_history.sql
@@ -1,0 +1,21 @@
+
+
+with source as (
+    select * from {{ source('cws', 'subscriptionhistory') }}
+
+),
+
+renamed as (
+    select 
+        id as subscription_history_event_id
+        , subscriptionid as subscription_id
+        , seats as licensed_seats
+        , to_timestamp(createat) as created_at
+
+    from source
+)
+
+select 
+    *
+from
+    renamed


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Adds a model for subscription history to aid in building out a "Cloud 360 Dashboard" - this specifically aids in exposing the current "billable" seat count on the workspace.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

