### PR TITLE
Hotfix: fix server daily details ext duplicate issue

### DIFF
--- a/transform/snowflake-dbt/models/mattermost/nightly/server_daily_details_ext.sql
+++ b/transform/snowflake-dbt/models/mattermost/nightly/server_daily_details_ext.sql
@@ -1,6 +1,7 @@
 {{config({
     "materialized": 'incremental',
     "schema": "mattermost",
+    "incremental_strategy": "delete+insert",
     "unique_key":'id',
     "snowflake_warehouse": "transform_l"
   })


### PR DESCRIPTION
#### Summary

Handle failure to insert duplicate in server daily details ext due to incompletely configured merge strategy.