### PR TITLE
Hotfix: fix negative registered active users

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/servers/int_server_active_days_spined.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/servers/int_server_active_days_spined.sql
@@ -111,9 +111,9 @@ select
     -- Activity data
     coalesce(activity.daily_active_users, legacy_activity.daily_active_users, d.count_active_users, 0) as daily_active_users,
     coalesce(activity.monthly_active_users, legacy_activity.monthly_active_users, 0) as monthly_active_users,
-    coalesce(activity.count_registered_users, legacy_activity.count_registered_users, 0) as count_registered_users,
+    coalesce(activity.count_registered_users, legacy_activity.count_registered_users, d.count_users,  0) as count_registered_users,
     coalesce(activity.count_registered_deactivated_users, legacy_activity.count_registered_deactivated_users, 0) as count_registered_deactivated_users,
-    coalesce(activity.count_registered_users, legacy_activity.count_registered_users, 0) - coalesce(activity.count_registered_deactivated_users, legacy_activity.count_registered_deactivated_users, d.count_users, 0) as count_registered_active_users,
+    coalesce(activity.count_registered_users, legacy_activity.count_registered_users) - coalesce(activity.count_registered_deactivated_users, legacy_activity.count_registered_deactivated_users) as count_registered_active_users,
 
     coalesce(activity.count_public_channels, legacy_activity.count_public_channels, 0) as count_public_channels,
     coalesce(activity.count_private_channels, legacy_activity.count_private_channels, 0) as count_private_channels,

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -267,11 +267,6 @@ models:
         description: The number of daily active users.
       - name: count_registered_active_users
         description: The number of active (not deleted) registered users.
-        tests:
-          - dbt_utils.accepted_range:
-              min_value: 0
-              inclusive: true
-              where: "has_telemetry_data or has_legacy_telemetry_data or has_diagnostics_data"
       - name: is_enterprise_ready
         description: Whether the server is running an enterprise ready build.
       - name: count_reported_versions

--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -31,6 +31,10 @@ models:
               field: server_id
       - name: daily_active_users
         description: The number of unique active users for the given server and date.
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
       - name: monthly_active_users
         description: The number of unique active users for the date and previous 29 days.
       - name: weekly_active_users
@@ -57,8 +61,16 @@ models:
           Bots and deleted users are excluded. Reported by mattermost server.
       - name: count_registered_users
         description: Total number of users, including deleted users. Reported by mattermost server.
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
       - name: count_registered_deactivated_users
         description: Total number of inactive (deleted) users. Reported by mattermost server.
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
       - name: version_id
         description: The id of the server's version for the given date.
         tests:
@@ -255,6 +267,11 @@ models:
         description: The number of daily active users.
       - name: count_registered_active_users
         description: The number of active (not deleted) registered users.
+        tests:
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+              where: "has_telemetry_data or has_legacy_telemetry_data or has_diagnostics_data"
       - name: is_enterprise_ready
         description: Whether the server is running an enterprise ready build.
       - name: count_reported_versions


### PR DESCRIPTION
#### Summary

- [x] Remove `count_users` from security update check in count active registered users. count_users is the total number of registered users.
- [x] Move `count_users`  from security update check to registered users.
- [x] Add more tests.

After this PR is merged count active registered users (that is registered but not deleted) will not be available if only security update check data for a server are available.
 