### PR TITLE
Hotfix: Move documentation block to the right model

### DIFF
--- a/transform/mattermost-analytics/models/marts/product/_product__models.yml
+++ b/transform/mattermost-analytics/models/marts/product/_product__models.yml
@@ -84,10 +84,7 @@ models:
         description: Whether there are data reported for that server and date from front-end telemetry.
       - name: has_server_telemetry_data
         description: Whether there are data reported for that server and date from server-side telemetry.
-      - name: is_feature_shared_channels_enabled
-        description: Whether the shared channels feature has been enabled at the server
-      - name: is_feature_remote_cluster_service_enabled
-        description: Whether the remote cluster feature has been enabled at the server
+
     tests:
       # A date should only appear once per server
       - dbt_utils.unique_combination_of_columns:
@@ -293,6 +290,10 @@ models:
         description: The number of licensed seats, as reported by telemetry.
       - name: is_missing_license_data
         description: Whether license data are unavailable for the date.
+      - name: is_feature_shared_channels_enabled
+        description: Whether the shared channels feature has been enabled at the server
+      - name: is_feature_remote_cluster_service_enabled
+        description: Whether the remote cluster feature has been enabled at the server
 
   - name: dim_server_info
     description: Static information for a given server.


### PR DESCRIPTION
#### Summary
The two properties added by https://github.com/mattermost/mattermost-data-warehouse/pull/1624 were documented in the wrong model.

