### PR TITLE
Htofix: fix data type

### DIFF
--- a/load/snowflake/roles.yaml
+++ b/load/snowflake/roles.yaml
@@ -298,9 +298,11 @@ users:
         can_login: yes
         member_of:
             - stitch
+
     - test_user:
         can_login: no
-        member_of: test_bi
+        member_of:
+            - test_bi
 
 # Warehouses
 warehouses:


### PR DESCRIPTION
#### Summary


Use proper type for `member_of` values.