### PR TITLE
Chore: change job schedule

### DIFF
--- a/airflow/dags/mattermost_dags/general/monitoring.py
+++ b/airflow/dags/mattermost_dags/general/monitoring.py
@@ -18,7 +18,7 @@ with DAG(
     'monitoring',
     default_args=default_args,
     start_date=datetime(2017, 3, 20),
-    schedule='@daily',
+    schedule="0 10 * * *",
     catchup=False,
 ) as dag:
     check_stitch_extractions = SimpleHttpOperator(


### PR DESCRIPTION
#### Summary

Change monitoring job so that it runs after nightly DBT jobs. This way monitoring should consider recent syncs (instead of ~ 1 day old syncs), due to the move of syncs from hourly to nightly.