### PR TITLE
MM-58167: add country to server information

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -175,6 +175,9 @@ vars:
   # List of Known SKUs
   known_skus: ["professional", "enterprise"]
 
+  # List of excludable countries
+  excluded_countries: ["Russia", "Iran", "North Korea"]
+
 on-run-start:
   -  '{{ create_parse_qs_udf()}}'
   -  '{{ create_extract_license_data_udf()}}'

--- a/transform/mattermost-analytics/models/intermediate/product/servers/_excludable_servers/_int_servers__excludable_servers__models.yml
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/_excludable_servers/_int_servers__excludable_servers__models.yml
@@ -52,3 +52,12 @@ models:
         description: The server id.
       - name: reason
         description: The reason that this server is excluded.
+
+
+  - name: int_excludable_servers_country
+    description: List of servers with a last known country in the list of excluded countries.
+    columns:
+      - name: server_id
+        description: The server id.
+      - name: reason
+        description: The reason that this server is excluded.

--- a/transform/mattermost-analytics/models/intermediate/product/servers/_excludable_servers/int_excludable_servers_country.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/_excludable_servers/int_excludable_servers_country.sql
@@ -1,0 +1,11 @@
+select
+    server_id,
+    'Country' as reason
+from
+    {{ ref('int_server_ip_to_country') }}
+where
+    last_known_ip_country in (
+{% for country in var('excluded_countries') %}
+    '{{ country }}'{% if not loop.last %},{% endif %}
+{% endfor %}
+    )

--- a/transform/mattermost-analytics/models/intermediate/product/servers/_int_servers__models.yml
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/_int_servers__models.yml
@@ -150,3 +150,39 @@ models:
         description: The server's installation id.
       - name: cloud_hostname
         description: The name of the cloud workspace. Must be in format `<name>.cloud.mattermost.com`.
+
+  - name: int_server_telemetry_summary
+    description: A summary of telemetry received from each server.
+
+    columns:
+      - name: server_id
+        description: The server id.
+      - name: first_activity_date
+        description: The first date that telemetry was received from the server.
+      - name: last_activity_date
+        description: The last date that telemetry was received from the server.
+      - name: first_binary_edition
+        description: The first binary edition reported by the server.
+      - name: last_binary_edition
+        description: The last binary edition reported by the server.
+      - name: first_count_registered_active_users
+        description: The first count of registered (but not deleted) users reported by the server.
+      - name: last_count_registered_active_users
+        description: The last count of registered (but not deleted) users reported by the server.
+      - name: last_daily_active_users
+        description: The last daily active users reported by the server.
+      - name: last_monthly_active_users
+        description: The last monthly active users reported by the server.
+      - name: last_server_ip
+        description: The last known IP address of the server.
+
+  - name: int_server_ip_to_country
+    description: A mapping of server to country via the server's last known IP address.
+
+    columns:
+      - name: server_id
+        description: The server id.
+      - name: last_server_ip
+        description: The server's last known IP address.
+      - name: last_known_ip_country
+        description: The country of the server's last known IP address.

--- a/transform/mattermost-analytics/models/intermediate/product/servers/int_excludable_servers.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/int_excludable_servers.sql
@@ -22,3 +22,5 @@ union all
 select * from {{ ref('int_excludable_servers_single_day_activity') }} where server_id is not null
 union all
 select * from {{ ref('int_excludable_servers_invalid_server_id')}} where server_id is not null
+union all
+select * from {{ ref('int_excludable_servers_country')}} where server_id is not null

--- a/transform/mattermost-analytics/models/intermediate/product/servers/int_server_ip_to_country.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/int_server_ip_to_country.sql
@@ -1,0 +1,42 @@
+{{
+    config({
+        "materialized": "table",
+        "cluster_by": ["server_id"],
+        "snowflake_warehouse": "transform_l"
+    })
+}}
+
+-- Precalculate the country for each known IP address
+with server_ips as (
+    -- Store distinct IPs to avoid parsing the same IP multiple times
+    select
+        distinct
+            st.last_server_ip,
+            parse_ip(st.last_server_ip, 'INET', 1) as parsed_server_ip,
+        case
+            when parsed_server_ip:error is null
+                then parse_ip(st.last_server_ip || '/7', 'INET'):ipv4_range_start
+            else null
+        end as ip_bucket
+    from
+        {{ ref('int_server_telemetry_summary') }} st
+), ip2country as (
+    select
+        si.last_server_ip,
+        case
+            when si.parsed_server_ip:error is not null then 'Unknown'
+            else coalesce(l.country_name, 'Unknown')
+        end as last_known_ip_country
+    from
+        server_ips si
+        left join {{ ref('int_ip_country_lookup') }} l
+            on si.ip_bucket = l.join_bucket
+                and si.parsed_server_ip:ipv4 between l.ipv4_range_start and l.ipv4_range_end
+)
+select
+    st.server_id,
+    st.last_server_ip,
+    ip2c.last_known_ip_country
+from
+    {{ ref('int_server_telemetry_summary') }} st
+    left join ip2country ip2c on st.last_server_ip = ip2c.last_server_ip

