### PR TITLE
Chore: add tag to test

### DIFF
--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
@@ -8,7 +8,7 @@
         'cluster_by': ['to_date(received_at)'],
         'on_schema_change': 'append_new_columns',
         'snowflake_warehouse': 'transform_l',
-        'post_hook': 'delete from {{this}} where received_at < (select max(received_at) from {{ source(\'rudder_support\', \'base_events\') }})'
+        'post_hook': 'delete from {{this}} where received_at < (select max(received_at) from {{ source(\'rudder_support\', \'base_events\') }})',
     })
 }}
 

--- a/transform/mattermost-analytics/tests/staging/mm_telemetry_prod/test_defered_merge_events.sql
+++ b/transform/mattermost-analytics/tests/staging/mm_telemetry_prod/test_defered_merge_events.sql
@@ -1,3 +1,9 @@
+{{
+    config({
+        'tags': ['hourly'],
+    })
+}}
+
 -- Assert that there's no overlap between base and delta table.
 -- Overlap should be addressed by the post-hook of the delta table.
 with base_table as (


### PR DESCRIPTION
#### Summary

This tag is required, as DBT is currently running the test as part of nightly due to the dependency to `source('rudder_support', 'base_events')`.  However, `base_events_delta` is only updated on hourly.