### PR TITLE
Hotfix: move transform_m workloads to transform_l

### DIFF
--- a/transform/snowflake-dbt/dbt_project.yml
+++ b/transform/snowflake-dbt/dbt_project.yml
@@ -42,7 +42,7 @@ models:
   mm_snowflake:
     bizops:
       nightly:
-        +snowflake_warehouse: "TRANSFORM_M"
+        +snowflake_warehouse: "TRANSFORM_L"
         tags: ["bizops", "nightly"]
 
     blp:
@@ -64,12 +64,12 @@ models:
 
     mattermost:
       nightly:
-        +snowflake_warehouse: "TRANSFORM_M"
+        +snowflake_warehouse: "TRANSFORM_L"
         tags: "nightly"
 
     staging:
       server:
-        +snowflake_warehouse: "TRANSFORM_M"
+        +snowflake_warehouse: "TRANSFORM_L"
         tags: ["server", "nightly"]
 
     qa:


### PR DESCRIPTION
#### Summary

Move workloads running in `TRANSFORM_M` to `TRANSFORM_L`. These workloads are small and they are waking up the suspended warehouse.