--- a/transform/mattermost-analytics/models/intermediate/product/servers/int_server_telemetry_summary.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/int_server_telemetry_summary.sql
@@ -1,0 +1,16 @@
+
+select
+    server_id,
+    min(activity_date) over (partition by server_id) as first_activity_date,
+    max(activity_date) over (partition by server_id ) as last_activity_date,
+    first_value(binary_edition) over (partition by server_id order by activity_date asc) as first_binary_edition,
+    last_value(binary_edition) over (partition by server_id order by activity_date asc) as last_binary_edition,
+    first_value(count_registered_active_users) over (partition by server_id order by activity_date asc) as first_count_registered_active_users,
+    last_value(count_registered_active_users) over (partition by server_id order by activity_date asc) as last_count_registered_active_users,
+    last_value(daily_active_users) over (partition by server_id order by activity_date asc) as last_daily_active_users,
+    last_value(monthly_active_users) over (partition by server_id order by activity_date asc) as last_monthly_active_users,
+    last_value(server_ip) over (partition by server_id order by activity_date asc) as last_server_ip
+from
+    {{ ref('int_server_active_days_spined') }}
+-- Keep only one row per server as the current query creates duplicates
+qualify row_number() over (partition by server_id order by server_id) = 1

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -316,6 +316,11 @@ models:
         description: Count of daily active users on the last day that telemetry was received at.
       - name: last_monthly_active_users
         description: Count of monthly active users on the last day that telemetry was received at.
+      - name: last_server_ip
+        description: The most recent IP address of the server.
+      - name: last_known_ip_country
+        description: The last known country the server is running on, as derived from the last known IP address.
+
 
   - name: dim_daily_server_config
     description: Daily server configuration.

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -176,6 +176,8 @@ models:
         description: Whether the server is in the seed file with known test servers. Data originates from seed file.
       - name: has_reason_community
         description: Whether the server is the community server. Data originated from seed file.
