### PR TITLE
Chore: handle backfilled licenses

### DIFF
--- a/transform/mattermost-analytics/models/staging/cws/_cws__models.yml
+++ b/transform/mattermost-analytics/models/staging/cws/_cws__models.yml
@@ -115,6 +115,16 @@ models:
       - name: sku_short_name
       - name: is_gov_sku
       - name: is_trial
+        description: |
+          Whether the license is a trial license or not. This value is not always taken directly from field value, as
+          it may be set to true for licenses that are not actually trial licenses. One such case is backfilled licenses
+          from Salesforce to Stripe.
+        tests:
+            - accepted_values:
+                # Backfilled licenses from Salesforce to Stripe are not trial licenses.
+                values: [ false ]
+                config:
+                    where: "company_name = 'sfdc-migration' and starts_at <'2023-04-01'"
       - name: company_name
       - name: customer_email
       - name: customer_id

--- a/transform/mattermost-analytics/models/staging/cws/stg_cws__license.sql
+++ b/transform/mattermost-analytics/models/staging/cws/stg_cws__license.sql
@@ -23,7 +23,12 @@ renamed as (
         , _license:sku_name::varchar as stripe_product_id
         , _license:sku_short_name::varchar as sku_short_name
         , _license:is_gov_sku::boolean as is_gov_sku
-        , _license:is_trial::boolean as is_trial
+        , case
+            -- Handle backfills from SFDC.
+            when _license:customer:company::varchar = 'sfdc-migration' and starts_at <'2023-04-01' then false
+            else _license:is_trial::boolean
+        end as is_trial
+
 
         -- Company information
         , _license:customer:company::varchar as company_name


### PR DESCRIPTION
#### Summary

Handle special case of licenses that have been backfilled and are falsely reported as trials.
