### PR TITLE
Chore: consider 30 days in active user base

### DIFF
--- a/transform/mattermost-analytics/models/reports/product/active_user_base/rpt_active_user_base.sql
+++ b/transform/mattermost-analytics/models/reports/product/active_user_base/rpt_active_user_base.sql
@@ -1,4 +1,35 @@
-with last_known_server_info as (
+with servers as (
+    -- Filter servers to narrow down to the ones useful for the report.
+    -- Keep list of servers with at least one user reported on the last 30 days.
+    -- Exclude servers with any exclusion reason.
+    select
+        fct_active_users.server_id,
+        fct_active_users.server_monthly_active_users,
+        fct_active_users.daily_active_users as client_daily_active_users,
+        fct_active_users.monthly_active_users as client_monthly_active_users,
+        fct_active_users.count_registered_users,
+        fct_active_users.count_registered_deactivated_users,
+        case
+          when fct_active_users.server_monthly_active_users < 50 then '1-50'
+          when (fct_active_users.server_monthly_active_users >= 50) and (fct_active_users.server_monthly_active_users < 500) THEN '50-500'
+          when (fct_active_users.server_monthly_active_users >= 500) and (fct_active_users.server_monthly_active_users < 1000) THEN '500-1000'
+          when fct_active_users.server_monthly_active_users >= 1000 then '>= 1000'
+          else 'Unknown'
+        end
+        as server_mau_bucket
+    from
+        {{ ref('fct_active_users') }} as fct_active_users
+        left join {{ ref('dim_excludable_servers') }} as dim_excludable_servers
+            on fct_active_users.server_id = dim_excludable_servers.server_id
+    where
+        -- Keep servers with at least one user reported on the last 30 days.
+        fct_active_users.activity_date >=  dateadd(day, -30, current_date)
+        and (fct_active_users.server_monthly_active_users ) > 0
+        -- Exclusion reasons - any server with any exclusion reason is excluded by default
+        and dim_excludable_servers.server_id is null
+    -- Keep only latest row
+    qualify row_number() over (partition by fct_active_users.server_id order by fct_active_users.activity_date desc) = 1
+), last_known_server_info as (
     select
         si.server_id,
         si.server_ip,
@@ -29,21 +60,7 @@ with last_known_server_info as (
     qualify row_number() over (partition by server_id order by activity_date desc) = 1
 )
 select
-    fct_active_users.server_id,
-    fct_active_users.server_monthly_active_users,
-    fct_active_users.daily_active_users as client_daily_active_users,
-    fct_active_users.monthly_active_users as client_monthly_active_users,
-    fct_active_users.count_registered_users,
-    fct_active_users.count_registered_deactivated_users,
-    case
-      when fct_active_users.server_monthly_active_users < 50 then '1-50'
-      when (fct_active_users.server_monthly_active_users >= 50) and (fct_active_users.server_monthly_active_users < 500) THEN '50-500'
-      when (fct_active_users.server_monthly_active_users >= 500) and (fct_active_users.server_monthly_active_users < 1000) THEN '500-1000'
-      when fct_active_users.server_monthly_active_users >= 1000 then '>= 1000'
-      else 'Unknown'
-    end
-    as server_mau_bucket,
-    last_known_server_info.server_ip as last_known_server_ip,
+    servers.*,
     case
         -- TODO: separate IPv6 from `Unknown`
         when parse_ip(last_known_server_info.server_ip, 'INET', 1):error is not null then 'Unknown'
@@ -63,20 +80,10 @@ select
     oauth.activity_date as last_known_oauth_info_date,
     {{ dbt_utils.star(ref('dim_latest_server_customer_info'), except=['server_id'], relation_alias='dim_latest_server_customer_info') }}
 from
-    {{ ref('fct_active_users') }} as fct_active_users
-    left join {{ ref('dim_excludable_servers') }} as dim_excludable_servers
-        on fct_active_users.server_id = dim_excludable_servers.server_id
+    servers
     left join {{ ref('dim_latest_server_customer_info') }} as dim_latest_server_customer_info
-        on fct_active_users.server_id = dim_latest_server_customer_info.server_id
-    left join last_known_server_info on fct_active_users.server_id = last_known_server_info.server_id
+        on servers.server_id = dim_latest_server_customer_info.server_id
+    left join last_known_server_info on servers.server_id = last_known_server_info.server_id
     left join {{ ref('int_ip_country_lookup') }} l
             on parse_ip(last_known_server_info.server_ip, 'INET', 1):ipv4 between l.ipv4_range_start and l.ipv4_range_end
     left join last_known_oauth_info oauth on fct_active_users.server_id = oauth.server_id
-where
-    -- Keep servers with at least one user reported on the last 30 days.
-    fct_active_users.activity_date >=  dateadd(day, -30, current_date)
-    and (fct_active_users.server_monthly_active_users ) > 0
-    -- Exclusion reasons - any server with any exclusion reason is excluded by default
-    and dim_excludable_servers.server_id is null
--- Keep only latest row
-qualify row_number() over (partition by fct_active_users.server_id order by fct_active_users.activity_date desc) = 1

--- a/transform/mattermost-analytics/models/reports/product/active_user_base/rpt_active_user_base.sql
+++ b/transform/mattermost-analytics/models/reports/product/active_user_base/rpt_active_user_base.sql
@@ -61,6 +61,7 @@ with servers as (
 )
 select
     servers.*,
+    last_known_server_info.server_ip as last_known_server_ip,
     case
         -- TODO: separate IPv6 from `Unknown`
         when parse_ip(last_known_server_info.server_ip, 'INET', 1):error is not null then 'Unknown'

--- a/transform/mattermost-analytics/models/reports/product/active_user_base/rpt_active_user_base.sql
+++ b/transform/mattermost-analytics/models/reports/product/active_user_base/rpt_active_user_base.sql
@@ -73,9 +73,8 @@ from
             on parse_ip(last_known_server_info.server_ip, 'INET', 1):ipv4 between l.ipv4_range_start and l.ipv4_range_end
     left join last_known_oauth_info oauth on fct_active_users.server_id = oauth.server_id
 where
-    -- Keep servers with at least one user reported on the last couple of days. This is the last day with full data.
-    -- Note that as telemetry might be send over the date, last date for a server might be either today or yesterday.
-    fct_active_users.activity_date >=  dateadd(day, -1, current_date)
+    -- Keep servers with at least one user reported on the last 30 days.
+    fct_active_users.activity_date >=  dateadd(day, -30, current_date)
     and (fct_active_users.server_monthly_active_users ) > 0
     -- Exclusion reasons - any server with any exclusion reason is excluded by default
     and dim_excludable_servers.server_id is null

--- a/transform/mattermost-analytics/models/reports/product/active_user_base/rpt_active_user_base.sql
+++ b/transform/mattermost-analytics/models/reports/product/active_user_base/rpt_active_user_base.sql
@@ -86,4 +86,4 @@ from
     left join last_known_server_info on servers.server_id = last_known_server_info.server_id
     left join {{ ref('int_ip_country_lookup') }} l
             on parse_ip(last_known_server_info.server_ip, 'INET', 1):ipv4 between l.ipv4_range_start and l.ipv4_range_end
-    left join last_known_oauth_info oauth on fct_active_users.server_id = oauth.server_id
+    left join last_known_oauth_info oauth on servers.server_id = oauth.server_id


### PR DESCRIPTION
#### Summary

Consider active as any server that has sent telemetry in the last 30 days.
