### PR TITLE
Hotfix: use only daily info for daily user id

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_legacy_telemetry.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_legacy_telemetry.sql
@@ -38,7 +38,7 @@ with tmp as (
 )
 select
     -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
-    {{ dbt_utils.generate_surrogate_key(['received_at_date', 'activity_date', 'server_id', 'user_id']) }} as daily_user_id
+    {{ dbt_utils.generate_surrogate_key(['activity_date', 'server_id', 'user_id']) }} as daily_user_id
     , activity_date
     , server_id
     , user_id

--- a/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_mobile_telemetry.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_mobile_telemetry.sql
@@ -34,7 +34,7 @@ with tmp as (
 )
 select
     -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
-    {{ dbt_utils.generate_surrogate_key(['received_at_date', 'activity_date', 'server_id', 'user_id']) }} as daily_user_id
+    {{ dbt_utils.generate_surrogate_key(['activity_date', 'server_id', 'user_id']) }} as daily_user_id
     , activity_date
     , server_id
     , user_id

--- a/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_server_telemetry.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_server_telemetry.sql
@@ -38,7 +38,7 @@ with tmp as (
 )
 select
     -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
-    {{ dbt_utils.generate_surrogate_key(['received_at_date', 'activity_date', 'server_id', 'user_id']) }} as daily_user_id
+    {{ dbt_utils.generate_surrogate_key(['activity_date', 'server_id', 'user_id']) }} as daily_user_id
     , activity_date
     , server_id
     , user_id

--- a/transform/mattermost-analytics/models/intermediate/product/boards_active_users/int_boards_client_telemetry_daily.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/boards_active_users/int_boards_client_telemetry_daily.sql
@@ -34,7 +34,7 @@ with tmp as (
 )
 select
     -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
-    {{ dbt_utils.generate_surrogate_key(['received_at_date', 'activity_date', 'server_id', 'user_id']) }} as daily_user_id
+    {{ dbt_utils.generate_surrogate_key(['activity_date', 'server_id', 'user_id']) }} as daily_user_id
     , activity_date
     , server_id
     , user_id

--- a/transform/mattermost-analytics/models/intermediate/product/calls_active_users/int_calls_client_telemetry_daily.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/calls_active_users/int_calls_client_telemetry_daily.sql
@@ -34,7 +34,7 @@ with tmp as (
 )
 select
     -- Surrogate key required as it's both a good practice, as well as allows merge incremental strategy.
-    {{ dbt_utils.generate_surrogate_key(['received_at_date', 'activity_date', 'server_id', 'user_id']) }} as daily_user_id
+    {{ dbt_utils.generate_surrogate_key(['activity_date', 'server_id', 'user_id']) }} as daily_user_id
     , activity_date
     , server_id
     , user_id


### PR DESCRIPTION
#### Summary

Removes `received_at` from `daily_user_id` expression.  

The reason for this choice, is that In case of late arriving events, there might be multiple `received_at` for the same (`timestamp`, `server_id`, `user_id`) combination, potentially leading to duplicate rows for the same user id. 

Note that since the daily user id logic is changing on some models, a full refresh will be required on these models and their downstream. This will ensure that only a single type of logic is used for deriving ids.