### PR TITLE
MM-60600: roll back received_at without overlap

### DIFF
--- a/transform/mattermost-analytics/dbt_project.yml
+++ b/transform/mattermost-analytics/dbt_project.yml
@@ -248,8 +248,6 @@ vars:
     - "total_size"
     - "user_actual_role"
 
-  # Deferred merge configuration
-  base_table_overlap_days: 2
 
 on-run-start:
   -  '{{ create_parse_qs_udf()}}'

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
@@ -21,5 +21,5 @@ where
     received_at >= (select max(received_at) from {{ this }})
 {% else %}
     -- Add buffer for late arriving events.
-    received_at >= (select dateadd(day, -{{ var('base_table_overlap_days') }}, max(received_at)) from {{ source('rudder_support', 'base_events') }})
+    received_at >= (select max(received_at) from {{ source('rudder_support', 'base_events') }})
 {% endif %}

--- a/transform/mattermost-analytics/tests/staging/mm_telemetry_prod/test_defered_merge_events.sql
+++ b/transform/mattermost-analytics/tests/staging/mm_telemetry_prod/test_defered_merge_events.sql
@@ -17,5 +17,4 @@ select
 from
     base_table cross join delta_table
 where
-    dateadd(day, -{{ var('base_table_overlap_days') }}, base_table.last_received_at) > delta_table.first_received_at
-
+    base_table.last_received_at > delta_table.first_received_at

--- a/transform/mattermost-analytics/tests/staging/mm_telemetry_prod/test_defered_merge_events.sql
+++ b/transform/mattermost-analytics/tests/staging/mm_telemetry_prod/test_defered_merge_events.sql
@@ -4,7 +4,7 @@
     })
 }}
 
--- Assert that there's no overlap between base and delta table for more than the last 2 days.
+-- Assert that there's no overlap between base and delta table.
 -- Overlap should be addressed by the post-hook of the delta table.
 with base_table as (
     select max(received_at) as last_received_at from {{ source('rudder_support', 'base_events') }}


### PR DESCRIPTION
#### Summary

Rollback to previous version.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60600