### PR TITLE
Hotfix: handle unknown in country name

### DIFF
--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_in_product_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_in_product_trial_requests.sql
@@ -38,6 +38,7 @@ with trial_requests as (
         case
            -- Fix inconsistency in country name so that it matches values expected by SF
            when country_name = 'United States of America' then 'United States'
+           when country_name is null then ''
            else country_name
         end as country,                                     -- Mapped to field country - Can be either name or country code
         start_at as trial_start_at,                         -- Mapped to request_a_trial_date__c and Click_to_Accept_Date_Time_Trial__c

--- a/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
+++ b/transform/mattermost-analytics/models/staging/cws/stg_cws__trial_requests.sql
@@ -48,7 +48,11 @@ renamed as (
         end as contact_email,
 
         -- Company info
-        companycountry as country_name,
+        case
+            when companycountry = 'Unknown' then null
+            when companycountry = '' then null
+            else companycountry
+        end as country_name,
         case
             when trim(companyname) = '' then null
             else companyname


### PR DESCRIPTION
#### Summary

- [x] Handle `Unknown` country names.
- [x] Consistently handle empty country strings.