### PR TITLE
Chore: don't delete late arriving events

### DIFF
--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
@@ -8,7 +8,7 @@
         'cluster_by': ['to_date(received_at)'],
         'on_schema_change': 'append_new_columns',
         'snowflake_warehouse': 'transform_l',
-        'post_hook': 'delete from {{this}} where id in (select id from {{ source(\'rudder_support\', \'base_events\') where received_at > dateadd(day, -5, current_date))'
+        'post_hook': 'delete from {{this}} where id in (select id from {{ source(\'rudder_support\', \'base_events\') }} where received_at > dateadd(day, -5, current_date))'
     })
 }}
 

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
@@ -8,7 +8,7 @@
         'cluster_by': ['to_date(received_at)'],
         'on_schema_change': 'append_new_columns',
         'snowflake_warehouse': 'transform_l',
-        'post_hook': 'delete from {{this}} where id in (select id from {{ source(\'rudder_support\', \'base_events\') where received_at > dataadd(day, -5, current_date))'
+        'post_hook': 'delete from {{this}} where id in (select id from {{ source(\'rudder_support\', \'base_events\') where received_at > dateadd(day, -5, current_date))'
     })
 }}
 

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
@@ -8,7 +8,7 @@
         'cluster_by': ['to_date(received_at)'],
         'on_schema_change': 'append_new_columns',
         'snowflake_warehouse': 'transform_l',
-        'post_hook': 'delete from {{this}} where received_at < (select max(received_at) from {{ source(\'rudder_support\', \'base_events\') }})',
+        'post_hook': 'delete from {{this}} where id in (select id from {{ source(\'rudder_support\', \'base_events\') where received_at > dataadd(day, -5, current_date))'
     })
 }}
 


### PR DESCRIPTION
#### Summary

Some events are arriving late (with a couple of hours difference). Changing the post-hook query to delete only events that have been merged in the past 7 days instead of events before the maximum received date.