### PR TITLE
Update stripe subscription model

### DIFF
--- a/transform/mattermost-analytics/models/marts/sales/fct_subscription_history.sql
+++ b/transform/mattermost-analytics/models/marts/sales/fct_subscription_history.sql
@@ -2,7 +2,7 @@ select
     sh.subscription_history_event_id
     , s.subscription_id
     , s.customer_id
-    , COALESCE(sh.licensed_seats, s.quantity) as licensed_seats
+    , COALESCE(sh.licensed_seats, s.metadata:"license-seats", s.quantity) as licensed_seats
     , sh.created_at
     , s.cws_dns
     , s.cws_installation

--- a/transform/mattermost-analytics/models/marts/sales/fct_subscription_history.sql
+++ b/transform/mattermost-analytics/models/marts/sales/fct_subscription_history.sql
@@ -2,7 +2,7 @@ select
     sh.subscription_history_event_id
     , s.subscription_id
     , s.customer_id
-    , COALESCE(sh.licensed_seats, s.metadata:"license-seats", s.quantity) as licensed_seats
+    , COALESCE(sh.licensed_seats, s.quantity) as licensed_seats
     , sh.created_at
     , s.cws_dns
     , s.cws_installation

--- a/transform/mattermost-analytics/models/staging/stripe/_stripe__models.yml
+++ b/transform/mattermost-analytics/models/staging/stripe/_stripe__models.yml
@@ -448,7 +448,7 @@ models:
       - name: proration_details
         description: Additional details for proration line items
       - name: quantity
-        description: Quantity of units for the invoice item.
+        description: Quantity of units for the invoice item. This quantity represents the number of seats purchased.
       - name: subscription_id
         description: The subscription that this invoice item has been created for, if any.
       - name: subscription_item

--- a/transform/mattermost-analytics/models/staging/stripe/stg_stripe__subscriptions.sql
+++ b/transform/mattermost-analytics/models/staging/stripe/stg_stripe__subscriptions.sql
@@ -39,7 +39,10 @@ subscriptions as (
         items,
         livemode,
         pending_setup_intent,
-        quantity,
+        case 
+            when metadata:"license-seats"::int > 0 then metadata:"license-seats"::int
+            else quantity
+        end as quantity,
         status,
         tax_percent,
         updated_by_event_type,


### PR DESCRIPTION
#### Summary
For licensed subscriptions, the Quantity will be 0, and the metadata `license-seats` will contain the actual quantity. This PR makes it so that the latter is used if defined, otherwise, it will use the former. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
N/A

