### PR TITLE
MM-60600: handle incremental logic after deletion

### DIFF
--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
@@ -14,7 +14,7 @@
 with time_thresholds as (
     -- Last date of the base table will be used if (a) it's the first run of the model or (b) the model is incremental
     -- but doesn't contain any rows.
-    select max(received_at) as time_threshold from {{ source('rudder_support', 'base_events') }})
+    select max(received_at) as time_threshold from {{ source('rudder_support', 'base_events') }}
 {% if is_incremental() %}
     -- If model is incremental, also consider the last date of the model itself. If there are rows, then received_at
     -- will be greater than the max value of received at of the base table.

--- a/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
+++ b/transform/mattermost-analytics/models/staging/mm_telemetry_prod/base/base_events_delta.sql
@@ -11,14 +11,20 @@
     })
 }}
 
+with time_thresholds as (
+    -- Last date of the base table will be used if (a) it's the first run of the model or (b) the model is incremental
+    -- but doesn't contain any rows.
+    select max(received_at) as time_threshold from {{ source('rudder_support', 'base_events') }})
+{% if is_incremental() %}
+    -- If model is incremental, also consider the last date of the model itself. If there are rows, then received_at
+    -- will be greater than the max value of received at of the base table.
+    union all
+    select max(received_at) as time_threshold from {{ this }}
+{% endif %}
+)
 select
     {{ dbt_utils.star(from=source('mm_telemetry_prod', 'event')) }}
 from
     {{ source('mm_telemetry_prod', 'event') }}
 where
-{% if is_incremental() %}
-    received_at >= (select max(received_at) from {{ this }})
-{% else %}
-    -- Add buffer for late arriving events.
-    received_at >= (select max(received_at) from {{ source('rudder_support', 'base_events') }})
-{% endif %}
+    received_at >= (select max(time_threshold) from time_thresholds)


### PR DESCRIPTION
#### Summary

Handles edge case of empty delta table after merge. In this case `max(received_at)` will be null, effectively blocking incremental logic. To address that, `max(received_at)` from base table is used.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60600