### PR TITLE
MM-60551: add extra character for invalid email

### DIFF
--- a/transform/mattermost-analytics/macros/validation/validate_email.sql
+++ b/transform/mattermost-analytics/macros/validation/validate_email.sql
@@ -1,6 +1,6 @@
 {% macro validate_email(column) -%}
     {%-
-        set invalid_chars = ['\\\\', '/', '(', ')', '&', '$', '^', '&', '!', ' ', '<', '>', '“', '\\u2006', '\\u00a0']
+        set invalid_chars = ['\\\\', '/', '(', ')', '&', '$', '^', '&', '!', ' ', '<', '>', '“', '\\u2006', '\\u00a0', '`']
     -%}
     {{ column }} LIKE '%_@__%.__%' and {{ column }} not like '%@%@%'
     {% for char in invalid_chars %}

--- a/transform/mattermost-analytics/tests/macros/test_validate_email.sql
+++ b/transform/mattermost-analytics/tests/macros/test_validate_email.sql
@@ -13,8 +13,8 @@ with test_values as (
             ('a!b@test.com'),
             ('<user@test.com>'),
             ('a“b@test.com'),
-            ('ab@test.co\u2006m'),
-            ('ab@test.co\uu00a0'),
+            ('ab@test.co\\u2006m'),
+            ('ab@test.co\\uu00a0'),
             ('ab@test.com`')
     ) as t(test_email)
 )

--- a/transform/mattermost-analytics/tests/macros/test_validate_email.sql
+++ b/transform/mattermost-analytics/tests/macros/test_validate_email.sql
@@ -12,7 +12,10 @@ with test_values as (
             ('a/b@test.com'),
             ('a!b@test.com'),
             ('<user@test.com>'),
-            ('a“b@test.com')
+            ('a“b@test.com'),
+            ('ab@test.co\u2006m'),
+            ('ab@test.co\uu00a0'),
+            ('ab@test.com`')
     ) as t(test_email)
 )
 select

--- a/transform/snowflake-dbt/macros/validators.sql
+++ b/transform/snowflake-dbt/macros/validators.sql
@@ -1,6 +1,6 @@
 {% macro validate_email(column) -%}
     {%-
-        set invalid_chars = ['\\\\', '/', '(', ')', '&', '$', '^', '&', '!', ' ', '<', '>', '“', '\\u2006', '\\u00a0']
+        set invalid_chars = ['\\\\', '/', '(', ')', '&', '$', '^', '&', '!', ' ', '<', '>', '“', '\\u2006', '\\u00a0', '`']
     -%}
     {{ column }} LIKE '%_@__%.__%' and {{ column }} not like '%@%@%'
     {% for char in invalid_chars %}


### PR DESCRIPTION
#### Summary

Add ` as excludable character in list of valid email characters.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60551
