### PR TITLE
Chore: add daily_server_id field to nps_feedback model

### DIFF
--- a/transform/mattermost-analytics/models/marts/product/nps/fct_nps_feedback.sql
+++ b/transform/mattermost-analytics/models/marts/product/nps/fct_nps_feedback.sql
@@ -1,4 +1,5 @@
 select {{ dbt_utils.generate_surrogate_key(['nf.server_id', 'nf.user_id', 'nf.feedback', 'nf.event_date']) }} as nps_feedback_id
+       , {{ dbt_utils.generate_surrogate_key(['nf.event_date', 'nf.server_id']) }} AS daily_server_id,
        , nf.server_id as server_id
        , nf.user_id as user_id
        , nf.license_id as license_id

--- a/transform/mattermost-analytics/models/marts/product/nps/fct_nps_feedback.sql
+++ b/transform/mattermost-analytics/models/marts/product/nps/fct_nps_feedback.sql
@@ -1,5 +1,5 @@
 select {{ dbt_utils.generate_surrogate_key(['nf.server_id', 'nf.user_id', 'nf.feedback', 'nf.event_date']) }} as nps_feedback_id
-       , {{ dbt_utils.generate_surrogate_key(['nf.event_date', 'nf.server_id']) }} AS daily_server_id
+       , {{ dbt_utils.generate_surrogate_key(['nf.server_id', 'nf.event_date']) }} as daily_server_id
        , nf.server_id as server_id
        , nf.user_id as user_id
        , nf.license_id as license_id

--- a/transform/mattermost-analytics/models/marts/product/nps/fct_nps_feedback.sql
+++ b/transform/mattermost-analytics/models/marts/product/nps/fct_nps_feedback.sql
@@ -1,5 +1,5 @@
 select {{ dbt_utils.generate_surrogate_key(['nf.server_id', 'nf.user_id', 'nf.feedback', 'nf.event_date']) }} as nps_feedback_id
-       , {{ dbt_utils.generate_surrogate_key(['nf.event_date', 'nf.server_id']) }} AS daily_server_id,
+       , {{ dbt_utils.generate_surrogate_key(['nf.event_date', 'nf.server_id']) }} AS daily_server_id
        , nf.server_id as server_id
        , nf.user_id as user_id
        , nf.license_id as license_id

--- a/transform/mattermost-analytics/models/marts/product/nps/fct_nps_score.sql
+++ b/transform/mattermost-analytics/models/marts/product/nps/fct_nps_score.sql
@@ -79,7 +79,7 @@ with user_metrics as (
     , server_id
 )
 SELECT a.*,
-    {{ dbt_utils.generate_surrogate_key(['a.activity_date', 'a.server_id']) }} AS daily_server_id,
+    {{ dbt_utils.generate_surrogate_key(['a.server_id', 'a.activity_date']) }} as daily_server_id,
     {{ dbt_utils.generate_surrogate_key(['b.server_version_full']) }} AS version_id,
     a.count_user_promoters_daily + a.count_team_admin_promoters_daily + a.count_system_admin_promoters_daily AS count_promoters_daily,
     a.count_user_detractors_daily + a.count_team_admin_detractors_daily + a.count_system_admin_detractors_daily AS count_detractors_daily,


### PR DESCRIPTION
#### Summary
Add `daily_server_id` field to `nps_feedback` model. Needed later on in Looker to be able to join with `dim_daily_license` to surface the company name (and other info).
