### PR TITLE
MM-61359: sql query to channel

### DIFF
--- a/tests/utils/db/conftest.py
+++ b/tests/utils/db/conftest.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 from sqlalchemy import VARCHAR, Column, DateTime, Integer, MetaData, Table
 
@@ -44,3 +45,12 @@ def delta_table_2():
         Column('extra', VARCHAR(255)),
         Column('column_b', Integer()),
     )
+
+
+@pytest.fixture
+def test_data(sqlalchemy_memory_engine):
+    with sqlalchemy_memory_engine.connect() as conn, conn.begin():
+        df = pd.DataFrame({'id': [1, 2], 'title': ['The Great Gatsby', 'The Lord of the Rings']})
+        df.to_sql('books', conn)
+
+        return df

--- a/tests/utils/db/test_helpers.py
+++ b/tests/utils/db/test_helpers.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from textwrap import dedent
 
+import pandas as pd
 import pytest
 from mock.mock import call
 
@@ -9,6 +10,7 @@ from utils.db.helpers import (
     TableStats,
     clone_table,
     get_table_stats_for_schema,
+    load_query,
     load_table_definition,
     merge_event_delta_table_into,
     move_table,
@@ -363,3 +365,9 @@ def test_should_add_new_columns_and_merge_table(mocker, base_table, delta_table_
 
     # THEN: expect the merge statement to have the correct parameters
     assert mock_exec.call_args[0][0].compile().params == {"first_duplicate_date": "2022-12-21T23:55:59"}
+
+
+def test_load_query(sqlalchemy_memory_engine, test_data):
+    with sqlalchemy_memory_engine.connect() as conn, conn.begin():
+        df = load_query(conn, "SELECT id, title FROM books")
+        pd.testing.assert_frame_equal(df, test_data)

--- a/tests/utils/db/test_service.py
+++ b/tests/utils/db/test_service.py
@@ -1,0 +1,42 @@
+import json
+from textwrap import dedent
+
+from responses import Response
+
+from utils.db.service import post_query_results
+
+
+def test_post_query_results(sqlalchemy_memory_engine, test_data, responses):
+    # GIVEN: a mattermost server waiting for a request
+
+    response = Response(
+        method="POST",
+        url='https://mattermost.a-test-server.com',
+        status=200,
+        content_type='application/json',
+    )
+    responses.add(response)
+
+    # GIVEN: a database with some data
+    with sqlalchemy_memory_engine.connect() as conn, conn.begin():
+        # WHEN: request to post query results to Mattermost
+        post_query_results(
+            conn,
+            'select id, title from books order by id',
+            ['ISBN', 'Title'],
+            'https://mattermost.a-test-server.com',
+            'book-club',
+        )
+
+    # THEN: a request is made to the Mattermost server
+    assert json.loads(responses.calls[0].request.body) == {
+        'text': dedent(
+            '''
+            |   ISBN | Title                 |
+            |--------|-----------------------|
+            |      1 | The Great Gatsby      |
+            |      2 | The Lord of the Rings |
+        '''
+        ).strip(),
+        'channel': 'book-club',
+    }

--- a/utils/db/__main__.py
+++ b/utils/db/__main__.py
@@ -4,7 +4,8 @@ import click
 
 from utils.cli.context import snowflake_engine_context
 from utils.cli.logging import initialize_cli_logging
-from utils.db.helpers import clone_table, merge_event_delta_table_into
+from utils.db.helpers import clone_table, load_query, merge_event_delta_table_into
+from utils.helpers import post_to_mattermost
 
 initialize_cli_logging(logging.INFO, 'stderr')
 
@@ -108,6 +109,36 @@ def merge(
             delta_table_schema,
             delta_table,
             dedup_prune_days=dedup_prune_days,
+        )
+
+
+@snowflake.group()
+@click.pass_context
+def post_query():
+    pass
+
+
+@post_query.command()
+@click.pass_context
+def feedback(ctx: click.Context, url: str):
+    with ctx.obj['engine'].begin() as conn, conn.begin():
+        df = load_query(
+            conn,
+            '''
+        SELECT
+            feedback
+            , rating
+            , page_path
+            , ua_browser_family
+            , ua_os_family
+            , geolocated_country_name
+        FROM "REPORTS_DOCS".rpt_docs_feedback
+        WHERE timestamp::date >= current_date() - 7 AND timestamp::date <= current_date() - 1 
+        ORDER BY timestamp DESC
+        ''',
+        )
+        post_to_mattermost(
+            url, 'mattermost-documentation-feedback', df, ['Feedback', 'Rating', 'Path', 'Browser', 'OS', 'Country']
         )
 
 

--- a/utils/db/__main__.py
+++ b/utils/db/__main__.py
@@ -128,14 +128,15 @@ def feedback(ctx: click.Context, url: str, channel: str):
             '''
                 SELECT
                     to_date(timestamp) as date
-                    , feedback
+                    , COALESCE(feedback, 'No feedback') as feedback
                     , rating
                     , page_path
                     , ua_browser_family
                     , ua_os_family
                     , geolocated_country_name
                 FROM "REPORTS_DOCS".rpt_docs_feedback
-                WHERE timestamp::date >= current_date() - 7 AND timestamp::date <= current_date() - 1
+                WHERE
+                    timestamp::date >= current_date() - 7 AND timestamp::date <= current_date() - 1
                 ORDER BY timestamp DESC
             ''',
             ['Date', 'Feedback', 'Rating', 'Path', 'Browser', 'OS', 'Country'],

--- a/utils/db/helpers.py
+++ b/utils/db/helpers.py
@@ -319,3 +319,10 @@ def merge_event_delta_table_into(
     # Workaround for https://github.com/snowflakedb/snowflake-sqlalchemy/issues/536
     stmt = text(merge.__repr__()).bindparams(first_duplicate_date=first_duplicate_date)
     conn.execute(stmt)
+
+
+def load_query(conn: Connection, query: str) -> pd.DataFrame:
+    """
+    Loads a query into a DataFrame.
+    """
+    return pd.read_sql(query, conn)

--- a/utils/db/service.py
+++ b/utils/db/service.py
@@ -1,0 +1,25 @@
+import logging
+from typing import List
+
+from sqlalchemy.engine import Connection
+
+from utils.db.helpers import load_query
+from utils.helpers import post_to_mattermost
+
+logger = logging.getLogger(__name__)
+
+
+def post_query_results(
+    conn: Connection,
+    query: str,
+    headers: List[str],
+    url: str,
+    channel: str,
+):
+    """
+    Post query results to Mattermost.
+    """
+    logger.info('Querying data...')
+    df = load_query(conn, query)
+    logger.info('Sending dataframe to mattermost...')
+    post_to_mattermost(url, channel, df, headers)

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,6 +1,22 @@
 from datetime import timedelta
+from typing import List
+
+import pandas as pd
+import requests
+from tabulate import tabulate
 
 
 def daterange(start_date, end_date):
     for n in range(int((end_date - start_date).days)):
         yield start_date + timedelta(n)
+
+
+def post_to_mattermost(url: str, channel: str, df: pd.DataFrame, headers: List[str]):
+    msg = tabulate(df, headers=headers, tablefmt='github', showindex='never')
+    response = requests.post(
+        url,
+        json={"text": msg, "channel": channel},
+    )
+
+    if response.status_code != 200:
+        raise ValueError(f'Request to Mattermost returned {response.status_code}, the response is:\n{response.text}')


### PR DESCRIPTION
#### Summary

- [x] Add functions for reading a query to a python dataframe and posting the dataframe as a table to a mattermost channel.
- [x] Add CLI command for sending feedback to a channel.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61359
