### PR TITLE
Hotfix: properly handle different user id columns

### DIFF
--- a/transform/mattermost-analytics/models/staging/copilot/stg_copilot__tracks.sql
+++ b/transform/mattermost-analytics/models/staging/copilot/stg_copilot__tracks.sql
@@ -3,7 +3,7 @@ select
     , event as event_table
     , event_text as event_name
     , user_id as server_id
-    , actual_user_id as user_id
+    , coalesce(actual_user_id, user_actual_id) as user_id
     , received_at as received_at
     , timestamp  as timestamp
     -- Backfill past events


### PR DESCRIPTION
#### Summary

Build on top of previous hotfix. Seems that some events use `user_actual_id`, while others use `actual_user_id` for user id.