### PR TITLE
MM-60551: lead account link

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -154,7 +154,7 @@ vars:
     test_coverage_target: 75
     model_types: [ 'staging', 'intermediate', 'marts', 'other', 'reports' ]
     staging_prefixes: ['stg_', 'base_']
-    marts_prefixes: ['fct_', 'dim_', 'grp_', 'bdg_']
+    marts_prefixes: ['fct_', 'dim_', 'grp_', 'bdg_', 'sync_']
     reports_folder_name: reports
     reports_prefixes: [ 'rpt_' ]
 

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/_hightouch__models.yml
@@ -114,3 +114,22 @@ models:
         #       values: ['Account created', 'Email verified', 'Workspace created', null]
       - name: is_valid_email
         description: Whether the email is valid. Used to skip invalid emails.
+
+  - name: sync_lead_account_link
+    description: |
+      Assigns leads to specific accounts. This model is used to sync the lead to account link to Salesforce.
+
+    columns:
+      - name: lead_id
+        description: The Salesforce id of the lead.
+        tests:
+          - not_null
+          - unique
+      - name: account_id
+        description: The salesforce id of the account.
+      - name: lead_email
+        description: The email of the lead.
+      - name: account_name
+        description: The name of the account.
+      - name: clearbit_domain
+        description: The email domain assigned to the account via Clearbit.

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/sync_lead_account_link.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/sync_lead_account_link.sql
@@ -1,9 +1,9 @@
 select
     l.lead_id,
     a.account_id,
-    l.email,
-    a.name,
-    a.cbit__clearbitdomain__c
+    l.email as lead_eamil,
+    a.name as account_name,
+    a.cbit__clearbitdomain__c as clearbit_domain
 from
     {{ ref('stg_salesforce__lead') }} l
     left join {{ ref('stg_salesforce__account')}} a on a.cbit__clearbitdomain__c = split_part(l.email,'@',2)

--- a/transform/mattermost-analytics/models/marts/sales/hightouch/sync_lead_account_link.sql
+++ b/transform/mattermost-analytics/models/marts/sales/hightouch/sync_lead_account_link.sql
@@ -1,0 +1,20 @@
+with lead_account_link as (
+    select
+        l.lead_id,
+        coalesce(l.existing_account__c, a.account_id) as account_id,
+        a.created_at as account_created_at
+    from
+        {{ ref('stg_salesforce__lead') }} l
+        left join {{ ref('stg_salesforce__account')}} on a.cbit__clearbitdomain__c = split_part(email,'@',2)
+    where
+        l.converted_at is null
+        and existing_account__c is null
+)
+select
+    lead_account_link.*
+from
+    lead_update_account_link
+    join {{ ref('stg_salesforce__lead') }} on lead.sfid = lead_update_account_link.sfid
+where
+  lead.existing_account__c is distinct from coalesce(lead.existing_account__c, lead_update_account_link.account_id)
+qualify row_count() over(partition by lead_id order by created_at desc) = 1


### PR DESCRIPTION
#### Summary

- [x] Move lead <--> account link sync to new project.
- [x] Simplify query
- [x] Add logic in case of multiple accounts matching.

There's a few things worth noting:
- Adding a new prefix for hightouch syncs (`sync_`). Previous syncs were using `fct_`, which led to some confusion. 
- Hightouch syncs on the new project run hourly. This sync was previous converted to nightly due to cost optimization efforts. 
- Since it's a new model, it makes sense to create a new sync and sunset the old one in hightouch. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60551