+      - name: has_reason_country
+        description: Whether the server's IP is in a list of excluded countries.
 
   - name: dim_version
     description: List of known server versions

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -1,20 +1,4 @@
-with server_telemetry_summary as (
-    select
-        server_id,
-        min(activity_date) over (partition by server_id) as first_activity_date,
-        max(activity_date) over (partition by server_id ) as last_activity_date,
-        first_value(binary_edition) over (partition by server_id order by activity_date asc) as first_binary_edition,
-        last_value(binary_edition) over (partition by server_id order by activity_date asc) as last_binary_edition,
-        first_value(count_registered_active_users) over (partition by server_id order by activity_date asc) as first_count_registered_active_users,
-        last_value(count_registered_active_users) over (partition by server_id order by activity_date asc) as last_count_registered_active_users,
-        last_value(daily_active_users) over (partition by server_id order by activity_date asc) as last_daily_active_users,
-        last_value(monthly_active_users) over (partition by server_id order by activity_date asc) as last_monthly_active_users,
-        last_value(server_ip) over (partition by server_id order by activity_date asc) as last_server_ip
-    from
-        {{ ref('int_server_active_days_spined') }}
-    -- Keep only one row per server as the current query creates duplicates
-    qualify row_number() over (partition by server_id order by server_id) = 1
-), user_telemetry_summary as (
+with user_telemetry_summary as (
     select
         server_id,
         min(activity_date) as first_activity_date,
@@ -25,31 +9,6 @@ with server_telemetry_summary as (
         is_active_today
     group by
         server_id
-), server_ips as (
-    -- Store distinct IPs to avoid parsing the same IP multiple times
-    select
-        distinct
-            st.last_server_ip,
-            parse_ip(st.last_server_ip, 'INET', 1) as parsed_server_ip,
-        case
-            when parsed_server_ip:error is null
-                then parse_ip(st.last_server_ip || '/7', 'INET'):ipv4_range_start
-            else null
-        end as ip_bucket
-    from
-        server_telemetry_summary st
-), ip2country as (
-    select
-        si.last_server_ip,
-        case
-            when si.parsed_server_ip:error is not null then 'Unknown'
-            else coalesce(l.country_name, 'Unknown')
-        end as last_known_ip_country
-    from
-        server_ips si
-        left join {{ ref('int_ip_country_lookup') }} l
-            on si.ip_bucket = l.join_bucket
-                and si.parsed_server_ip:ipv4 between l.ipv4_range_start and l.ipv4_range_end
 ), server_info as (
    select
        coalesce(st.server_id, ut.server_id) as server_id,
@@ -71,7 +30,7 @@ with server_telemetry_summary as (
        st.last_monthly_active_users,
        st.last_server_ip
     from
-        server_telemetry_summary st
+        {{ ref('int_server_telemetry_summary') }} st
         full outer join user_telemetry_summary ut on st.server_id = ut.server_id
 )
 select
@@ -92,4 +51,4 @@ select
 from
     server_info si
     left join {{ ref('int_server_hosting_type') }} ht on si.server_id = ht.server_id
-    left join ip2country ip on si.last_server_ip = ip.last_server_ip
+    left join {{ ref('int_server_ip_to_country') }} ip on si.server_id = ip.server_id

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -68,14 +68,14 @@ select
     si.last_count_registered_active_users,
     si.last_daily_active_users,
     si.last_monthly_active_users,
-    si.last_server_ip,
-    case
-        when si.parsed_server_ip:error is not null then 'Unknown'
-        else coalesce(l.country_name, 'Unknown')
-    end as last_known_ip_country
+    si.last_server_ip
+--     case
+--         when si.parsed_server_ip:error is not null then 'Unknown'
+--         else coalesce(l.country_name, 'Unknown')
+--     end as last_known_ip_country
 from
     server_info si
     left join {{ ref('int_server_hosting_type') }} ht on si.server_id = ht.server_id
-    left join {{ ref('int_ip_country_lookup') }} l
-                on si.ip_bucket = l.join_bucket
-                    and si.parsed_server_ip:ipv4 between l.ipv4_range_start and l.ipv4_range_end
+--     left join {{ ref('int_ip_country_lookup') }} l
+--                 on si.ip_bucket = l.join_bucket
+--                     and si.parsed_server_ip:ipv4 between l.ipv4_range_start and l.ipv4_range_end

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -48,7 +48,7 @@ with server_telemetry_summary as (
        parse_ip(st.last_server_ip, 'INET', 1) as parsed_server_ip,
         case
             when parsed_server_ip:error is null
-                then parse_ip(si.last_server_ip || '/7', 'INET'):ipv4_range_start
+                then parse_ip(st.last_server_ip || '/7', 'INET'):ipv4_range_start
             else null
         end as ip_bucket
     from

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -47,7 +47,7 @@ select
     si.last_daily_active_users,
     si.last_monthly_active_users,
     si.last_server_ip,
-    ip.last_known_ip_country
+    coalesce(ip.last_known_ip_country, 'Unknown') as last_known_ip_country
 from
     server_info si
     left join {{ ref('int_server_hosting_type') }} ht on si.server_id = ht.server_id

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -48,7 +48,7 @@ with server_telemetry_summary as (
        parse_ip(st.last_server_ip, 'INET', 1) as parsed_server_ip,
         case
             when parsed_server_ip:error is null
-                then parse_ip(si.server_ip || '/7', 'INET'):ipv4_range_start
+                then parse_ip(si.last_server_ip || '/7', 'INET'):ipv4_range_start
             else null
         end as ip_bucket
     from

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -25,6 +25,31 @@ with server_telemetry_summary as (
         is_active_today
     group by
         server_id
+), server_ips as (
+    -- Store distinct IPs to avoid parsing the same IP multiple times
+    select
+        distinct
+            st.last_server_ip,
+            parse_ip(st.last_server_ip, 'INET', 1) as parsed_server_ip,
+        case
+            when parsed_server_ip:error is null
+                then parse_ip(st.last_server_ip || '/7', 'INET'):ipv4_range_start
+            else null
+        end as ip_bucket
+    from
+        server_telemetry_summary st
+), ip2country as (
+    select
+        si.last_server_ip,
+        case
+            when si.parsed_server_ip:error is not null then 'Unknown'
+            else coalesce(l.country_name, 'Unknown')
+        end as last_known_ip_country
+    from
+        server_ips si
+        left join {{ ref('int_ip_country_lookup') }} l
+            on si.ip_bucket = l.join_bucket
+                and si.parsed_server_ip:ipv4 between l.ipv4_range_start and l.ipv4_range_end
 ), server_info as (
    select
        coalesce(st.server_id, ut.server_id) as server_id,
@@ -44,13 +69,7 @@ with server_telemetry_summary as (
        st.last_count_registered_active_users,
        st.last_daily_active_users,
        st.last_monthly_active_users,
-       st.last_server_ip,
-       parse_ip(st.last_server_ip, 'INET', 1) as parsed_server_ip,
-        case
-            when parsed_server_ip:error is null
-                then parse_ip(st.last_server_ip || '/7', 'INET'):ipv4_range_start
-            else null
-        end as ip_bucket
+       st.last_server_ip
     from
         server_telemetry_summary st
         full outer join user_telemetry_summary ut on st.server_id = ut.server_id
@@ -68,14 +87,9 @@ select
     si.last_count_registered_active_users,
     si.last_daily_active_users,
     si.last_monthly_active_users,
-    si.last_server_ip
---     case
---         when si.parsed_server_ip:error is not null then 'Unknown'
---         else coalesce(l.country_name, 'Unknown')
---     end as last_known_ip_country
+    si.last_server_ip,
+    ip.last_known_ip_country
 from
     server_info si
     left join {{ ref('int_server_hosting_type') }} ht on si.server_id = ht.server_id
---     left join {{ ref('int_ip_country_lookup') }} l
---                 on si.ip_bucket = l.join_bucket
---                     and si.parsed_server_ip:ipv4 between l.ipv4_range_start and l.ipv4_range_end
+    left join ip2country ip on si.last_server_ip = ip.last_server_ip

--- a/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_server_info.sql
@@ -8,7 +8,8 @@ with server_telemetry_summary as (
         first_value(count_registered_active_users) over (partition by server_id order by activity_date asc) as first_count_registered_active_users,
         last_value(count_registered_active_users) over (partition by server_id order by activity_date asc) as last_count_registered_active_users,
         last_value(daily_active_users) over (partition by server_id order by activity_date asc) as last_daily_active_users,
-        last_value(monthly_active_users) over (partition by server_id order by activity_date asc) as last_monthly_active_users
+        last_value(monthly_active_users) over (partition by server_id order by activity_date asc) as last_monthly_active_users,
+        last_value(server_ip) over (partition by server_id order by activity_date asc) as last_server_ip
     from
         {{ ref('int_server_active_days_spined') }}
     -- Keep only one row per server as the current query creates duplicates
@@ -42,7 +43,14 @@ with server_telemetry_summary as (
        st.first_count_registered_active_users,
        st.last_count_registered_active_users,
        st.last_daily_active_users,
-       st.last_monthly_active_users
+       st.last_monthly_active_users,
+       st.last_server_ip,
+       parse_ip(st.last_server_ip, 'INET', 1) as parsed_server_ip,
+        case
+            when parsed_server_ip:error is null
+                then parse_ip(si.server_ip || '/7', 'INET'):ipv4_range_start
+            else null
+        end as ip_bucket
     from
         server_telemetry_summary st
         full outer join user_telemetry_summary ut on st.server_id = ut.server_id
@@ -59,7 +67,15 @@ select
     si.first_count_registered_active_users,
     si.last_count_registered_active_users,
     si.last_daily_active_users,
-    si.last_monthly_active_users
+    si.last_monthly_active_users,
+    si.last_server_ip,
+    case
+        when si.parsed_server_ip:error is not null then 'Unknown'
+        else coalesce(l.country_name, 'Unknown')
+    end as last_known_ip_country
 from
     server_info si
     left join {{ ref('int_server_hosting_type') }} ht on si.server_id = ht.server_id
+    left join {{ ref('int_ip_country_lookup') }} l
+                on si.ip_bucket = l.join_bucket
+                    and si.parsed_server_ip:ipv4 between l.ipv4_range_start and l.ipv4_range_end


### PR DESCRIPTION
#### Summary

- [x] Add latest country info to each server summary.
- [x] Add country exclusion reason.

Some of the logic encapsulated in `dim_server_info` was moved to intermediate layer models in order to support both adding country exclusion reason and adding country in `dim_server_info`. This is an optimization that helps in running the heavy join query between server ip and country. It also helps by pruning the join size due to performing the range join on distinct ips (~ 33% of full size).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-58167