### PR TITLE
Chore: run test on CI only

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/product/active_users/_int_active_users__models.yml
+++ b/transform/mattermost-analytics/models/intermediate/product/active_users/_int_active_users__models.yml
@@ -130,3 +130,4 @@ models:
             - activity_date
             - server_id
             - user_id
+          tags: ['run-on-ci-only']


### PR DESCRIPTION
#### Summary

Please treat this PR is a proposal. 

The challenge is that there is a test that takes too long to run. It's in the intermediate layer. This test is useful during development, as it can catch important structural changes in the model early. However, it is not essential on daily/hourly, as there are downstream models that might help catching those issues.

The suggestion is to introduce a new tag `run-on-ci-only`. Models/tests with this tag will not run on daily & hourly job. They will run in CI jobs, and only if this or an upstream model has been modified.