### PR TITLE
Hotfix: handle empty strings in company name

### DIFF
--- a/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
+++ b/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
@@ -50,7 +50,7 @@ renamed as (
         -- Company info
         companycountry as country_name,
         case
-            when companyname = '' then null
+            when trim(companyname) = '' then null
             else companyname
         end as company_name,
         companysize as company_size_bucket,


### PR DESCRIPTION
#### Summary

Properly handle whitespace characters as company name.