### PR TITLE
MM-60014 - Update freshness check on `user_start_recording` Calls event.

### DIFF
--- a/transform/mattermost-analytics/models/staging/mm_calls_test_go/_mm_calls_test_go__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mm_calls_test_go/_mm_calls_test_go__sources.yml
@@ -34,6 +34,7 @@ sources:
       - name: user_raise_hand
       - name: user_share_screen
       - name: user_start_recording
+        freshness: null # Events are really sparse
       - name: user_stop_recording
         freshness: null # Events are really sparse
       - name: user_unshare_screen

--- a/transform/mattermost-analytics/models/staging/mm_calls_test_go/_mm_calls_test_go__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mm_calls_test_go/_mm_calls_test_go__sources.yml
@@ -34,9 +34,15 @@ sources:
       - name: user_raise_hand
       - name: user_share_screen
       - name: user_start_recording
-        freshness: null # Events are really sparse
+        freshness: # Check that telemetry data have been received in the past 7 days
+        warn_after: { count: 4, period: day }
+        error_after: { count: 7, period: day }
+        loaded_at_field: received_at
       - name: user_stop_recording
-        freshness: null # Events are really sparse
+        freshness: # Check that telemetry data have been received in the past 14 days
+        warn_after: { count: 7, period: day }
+        error_after: { count: 14, period: day }
+        loaded_at_field: received_at
       - name: user_unshare_screen
 
       - name: tracks


### PR DESCRIPTION
#### Summary
Update freshness check on `user_start_recording` Calls event.
Note: this unblocks current dbt mattermost-analytics nightly job failures.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60014
