### PR TITLE
Hotfix: use latest received_at

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_legacy_telemetry.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_legacy_telemetry.sql
@@ -44,10 +44,11 @@ select
     , user_id
     , true as is_active
     -- Required for incremental loading
-    , received_at_date
+    -- Use max to ensure that the most recent received_at_date is used
+    , max(received_at_date) as received_at_date
     , {{ dbt_utils.pivot('client_type', ['IS_DESKTOP', 'IS_WEBAPP']) }}
     from tmp
 where
     activity_date >= '{{ var('telemetry_start_date')}}'
 group by 
-    activity_date, server_id, user_id, received_at_date
+    activity_date, server_id, user_id

--- a/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_mobile_telemetry.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_mobile_telemetry.sql
@@ -40,8 +40,10 @@ select
     , user_id
     , true as is_active
     -- Required for incremental loading
-    , received_at_date
+    -- Use max to ensure that the most recent received_at_date is used
+    , max(received_at_date) as received_at_date
 from
     tmp
 where
     activity_date >= '{{ var('telemetry_start_date')}}'
+group by activity_date, server_id, user_id

--- a/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_server_telemetry.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/active_users/int_user_active_days_server_telemetry.sql
@@ -44,10 +44,11 @@ select
     , user_id
     , true as is_active
     -- Required for incremental loading
-    , received_at_date
+    -- Use max to ensure that the most recent received_at_date is used
+    , max(received_at_date) as received_at_date
     , {{ dbt_utils.pivot('client_type', ['IS_DESKTOP', 'IS_WEBAPP']) }}
     from tmp
 where
     activity_date >= '{{ var('telemetry_start_date')}}'
 group by 
-    activity_date, server_id, user_id, received_at_date
+    activity_date, server_id, user_id

--- a/transform/mattermost-analytics/models/intermediate/product/boards_active_users/int_boards_client_telemetry_daily.sql
+++ b/transform/mattermost-analytics/models/intermediate/product/boards_active_users/int_boards_client_telemetry_daily.sql
@@ -40,8 +40,10 @@ select
     , user_id
     , true as is_active
     -- Required for incremental loading
-    , received_at_date
+    -- Use max to ensure that the most recent received_at_date is used
+    , max(received_at_date) as received_at_date
 from
     tmp
 where
     activity_date >= '{{ var('telemetry_start_date')}}'
+group by activity_date, server_id, user_id


### PR DESCRIPTION
#### Summary

Use latest `received_at_date` when handling late arriving events during incremental runs. This might occur in case the incremental batch contains events for the same user but with different `received_at` dates.