### PR TITLE
Adjust fct_subscription_history join and other fields

### DIFF
--- a/transform/mattermost-analytics/models/marts/sales/fct_subscription_history.sql
+++ b/transform/mattermost-analytics/models/marts/sales/fct_subscription_history.sql
@@ -11,7 +11,7 @@ select
     , s.billing_type
     , s.status
     , CASE 
-        WHEN sh.subscription_id IS NULL THEN NULL -- Return NULL if no history found, so looker can filter for NULL OR TRUE
+        WHEN sh.subscription_id IS NULL THEN true -- If there isn't a matching subscription history value this is treated as the latest one
         ELSE ROW_NUMBER() OVER (PARTITION BY sh.subscription_id ORDER BY sh.created_at DESC) = 1 
     END AS is_latest
 from

--- a/transform/mattermost-analytics/models/staging/stripe/stg_stripe__subscriptions.sql
+++ b/transform/mattermost-analytics/models/staging/stripe/stg_stripe__subscriptions.sql
@@ -75,7 +75,7 @@ subscriptions as (
             -- License data available
             when metadata:"cws-license-end-date"::int > 0 then TRY_TO_TIMESTAMP_NTZ(metadata:"cws-license-end-date"::varchar)
             -- Cloud Licensed Subscriptions, sales serve (fields set by humans, formatted 2024-05-22)
-            when metadata:"license-end-at"::varchar  != '' then TRY_TO_TIMESTAMP_NTZ(metadata:"license-end-at"::varchar)
+            when metadata:"license-end-at"::varchar  != '' then TRY_TO_TIMESTAMP_NTZ(metadata:"license-end-date"::varchar)
             -- Handle backfills
             when sfdc_migrated_license_id is not null then current_period_end_at
             -- Handle bug where both license start and end date is 0

--- a/transform/mattermost-analytics/models/staging/stripe/stg_stripe__subscriptions.sql
+++ b/transform/mattermost-analytics/models/staging/stripe/stg_stripe__subscriptions.sql
@@ -75,7 +75,7 @@ subscriptions as (
             -- License data available
             when metadata:"cws-license-end-date"::int > 0 then TRY_TO_TIMESTAMP_NTZ(metadata:"cws-license-end-date"::varchar)
             -- Cloud Licensed Subscriptions, sales serve (fields set by humans, formatted 2024-05-22)
-            when metadata:"license-end-at"::varchar  != '' then TRY_TO_TIMESTAMP_NTZ(metadata:"license-end-date"::varchar)
+            when metadata:"license-end-date"::varchar  != '' then TRY_TO_TIMESTAMP_NTZ(metadata:"license-end-date"::varchar)
             -- Handle backfills
             when sfdc_migrated_license_id is not null then current_period_end_at
             -- Handle bug where both license start and end date is 0


### PR DESCRIPTION
#### Summary
Adjusts the fct_subscription_history table to right join on subscriptions
Adjusts the `IS_LATEST` logic to set the value to TRUE if there isn't a matching subscription history event for a given subscription (from the right join) - this allows us to not have to do sub queries to check for iff there is only one is_latest = false for a record. 
Filters records that don't have a s.CWS_INSTALLATION value, as non cloud workspaces are irrelevant to this data set


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

