### PR TITLE
MM-60551: ignore campaign member inconsistencies

### DIFF
--- a/transform/mattermost-analytics/models/marts/sales/hightouch/fct_in_product_trial_requests.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/fct_in_product_trial_requests.sql
@@ -89,7 +89,7 @@ from
     left join {{ ref('country_codes') }} cc on tr.country = cc.code
     left join {{ ref('stg_salesforce__lead') }} l on tr.normalized_email = l.email
     left join {{ ref('stg_salesforce__campaign_member') }} cm
-        on l.lead_id = cm.lead_id and tr.normalized_email = cm.email and cm.campaign_id = '{{ var('in_product_trial_campaign_id') }}'
+        on l.lead_id = cm.lead_id and cm.campaign_id = '{{ var('in_product_trial_campaign_id') }}'
     left join {{ ref('int_onprem_trial_license_information') }} tli on tli.trial_request_id = tr.trial_request_id
 where
     -- Skip invalid emails


### PR DESCRIPTION
#### Summary

Be more relaxed in inconsistencies existing in campaign members.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60551