### PR TITLE
Chore: surface ARR values from SFDC account in licenses models

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/licenses/int_known_licenses.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/licenses/int_known_licenses.sql
@@ -38,7 +38,7 @@ with deduped_legacy_licenses as (
         license_start_date__c as starts_at,
         license_end_date__c as expire_at,
         seats_from_name,
-        a.arr_current_c as account_arr
+        a.arr_current__c as account_arr
     from
         {{ ref('stg_salesforce__opportunity') }} o
         left join {{ ref('stg_salesforce__account') }} a  on o.account_id = a.account_id

--- a/transform/mattermost-analytics/models/intermediate/product/licenses/int_known_licenses.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/licenses/int_known_licenses.sql
@@ -37,7 +37,8 @@ with deduped_legacy_licenses as (
         license_key__c as license_id,
         license_start_date__c as starts_at,
         license_end_date__c as expire_at,
-        seats_from_name
+        seats_from_name,
+        a.arr_current_c as account_arr
     from
         {{ ref('stg_salesforce__opportunity') }} o
         left join {{ ref('stg_salesforce__account') }} a  on o.account_id = a.account_id
@@ -89,6 +90,7 @@ select
     , legacy.expire_at as legacy_expire_at
     , sf.expire_at as salesforce_expire_at
     , t.expire_at as telemetry_expire_at
+    , sf.account_arr as salesforce_account_arr
 
     -- Metadata related to source of information for each license.
     , cws.license_id is not null as in_cws

--- a/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
+++ b/transform/mattermost-analytics/models/marts/product/dim_daily_license.sql
@@ -15,6 +15,7 @@ select
     , coalesce(k.in_cws, false) as in_cws
     , coalesce(k.in_legacy, false) as in_legacy
     , coalesce(k.in_salesforce, false) as in_salesforce
+    , k.salesforce_account_arr
 
     -- Metadata to be used for tests
     , l.expire_at = k.expire_at as is_matching_expiration_date

--- a/transform/mattermost-analytics/models/marts/product/licenses/fct_licenses.sql
+++ b/transform/mattermost-analytics/models/marts/product/licenses/fct_licenses.sql
@@ -24,5 +24,6 @@ select
     , in_legacy
     , in_salesforce
     , in_telemetry
+    , salesforce_account_arr
 from
     {{ ref('int_known_licenses') }}


### PR DESCRIPTION
#### Summary
- surface ARR values from SFDC account in licenses models