### PR TITLE
Chore: explicitly disable scheduled runs on manual DAG

### DIFF
--- a/airflow/dags/mattermost_dags/transformation/deferred_merge.py
+++ b/airflow/dags/mattermost_dags/transformation/deferred_merge.py
@@ -39,6 +39,7 @@ with DAG(
     "manual_deferred_merge",
     default_args=default_args,
     catchup=False,
+    schedule=None,  # Don't schedule this DAG, trigger manually
     max_active_runs=1,  # Don't allow multiple concurrent dag executions
     doc_md=doc_md,
 ) as dag:


### PR DESCRIPTION
#### Summary

Explicitly disable scheduled runs for manual deferred merge jobs.