### PR TITLE
Add 'fresh' column to performance-events

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -178,6 +178,51 @@ vars:
   # List of excludable countries
   excluded_countries: ["Russia", "Iran", "North Korea"]
 
+  # List of properties for performance metrics
+  performance_metrics_properties:
+    # Event and user properties
+    - "category"
+    - "user_id"
+    - "type"
+    - "user_actual_id"
+    # Context properties
+    - "context_app_namespace"
+    - "context_library_name"
+    - "context_app_version"
+    - "context_app_build"
+    - "context_library_version"
+    - "context_app_name"
+    - "context_locale"
+    - "context_screen_density"
+    # Properties
+    - "after"
+    - "channel"
+    - "count"
+    - "duration"
+    - "first"
+    - "first_effectiveness"
+    - "first_recomputations"
+    - "fresh"
+    - "is_first_preload"
+    - "longest_api_resource"
+    - "longest_api_resource_duration"
+    - "max_api_resource_size"
+    - "num_high"
+    - "num_low"
+    - "num_medium"
+    - "num_of_request"
+    - "num_total"
+    - "request_count"
+    - "second"
+    - "second_effectiveness"
+    - "second_recomputations"
+    - "third"
+    - "third_effectiveness"
+    - "third_recomputations"
+    - "total_duration"
+    - "total_size"
+    - "user_actual_role"
+
 on-run-start:
   -  '{{ create_parse_qs_udf()}}'
   -  '{{ create_extract_license_data_udf()}}'

--- a/transform/mattermost-analytics/models/marts/web_app/platform/grp_performance_events.sql
+++ b/transform/mattermost-analytics/models/marts/web_app/platform/grp_performance_events.sql
@@ -23,7 +23,7 @@ WITH performance_rc AS (
 ), 
 performance_prod AS (
     SELECT
-        'I' AS _source_relation,
+        'int_mm_telemetry_prod_performance_events' AS _source_relation,
         {{dbt_utils.star(ref('int_mm_telemetry_prod_performance_events'))}}
      FROM
        {{ ref('int_mm_telemetry_prod_performance_events') }}

--- a/transform/mattermost-analytics/models/marts/web_app/platform/grp_performance_events.sql
+++ b/transform/mattermost-analytics/models/marts/web_app/platform/grp_performance_events.sql
@@ -23,7 +23,7 @@ WITH performance_rc AS (
 ), 
 performance_prod AS (
     SELECT
-        'int_mm_telemetry_prod_performance_events' AS _source_relation,
+        'I' AS _source_relation,
         {{dbt_utils.star(ref('int_mm_telemetry_prod_performance_events'))}}
      FROM
        {{ ref('int_mm_telemetry_prod_performance_events') }}

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/_mm_telemetry_prod__models.yml
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/_mm_telemetry_prod__models.yml
@@ -62,6 +62,7 @@ models:
       - name: request_count
       - name: event_date
       - name: received_at_date
+      - name: fresh
 
 
   - name: stg_mm_telemetry_prod__server

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__performance_events.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__performance_events.sql
@@ -1,20 +1,13 @@
-{%- set include_columns = [ "channel", "context_app_namespace", "user_actual_id"
-, "context_library_name", "type", "context_app_version" , "user_actual_role" 
-, "context_app_build" , "context_library_version", "context_app_name"
-, "context_locale", "context_screen_density" 
-, "category" , "duration" , "num_of_request", "max_api_resource_size"
-, "longest_api_resource_duration" , "user_id", "count", "request_count", "fresh"] -%}
-        
 WITH performance_events AS (
     SELECT
-      {{ get_rudderstack_columns() }}
-        , {% for column in include_columns %}
-        {{ column }} AS {{ column }}
-        {% if not loop.last %},{% endif %}
-    {% endfor %}
-    , coalesce(context_useragent, context_user_agent) as context_user_agent
-    , timestamp::date as event_date
-    , received_at::date as received_at_date
+        {{ get_rudderstack_columns() }}
+        , {% for column in var('performance_metrics_properties') %}
+            {{ column }} AS {{ column }}
+            {% if not loop.last %},{% endif %}
+        {% endfor %}
+        , coalesce(context_useragent, context_user_agent) as context_user_agent
+        , timestamp::date as event_date
+        , received_at::date as received_at_date
     FROM
       {{ source('mm_telemetry_prod', 'event') }}
     WHERE CATEGORY = 'performance'

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__performance_events.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/stg_mm_telemetry_prod__performance_events.sql
@@ -3,7 +3,7 @@
 , "context_app_build" , "context_library_version", "context_app_name"
 , "context_locale", "context_screen_density" 
 , "category" , "duration" , "num_of_request", "max_api_resource_size"
-, "longest_api_resource_duration" , "user_id", "count", "request_count"] -%}
+, "longest_api_resource_duration" , "user_id", "count", "request_count", "fresh"] -%}
         
 WITH performance_events AS (
     SELECT

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_rc/_mm_telemetry_rc__models.yml
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_rc/_mm_telemetry_rc__models.yml
@@ -63,3 +63,4 @@ models:
       - name: request_count
       - name: event_date
       - name: received_at_date
+      - name: fresh

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_rc/stg_mm_telemetry_rc__performance_events.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_rc/stg_mm_telemetry_rc__performance_events.sql
@@ -3,7 +3,7 @@
 , "context_app_build" , "context_library_version", "context_app_name"
 , "context_locale", "context_screen_density" 
 , "category" , "duration" , "num_of_request", "max_api_resource_size"
-, "longest_api_resource_duration" , "user_id", "count", "request_count"] -%}
+, "longest_api_resource_duration" , "user_id", "count", "request_count", "fresh"] -%}
         
 WITH performance_events AS (
     SELECT

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_rc/stg_mm_telemetry_rc__performance_events.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_rc/stg_mm_telemetry_rc__performance_events.sql
@@ -1,20 +1,14 @@
-{%- set include_columns = [ "channel", "context_app_namespace", "user_actual_id"
-, "context_library_name", "type", "context_app_version" , "user_actual_role" 
-, "context_app_build" , "context_library_version", "context_app_name"
-, "context_locale", "context_screen_density" 
-, "category" , "duration" , "num_of_request", "max_api_resource_size"
-, "longest_api_resource_duration" , "user_id", "count", "request_count", "fresh"] -%}
-        
 WITH performance_events AS (
     SELECT
-      {{ get_rudderstack_columns() }}
-        , {% for column in include_columns %}
-        {{ column }} AS {{ column }}
-        {% if not loop.last %},{% endif %}
-    {% endfor %}
-    , coalesce(context_useragent, context_user_agent) as context_user_agent
-    , timestamp::date as event_date
-    , received_at::date as received_at_date
+        {{ get_rudderstack_columns() }}
+        , {% for column in var('performance_metrics_properties') %}
+            {{ column }} AS {{ column }}
+            {% if not loop.last %},{% endif %}
+        {% endfor %}
+
+        , coalesce(context_useragent, context_user_agent) as context_user_agent
+        , timestamp::date as event_date
+        , received_at::date as received_at_date
     FROM
       {{ source('mm_telemetry_rc', 'event') }}
     WHERE CATEGORY = 'performance'


### PR DESCRIPTION
#### Summary
This column wasn't included in the `include_columns` function, but was added as a field in the mart_web_app.grp_performance_events explore, which caused errors. This PR adds the field 

#### Ticket Link
None
