### PR TITLE
MM-61976: fix breaking table

### DIFF
--- a/tests/utils/db/conftest.py
+++ b/tests/utils/db/conftest.py
@@ -54,3 +54,12 @@ def test_data(sqlalchemy_memory_engine):
         df.to_sql('books', conn)
 
         return df
+
+
+@pytest.fixture
+def test_data_with_newline(sqlalchemy_memory_engine):
+    with sqlalchemy_memory_engine.connect() as conn, conn.begin():
+        df = pd.DataFrame({'id': [1, 2], 'title': ['The Great Gatsby', 'The Lord of the Rings:\nThe Two Towers']})
+        df.to_sql('books', conn)
+
+        return df

--- a/tests/utils/db/test_service.py
+++ b/tests/utils/db/test_service.py
@@ -43,6 +43,43 @@ def test_post_query_results(sqlalchemy_memory_engine, test_data, responses):
     }
 
 
+def test_post_query_results_with_new_line(sqlalchemy_memory_engine, test_data_with_newline, responses):
+    # GIVEN: a mattermost server waiting for a request
+
+    response = Response(
+        method="POST",
+        url='https://mattermost.a-test-server.com',
+        status=200,
+        content_type='application/json',
+    )
+    responses.add(response)
+
+    # GIVEN: a database with some data
+    with sqlalchemy_memory_engine.connect() as conn, conn.begin():
+        # WHEN: request to post query results to Mattermost
+        post_query_results(
+            conn,
+            'select id, title from books order by id',
+            ['ISBN', 'Title'],
+            'https://mattermost.a-test-server.com',
+            'book-club',
+            'No books found'
+        )
+
+    # THEN: a request is made to the Mattermost server
+    assert json.loads(responses.calls[0].request.body) == {
+        'text': dedent(
+            '''
+            |   ISBN | Title                                  |
+            |--------|----------------------------------------|
+            |      1 | The Great Gatsby                       |
+            |      2 | The Lord of the Rings:\\nThe Two Towers |
+        '''
+        ).strip(),
+        'channel': 'book-club',
+    }
+
+
 def test_post_query_results_with_empty_results(sqlalchemy_memory_engine, test_data, responses):
     # GIVEN: a mattermost server waiting for a request
 
@@ -71,3 +108,4 @@ def test_post_query_results_with_empty_results(sqlalchemy_memory_engine, test_da
         'text': 'No books found',
         'channel': 'book-club',
     }
+

--- a/tests/utils/db/test_service.py
+++ b/tests/utils/db/test_service.py
@@ -63,7 +63,7 @@ def test_post_query_results_with_new_line(sqlalchemy_memory_engine, test_data_wi
             ['ISBN', 'Title'],
             'https://mattermost.a-test-server.com',
             'book-club',
-            'No books found'
+            'No books found',
         )
 
     # THEN: a request is made to the Mattermost server
@@ -108,4 +108,3 @@ def test_post_query_results_with_empty_results(sqlalchemy_memory_engine, test_da
         'text': 'No books found',
         'channel': 'book-club',
     }
-

--- a/utils/db/__main__.py
+++ b/utils/db/__main__.py
@@ -136,7 +136,7 @@ def feedback(ctx: click.Context, url: str, channel: str):
                     , geolocated_country_name
                 FROM "REPORTS_DOCS".rpt_docs_feedback
                 WHERE
-                    timestamp::date >= current_date() - 7 AND timestamp::date <= current_date() - 1
+                    timestamp::date >= current_date() - 14 AND timestamp::date <= current_date() - 1
                 ORDER BY timestamp DESC
             ''',
             ['Date', 'Feedback', 'Rating', 'Path', 'Browser', 'OS', 'Country'],

--- a/utils/db/__main__.py
+++ b/utils/db/__main__.py
@@ -136,7 +136,7 @@ def feedback(ctx: click.Context, url: str, channel: str):
                     , geolocated_country_name
                 FROM "REPORTS_DOCS".rpt_docs_feedback
                 WHERE
-                    timestamp::date >= current_date() - 14 AND timestamp::date <= current_date() - 1
+                    timestamp::date >= current_date() - 7 AND timestamp::date <= current_date() - 1
                 ORDER BY timestamp DESC
             ''',
             ['Date', 'Feedback', 'Rating', 'Path', 'Browser', 'OS', 'Country'],

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -18,6 +18,9 @@ def post_df_to_mattermost(url: str, channel: str, df: pd.DataFrame, headers: Lis
             json={"text": empty_data_message, "channel": channel},
         )
     else:
+        for col in df.select_dtypes(include=['object']).columns:
+            df[col] = df[col].apply(lambda val: val.replace("\n", "\\n") if val and type(val) == str else val)
+
         msg = tabulate(df, headers=headers, tablefmt='github', showindex='never')
         response = requests.post(
             url,


### PR DESCRIPTION
#### Summary

Escapes newline characters in order to fix broken tables when a text contains a newline. Mattermost doesn't currently support multi-line characters in table cells.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-61976
