### PR TITLE
Chore: add license dimension to active servers

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/licenses/_daily_licenses/int_server_license_daily.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/licenses/_daily_licenses/int_server_license_daily.sql
@@ -1,3 +1,10 @@
+-- Temporary materialize
+{{
+  config({
+    "materialized": "table"
+  })
+}}
+
 with daily_licenses as (
     select
         server_id

--- a/transform/mattermost-analytics/models/intermediate/product/licenses/_daily_licenses/int_server_license_daily.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/licenses/_daily_licenses/int_server_license_daily.sql
@@ -1,10 +1,3 @@
--- Temporary materialize
-{{
-  config({
-    "materialized": "table"
-  })
-}}
-
 with daily_licenses as (
     select
         server_id

--- a/transform/mattermost-analytics/models/intermediate/product/licenses/_daily_licenses/int_server_license_daily.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/licenses/_daily_licenses/int_server_license_daily.sql
@@ -33,7 +33,7 @@ with daily_licenses as (
         {{ ref('stg_mattermost2__license') }}
 )
 select
-    {{ dbt_utils.generate_surrogate_key(['server_id', 'license_telemetry_date']) }} AS daily_server_id,
+    {{ dbt_utils.generate_surrogate_key(['server_id', 'license_telemetry_date']) }} AS daily_server_id
     , server_id
     , license_telemetry_date
     , license_id

--- a/transform/mattermost-analytics/models/intermediate/product/licenses/_daily_licenses/int_server_license_daily.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/licenses/_daily_licenses/int_server_license_daily.sql
@@ -1,0 +1,51 @@
+with daily_licenses as (
+    select
+        server_id
+        , license_telemetry_date
+        , license_id
+        , customer_id
+        , installation_id
+        , license_name
+        , licensed_seats
+        , issued_at
+        , starts_at
+        , expire_at
+        , timestamp
+    from
+        {{ ref('stg_mm_telemetry_prod__license') }}
+
+    union
+
+    select
+        server_id
+        , license_telemetry_date
+        , license_id
+        , customer_id
+        -- Installation ID not reported by segment
+        , null as installation_id
+        , license_name
+        , licensed_seats
+        , issued_at
+        , starts_at
+        , expire_at
+        , timestamp
+    from
+        {{ ref('stg_mattermost2__license') }}
+)
+select
+    {{ dbt_utils.generate_surrogate_key(['server_id', 'license_telemetry_date']) }} AS daily_server_id,
+    , server_id
+    , license_telemetry_date
+    , license_id
+    , customer_id
+    , installation_id
+    , license_name
+    , licensed_seats
+    , issued_at
+    , starts_at
+    , expire_at
+    , expire_at < license_telemetry_date as has_license_expired
+from
+    daily_licenses
+-- Keep latest license per day
+qualify row_number() over (partition by server_id, license_telemetry_date order by timestamp desc) = 1

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -222,6 +222,9 @@ models:
         tests:
           - unique
           - not_null
+          - relationships:
+              to: ref('dim_daily_license')
+              field: daily_server_id
       - name: activity_date
         description: The date for the measurement.
         tests:
@@ -258,6 +261,10 @@ models:
         description: Whether there were security update server data reported for this server on the given date.
       - name: is_missing_activity_data
         description: Whether server activity data are available for the given date and server id.
+      - name: licensed_seats
+        description: The number of licensed seats, as reported by telemetry.
+      - name: is_missing_license_data
+        description: Whether license data are unavailable for the date.
 
   - name: dim_server_info
     description: Static information for a given server.
@@ -400,3 +407,56 @@ models:
         description: The most recent server id reporting the current installation id.
       - name: count_server_id
         description: The number of unique server ids reporting the current installation id.
+
+
+  - name: dim_daily_license
+    description: | 
+      Summary of license information for each server, based on license reported by telemetry. License is enriched with 
+      CWS data.
+
+    columns:
+      - name: daily_server_id
+        description: A unique id for each server and date
+        tests:
+          - unique
+          - not_null
+      - name: server_id
+        description: The server's unique id.
+      - name: license_telemetry_date
+        description: The date the license was reported by telemetry.
+      - name: license_id
+        description: The license's unique identifier.
+      - name: customer_id
+        description: The id of the customer assigned to the license. Taken from telemetry data.
+      - name: license_name
+        description: The name of the current license.
+      - name: licensed_seats
+        description: The number of licensed seats for the current license.
+      - name: issued_at
+        description: The date and time the license was issued at.
+      - name: starts_at
+        description: The date and time the license started at.
+      - name: expire_at
+        description: The date and time the license expires at.
+      - name: has_license_expired
+        description: Whether the server reported a license that has expired.
+      - name: is_trial
+        description: Whether the license is a trial license or not.
+      - name: company_name
+        description: The name of the company that this license has been issued for.
+      - name: contact_email
+        description: The email to be used for contacting the license's holder.
+        tags: ['pii']
+      - name: sku_short_name.
+        description: The SKU for the license or `Unknown` if it's not known (i.e. in legacy licenses).
+      - name: source
+        description: |
+          The source of extra data for license. Currently "CWS" for CWS, "Legacy" for legacy license data from S3,
+          or both.
+      - name: is_matching_expiration_date
+        description: |
+          Whether the expiration date reported via telemetry is matching the telemetry date from license information.
+      - name: is_matching_license_seats
+        description: |
+          Whether the licensed seats reported via telemetry is matching the number of licensed seats from license 
+          information.

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -225,6 +225,8 @@ models:
           - relationships:
               to: ref('dim_daily_license')
               field: daily_server_id
+              config:
+                where: "not is_missing_license_data"
       - name: activity_date
         description: The date for the measurement.
         tests:

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -420,10 +420,6 @@ models:
         tests:
           - unique
           - not_null
-      - name: server_id
-        description: The server's unique id.
-      - name: license_telemetry_date
-        description: The date the license was reported by telemetry.
       - name: license_id
         description: The license's unique identifier.
       - name: customer_id

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
@@ -2,7 +2,7 @@ select
     spine.daily_server_id
     , coalesce(l.license_id, 'Unknown') as license_id
     , coalesce(l.customer_id, 'Unknown') as customer_id
-    , coalesce(l.license_name, 'Unknown') as
+    , coalesce(l.license_name, 'Unknown') as license_name
     , coalesce(l.licensed_seats, 0) as licensed_seats
     , l.issued_at
     , l.starts_at

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
@@ -4,7 +4,6 @@ select
     , l.license_telemetry_date
     , l.license_id
     , l.customer_id
-    , l.installation_id
     , l.license_name
     , l.licensed_seats
     , l.issued_at
@@ -19,7 +18,7 @@ select
 
     -- Metadata to be used for tests
     , l.expire_at = k.expire_at as is_matching_expiration_date
-    , l.licensed_seats = k.licensed_seats as is_telemetry_matching_license_seats
+    , l.licensed_seats = k.licensed_seats as is_matching_license_seats
 from
     {{ ref('int_server_license_daily') }} l
     left join {{ ref('int_known_licenses') }} k on l.license_id = k.license_id

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
@@ -18,6 +18,5 @@ select
     , l.expire_at = k.expire_at as is_matching_expiration_date
     , l.licensed_seats = k.licensed_seats as is_matching_license_seats
 from
-    {{ ref('int_server_active_days_spined') }} spine
-    left join {{ ref('int_server_license_daily') }} l on spine.daily_server_id = l.daily_server_id
+    {{ ref('int_server_license_daily') }} l
     left join {{ ref('int_known_licenses') }} k on l.license_id = k.license_id

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
@@ -1,0 +1,25 @@
+select
+    l.daily_server_id
+    , l.server_id
+    , l.license_telemetry_date
+    , l.license_id
+    , l.customer_id
+    , l.installation_id
+    , l.license_name
+    , l.licensed_seats
+    , l.issued_at
+    , l.starts_at
+    , l.expire_at
+    , l.has_license_expired
+    , k.is_trial
+    , k.company_name
+    , k.contact_email
+    , k.sku_short_name
+    , k.source
+
+    -- Metadata to be used for tests
+    , l.expire_at = k.expire_at as is_matching_expiration_date
+    , l.licensed_seats = k.licensed_seats
+from
+    {{ ref('int_server_license_daily') }} l
+    left join {{ ref('int_known_licenses') }} k on l.license_id = k.license_id

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
@@ -19,7 +19,7 @@ select
 
     -- Metadata to be used for tests
     , l.expire_at = k.expire_at as is_matching_expiration_date
-    , l.licensed_seats = k.licensed_seats
+    , l.licensed_seats = k.licensed_seats as is_telemetry_matching_license_seats
 from
     {{ ref('int_server_license_daily') }} l
     left join {{ ref('int_known_licenses') }} k on l.license_id = k.license_id

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
@@ -1,9 +1,9 @@
 select
-    spine.daily_server_id
-    , coalesce(l.license_id, 'Unknown') as license_id
-    , coalesce(l.customer_id, 'Unknown') as customer_id
-    , coalesce(l.license_name, 'Unknown') as license_name
-    , coalesce(l.licensed_seats, 0) as licensed_seats
+    l.daily_server_id
+    , l.license_id
+    , l.customer_id
+    , l.license_name
+    , l.licensed_seats
     , l.issued_at
     , l.starts_at
     , l.expire_at

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
@@ -1,24 +1,23 @@
 select
-    l.daily_server_id
-    , l.server_id
-    , l.license_telemetry_date
-    , l.license_id
-    , l.customer_id
-    , l.license_name
-    , l.licensed_seats
+    spine.daily_server_id
+    , coalesce(l.license_id, 'Unknown') as license_id
+    , coalesce(l.customer_id, 'Unknown') as customer_id
+    , coalesce(l.license_name, 'Unknown') as
+    , coalesce(l.licensed_seats, 0) as licensed_seats
     , l.issued_at
     , l.starts_at
     , l.expire_at
     , l.has_license_expired
     , k.is_trial
-    , k.company_name
-    , k.contact_email
-    , k.sku_short_name
-    , k.source
+    , coalesce(k.company_name, 'Unknown') as company_name
+    , coalesce(k.contact_email, 'Unknown') as contact_email
+    , coalesce(k.sku_short_name, 'Unknown') as sku_short_name
+    , coalesce(k.source, 'None') as source
 
     -- Metadata to be used for tests
     , l.expire_at = k.expire_at as is_matching_expiration_date
     , l.licensed_seats = k.licensed_seats as is_matching_license_seats
 from
-    {{ ref('int_server_license_daily') }} l
+    {{ ref('int_server_active_days_spined') }} spine
+    left join {{ ref('int_server_license_daily') }} l on spine.daily_server_id = l.daily_server_id
     left join {{ ref('int_known_licenses') }} k on l.license_id = k.license_id

--- a/transform/mattermost-analytics/models/marts/product/fct_active_servers.sql
+++ b/transform/mattermost-analytics/models/marts/product/fct_active_servers.sql
@@ -31,7 +31,8 @@ select
     s.has_telemetry_data,
     s.has_legacy_telemetry_data,
     s.has_diagnostics_data,
-    s.is_missing_activity_data
+    s.is_missing_activity_data,
+    l.daily_server_id is null as is_missing_license_data
 from
     {{ ref('int_server_active_days_spined') }} s
     left join {{ ref('int_server_license_daily') }} l on s.daily_server_id = l.daily_server_id

--- a/transform/mattermost-analytics/models/marts/product/fct_active_servers.sql
+++ b/transform/mattermost-analytics/models/marts/product/fct_active_servers.sql
@@ -1,33 +1,37 @@
 select
     -- Identifiers
-    daily_server_id,
-    server_id,
-    activity_date,
+    s.daily_server_id,
+    s.server_id,
+    s.activity_date,
 
     -- Dimensions
+    l.license_id,
     {{ dbt_utils.generate_surrogate_key(['version_full']) }} AS version_id,
     -- Degenerate dimensions
-    installation_type,
+    s.installation_type,
     case
-        when count_registered_active_users < 10 then '< 10'
-        when count_registered_active_users >= 10 and count_registered_active_users < 100 then '10-100'
-        when count_registered_active_users >= 100 and count_registered_active_users < 250 then '100-250'
-        when count_registered_active_users >= 250 and count_registered_active_users < 500 then '250-500'
-        when count_registered_active_users >= 500 and count_registered_active_users < 1000 then '500-1000'
-        when count_registered_active_users >= 1000 and count_registered_active_users < 2500 then '1000-2500'
-        when count_registered_active_users >= 2500 then '>=2500'
+        when s.count_registered_active_users < 10 then '< 10'
+        when s.count_registered_active_users >= 10 and s.count_registered_active_users < 100 then '10-100'
+        when s.count_registered_active_users >= 100 and s.count_registered_active_users < 250 then '100-250'
+        when s.count_registered_active_users >= 250 and s.count_registered_active_users < 500 then '250-500'
+        when s.count_registered_active_users >= 500 and s.count_registered_active_users < 1000 then '500-1000'
+        when s.count_registered_active_users >= 1000 and s.count_registered_active_users < 2500 then '1000-2500'
+        when s.count_registered_active_users >= 2500 then '>=2500'
         else 'Unknown'
     end as registered_user_bin,
 
     -- Facts
-    count_registered_active_users,
-    is_enterprise_ready,
-    count_reported_versions,
+    s.count_registered_active_users,
+    s.is_enterprise_ready,
+    s.count_reported_versions,
+    -- TODO: handle cloud instances.
+    coalesce(l.licensed_seats, 0) as licensed_seats,
 
     -- Metadata
-    has_telemetry_data,
-    has_legacy_telemetry_data,
-    has_diagnostics_data,
-    is_missing_activity_data
+    s.has_telemetry_data,
+    s.has_legacy_telemetry_data,
+    s.has_diagnostics_data,
+    s.is_missing_activity_data
 from
-    {{ ref('int_server_active_days_spined') }}
+    {{ ref('int_server_active_days_spined') }} s
+    left join {{ ref('int_server_license_daily') }} l on s.daily_server_id = l.daily_server_id


### PR DESCRIPTION
#### Summary

- [x] Add daily license dimension to active servers.
- [x]  Add licensed seats for onprem servers.

Seats for cloud installations shall be added in a separate PR.