### PR TITLE
MM-52375 - Move more dbt models from hourly to nightly build cadence

### DIFF
--- a/transform/snowflake-dbt/models/blp/license_overview.sql
+++ b/transform/snowflake-dbt/models/blp/license_overview.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": "table",
     "schema": "blp"
+    "tags":["nightly"],
   })
 }}
 

--- a/transform/snowflake-dbt/models/blp/licenses.sql
+++ b/transform/snowflake-dbt/models/blp/licenses.sql
@@ -2,7 +2,7 @@
     "materialized": 'incremental',
     "schema": "blp",
     "unique_key": 'id',
-    "tags":'nightly'
+    "tags":['nightly']
   })
 }}
 

--- a/transform/snowflake-dbt/models/events/hourly/incident_response_events.sql
+++ b/transform/snowflake-dbt/models/events/hourly/incident_response_events.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "events",
-    "tags":"[nightly]"
+    "tags":["nightly"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/events/hourly/incident_response_events.sql
+++ b/transform/snowflake-dbt/models/events/hourly/incident_response_events.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "events",
-    "tags":"hourly"
+    "tags":"[nightly]"
   })
 }}
 

--- a/transform/snowflake-dbt/models/focalboard/focalboard_activity.sql
+++ b/transform/snowflake-dbt/models/focalboard/focalboard_activity.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "focalboard",
-    "tags":"hourly",
+    "tags":"[nightly]",
     "unique_key":"id"
   })
 }}

--- a/transform/snowflake-dbt/models/focalboard/focalboard_activity.sql
+++ b/transform/snowflake-dbt/models/focalboard/focalboard_activity.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "focalboard",
-    "tags":"[nightly]",
+    "tags":["nightly"],
     "unique_key":"id"
   })
 }}

--- a/transform/snowflake-dbt/models/focalboard/focalboard_blocks.sql
+++ b/transform/snowflake-dbt/models/focalboard/focalboard_blocks.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "focalboard",
-    "tags":"hourly",
+    "tags":"[nightly]",
     "unique_key":"id"
   })
 }}

--- a/transform/snowflake-dbt/models/focalboard/focalboard_blocks.sql
+++ b/transform/snowflake-dbt/models/focalboard/focalboard_blocks.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "focalboard",
-    "tags":"[nightly]",
+    "tags":["nightly"],
     "unique_key":"id"
   })
 }}

--- a/transform/snowflake-dbt/models/focalboard/focalboard_config.sql
+++ b/transform/snowflake-dbt/models/focalboard/focalboard_config.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "focalboard",
-    "tags":"hourly",
+    "tags":"[nightly]",
     "unique_key":"id"
   })
 }}

--- a/transform/snowflake-dbt/models/focalboard/focalboard_config.sql
+++ b/transform/snowflake-dbt/models/focalboard/focalboard_config.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "focalboard",
-    "tags":"[nightly]",
+    "tags":["nightly"],
     "unique_key":"id"
   })
 }}

--- a/transform/snowflake-dbt/models/focalboard/focalboard_server.sql
+++ b/transform/snowflake-dbt/models/focalboard/focalboard_server.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "focalboard",
-    "tags":"hourly",
+    "tags":"[nightly]",
     "unique_key":"id"
   })
 }}

--- a/transform/snowflake-dbt/models/focalboard/focalboard_server.sql
+++ b/transform/snowflake-dbt/models/focalboard/focalboard_server.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "focalboard",
-    "tags":"[nightly]",
+    "tags":["nightly"],
     "unique_key":"id"
   })
 }}

--- a/transform/snowflake-dbt/models/focalboard/focalboard_workspaces.sql
+++ b/transform/snowflake-dbt/models/focalboard/focalboard_workspaces.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "focalboard",
-    "tags":"hourly",
+    "tags":"[nightly]",
     "unique_key":"id"
   })
 }}

--- a/transform/snowflake-dbt/models/focalboard/focalboard_workspaces.sql
+++ b/transform/snowflake-dbt/models/focalboard/focalboard_workspaces.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "focalboard",
-    "tags":"[nightly]",
+    "tags":["nightly"],
     "unique_key":"id"
   })
 }}

--- a/transform/snowflake-dbt/models/incident_collaboration/incident_collaboration_fact.sql
+++ b/transform/snowflake-dbt/models/incident_collaboration/incident_collaboration_fact.sql
@@ -1,9 +1,9 @@
 {{config({
     "materialized": "incremental",
     "schema": "incident_collaboration",
-    "tags":"[nightly]",
+    "tags":["nightly"],
     "unique_key":"server_id",
-    "warehouse":"ANALYST_XS"
+    "warehouse":"TRANSFORM_XS"
   })
 }}
 

--- a/transform/snowflake-dbt/models/incident_collaboration/incident_collaboration_fact.sql
+++ b/transform/snowflake-dbt/models/incident_collaboration/incident_collaboration_fact.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "incident_collaboration",
-    "tags":"hourly",
+    "tags":"[nightly]",
     "unique_key":"server_id",
     "warehouse":"ANALYST_XS"
   })

--- a/transform/snowflake-dbt/models/incident_collaboration/incident_daily_details.sql
+++ b/transform/snowflake-dbt/models/incident_collaboration/incident_daily_details.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "incident_collaboration",
-    "tags":"hourly",
+    "tags":"[nightly]",
     "unique_key":"id",
     "warehouse":"ANALYST_XS"
   })

--- a/transform/snowflake-dbt/models/incident_collaboration/incident_daily_details.sql
+++ b/transform/snowflake-dbt/models/incident_collaboration/incident_daily_details.sql
@@ -1,9 +1,9 @@
 {{config({
     "materialized": "incremental",
     "schema": "incident_collaboration",
-    "tags":"[nightly]",
+    "tags":["nightly"],
     "unique_key":"id",
-    "warehouse":"ANALYST_XS"
+    "warehouse":"TRANSFORM_XS"
   })
 }}
  

--- a/transform/snowflake-dbt/models/qa/incident_response_telemetry.sql
+++ b/transform/snowflake-dbt/models/qa/incident_response_telemetry.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "qa",
-    "tags":"hourly"
+    "tags":"[nightly]"
   })
 }}
 

--- a/transform/snowflake-dbt/models/qa/incident_response_telemetry.sql
+++ b/transform/snowflake-dbt/models/qa/incident_response_telemetry.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "qa",
-    "tags":"[nightly]"
+    "tags":["nightly"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/sales/marketing_funnel.sql
+++ b/transform/snowflake-dbt/models/sales/marketing_funnel.sql
@@ -1,7 +1,8 @@
 {{
   config({
     "materialized": 'table',
-    "schema": "sales"
+    "schema": "sales",
+    "tags":["nightly"]
   })
 }}
 


### PR DESCRIPTION
#### Summary
- move incident response/collaboration and focalboard models from hourly to nightly build cadence.
- moving incident collaboration flows from ANALYTS_XS to TRANSFORM_XS as a precursor for warehouse consolidation.
- move some blp models - candidates for deprecation? (TBD)
- moving marketing_funnel to nightly as well since the Marketing team is not currently using the Looker reports. Next would be the web traffic-related models (TBD). 
 
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52375