### PR TITLE
Chore: disable slow test

### DIFF
--- a/transform/mattermost-analytics/models/marts/web_app/platform/_platform__models.yml
+++ b/transform/mattermost-analytics/models/marts/web_app/platform/_platform__models.yml
@@ -16,7 +16,7 @@ models:
         tests:
           - not_null
           - unique:
-              tags: ['slow']
+              tags: ['slow', 'disabled']
       - name: anonymous_id
       - name: received_at
       - name: sent_at


### PR DESCRIPTION
#### Summary

Disable uniqueness check. This is an extremely slow query. Given the model is just an copy of a subset of the events just for performance, it's unlikely duplicates will exist.

Note that the test is not removed in order to keep the semantics. The actual disable happens on DBT job configuration. If - in the future - we want to re-add it for sanity check, we can add it to a weekly job.