### PR TITLE
Hotfix: adjust filtering logic for cloud trials

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_cloud_trial_requests_history.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/trial_requests/int_cloud_trial_requests_history.sql
@@ -8,8 +8,6 @@ with customers as (
         , portal_customer_id
     FROM
         {{ ref('stg_stripe__customers') }}
-    where
-        created_at >= '2023-04-27' -- only select customers after the release.
 ),
 subscriptions as (
     select
@@ -27,6 +25,8 @@ subscriptions as (
         , license_end_at
     from
         {{ ref('stg_stripe__subscriptions') }}
+    where
+        created_at >= '2023-04-27' -- only select subscriptions after the release.
 )
 select
     'stripe:' || subscriptions.subscription_id as trial_request_id
@@ -52,9 +52,9 @@ select
     , 'Stripe' as request_source
     , 'cloud' as request_type
 from
-    customers
+    subscriptions
     -- Will lead to rows fanning out since a customer can have many subscriptions
-    left join subscriptions on subscriptions.customer_id = customers.customer_id
+    left join customers on subscriptions.customer_id = customers.customer_id
 where
     -- Only get trial subscriptions
     subscriptions.trial_start_at is not null


### PR DESCRIPTION
#### Summary

Cloud trials are currently filtered on customer creation date. This PR changes this to filtering based on subscription creation date. The reason for this change is that some customers with creation date before the cut-off date are creating trials.