### PR TITLE
MM-60178 - propagate more Stripe data source fields to the fct_trial_request_history table

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_cloud_trial_requests_history.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_cloud_trial_requests_history.sql
@@ -21,6 +21,7 @@ subscriptions as (
         , trial_end_at
         , product_id
         , created_at
+        , converted_to_paid_at
         , status
     from
         {{ ref('stg_stripe__subscriptions') }}

--- a/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_cloud_trial_requests_history.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_cloud_trial_requests_history.sql
@@ -19,7 +19,7 @@ subscriptions as (
         , customer_id
         , trial_start_at
         , trial_end_at
-        , product_id
+        , product_id as stripe_product_id
         , created_at
         , converted_to_paid_at
         , status
@@ -40,7 +40,7 @@ select
     , subscriptions.created_at::date as created_at
     , subscriptions.trial_start_at as start_at
     , subscriptions.trial_end_at as end_at
-    , subscriptions.product_id as product_id
+    , subscriptions.stripe_product_id as stripe_product_id
     , subscriptions.converted_to_paid_at as converted_to_paid_at
     , subscriptions.status as status
     , 'Stripe' as request_source

--- a/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_cloud_trial_requests_history.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_cloud_trial_requests_history.sql
@@ -21,6 +21,7 @@ subscriptions as (
         , trial_end_at
         , product_id
         , created_at
+        , status
     from
         {{ ref('stg_stripe__subscriptions') }}
 )
@@ -38,6 +39,9 @@ select
     , subscriptions.created_at::date as created_at
     , subscriptions.trial_start_at as start_at
     , subscriptions.trial_end_at as end_at
+    , subscriptions.product_id as product_id
+    , subscriptions.converted_to_paid_at as converted_to_paid_at
+    , subscriptions.status as status
     , 'Stripe' as request_source
     , 'cloud' as request_type
 from

--- a/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_onprem_trial_requests_history.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_onprem_trial_requests_history.sql
@@ -21,6 +21,9 @@ select
     , tr.start_at::date as created_at
     , tr.start_at
     , tr.end_at
+    , null as product_id
+    , null as converted_to_paid_at
+    , null as status
     , case
         when lower(site_url) = 'https://mattermost.com' then 'Website'
         else 'In-Product'

--- a/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_onprem_trial_requests_history.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_onprem_trial_requests_history.sql
@@ -21,7 +21,7 @@ select
     , tr.start_at::date as created_at
     , tr.start_at
     , tr.end_at
-    , null as product_id
+    , null as stripe_product_id
     , null as converted_to_paid_at
     , null as status
     , case

--- a/transform/mattermost-analytics/models/marts/product/trial_requests/fct_trial_request_history.sql
+++ b/transform/mattermost-analytics/models/marts/product/trial_requests/fct_trial_request_history.sql
@@ -40,7 +40,7 @@ select
     , tr.end_at
     , tr.request_source
     , tr.request_type
-    , tr.product_id
+    , tr.stripe_product_id
     , tr.converted_to_paid_at
     , tr.status
     , agg.first_trial_start_at

--- a/transform/mattermost-analytics/models/marts/product/trial_requests/fct_trial_request_history.sql
+++ b/transform/mattermost-analytics/models/marts/product/trial_requests/fct_trial_request_history.sql
@@ -40,6 +40,9 @@ select
     , tr.end_at
     , tr.request_source
     , tr.request_type
+    , tr.product_id
+    , tr.converted_to_paid_at
+    , tr.status
     , agg.first_trial_start_at
     , agg.last_trial_start_at
     , agg.num_company_types


### PR DESCRIPTION
#### Summary
Propagate more Stripe data source fields to the `fct_trial_request_history` table.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-60178
