### PR TITLE
Chore: Add converted_to_paid_at field to fct_subscription_history model

### DIFF
--- a/transform/mattermost-analytics/models/marts/sales/fct_subscription_history.sql
+++ b/transform/mattermost-analytics/models/marts/sales/fct_subscription_history.sql
@@ -4,6 +4,7 @@ select
     , s.customer_id
     , COALESCE(sh.licensed_seats, s.quantity) as licensed_seats
     , sh.created_at
+    , s.converted_to_paid_at
     , s.cws_dns
     , s.cws_installation
     , s.license_start_at


### PR DESCRIPTION
#### Summary
Add Stripe's `converted_to_paid_at` field to fct_subscription_history model.
