### PR TITLE
Fix duplicates in grp community tracks

### DIFF
--- a/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
+++ b/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
@@ -5,7 +5,6 @@
         "incremental_strategy": "delete+insert",
         "unique_key": ['event_id'],
         "snowflake_warehouse": "transform_l",
-        "full_refresh": True
     })
 }}
 

--- a/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
+++ b/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
@@ -5,7 +5,7 @@
         "incremental_strategy": "delete+insert",
         "unique_key": ['event_id'],
         "snowflake_warehouse": "transform_l",
-        full_refresh: True
+        "full_refresh": True
     })
 }}
 

--- a/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
+++ b/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
@@ -5,19 +5,20 @@
         "incremental_strategy": "delete+insert",
         "unique_key": ['event_id'],
         "snowflake_warehouse": "transform_l",
-
+        full_refresh: True
     })
 }}
 
-    SELECT
-        {{ dbt_utils.star(ref('stg_mm_telemetry_prod__tracks'), except=["context_user_agent"]) }},
-        'stg_mm_telemetry_prod__tracks' AS _source_relation,
-        received_at::date AS received_at_date
-     FROM
-       {{ ref('stg_mm_telemetry_prod__tracks') }}
-    WHERE server_id = '{{ var("community_server_id") }}'
+SELECT
+    {{ dbt_utils.star(ref('stg_mm_telemetry_prod__tracks'), except=["context_user_agent"]) }},
+    'stg_mm_telemetry_prod__tracks' AS _source_relation,
+    received_at::date AS received_at_date
+ FROM
+   {{ ref('stg_mm_telemetry_prod__tracks') }}
+WHERE
+    server_id = '{{ var("community_server_id") }}'
 {% if is_incremental() %}
     AND received_at >= (SELECT MAX(received_at) FROM {{ this }})
-    -- Dedup events in the same batch
-    qualify row_number() over (partition by event_id order by timestamp desc) = 1
 {% endif %}
+-- Dedup events in the same batch
+qualify row_number() over (partition by event_id order by timestamp desc) = 1

--- a/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
+++ b/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
@@ -4,7 +4,9 @@
         "cluster_by": ['received_at_date'],
         "incremental_strategy": "delete+insert",
         "unique_key": ['event_id'],
-        "snowflake_warehouse": "transform_l"
+        "snowflake_warehouse": "transform_l",
+        "on_schema_change": 'append_new_columns',
+
     })
 }}
 
@@ -17,4 +19,6 @@
     WHERE server_id = '{{ var("community_server_id") }}'
 {% if is_incremental() %}
     AND received_at >= (SELECT MAX(received_at) FROM {{ this }})
+    -- Dedup events in the same batch
+    qualify row_number() over (partition by event_id order by timestamp desc) =
 {% endif %}

--- a/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
+++ b/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
@@ -19,5 +19,5 @@
 {% if is_incremental() %}
     AND received_at >= (SELECT MAX(received_at) FROM {{ this }})
     -- Dedup events in the same batch
-    qualify row_number() over (partition by event_id order by timestamp desc) =
+    qualify row_number() over (partition by event_id order by timestamp desc) = 1
 {% endif %}

--- a/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
+++ b/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_prod__community_tracks.sql
@@ -5,7 +5,6 @@
         "incremental_strategy": "delete+insert",
         "unique_key": ['event_id'],
         "snowflake_warehouse": "transform_l",
-        "on_schema_change": 'append_new_columns',
 
     })
 }}

--- a/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_rc__community_tracks.sql
+++ b/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_rc__community_tracks.sql
@@ -4,7 +4,8 @@
         "cluster_by": ['received_at_date'],
         "incremental_strategy": "delete+insert",
         "unique_key": ['event_id'],
-        "snowflake_warehouse": "transform_l"
+        "snowflake_warehouse": "transform_l",
+        "on_schema_change": 'append_new_columns',
     })
 }}
 

--- a/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_rc__community_tracks.sql
+++ b/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_rc__community_tracks.sql
@@ -5,7 +5,6 @@
         "incremental_strategy": "delete+insert",
         "unique_key": ['event_id'],
         "snowflake_warehouse": "transform_l",
-        "on_schema_change": 'append_new_columns',
     })
 }}
 

--- a/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_rc__community_tracks.sql
+++ b/transform/mattermost-analytics/models/intermediate/web_app/community/int_mm_telemetry_rc__community_tracks.sql
@@ -8,13 +8,13 @@
     })
 }}
 
-    SELECT
-        {{ dbt_utils.star(ref('stg_mm_telemetry_rc__tracks')) }},
-        'stg_mm_telemetry_rc__tracks' AS _source_relation,
-        received_at::date as received_at_date
-     FROM
-       {{ ref('stg_mm_telemetry_rc__tracks') }}
-    WHERE server_id = '{{ var("community_server_id") }}'
+SELECT
+    {{ dbt_utils.star(ref('stg_mm_telemetry_rc__tracks')) }},
+    'stg_mm_telemetry_rc__tracks' AS _source_relation,
+    received_at::date as received_at_date
+FROM
+   {{ ref('stg_mm_telemetry_rc__tracks') }}
+WHERE server_id = '{{ var("community_server_id") }}'
 {% if is_incremental() %}
     AND received_at >= (SELECT MAX(received_at) FROM {{ this }})
 {% endif %}


### PR DESCRIPTION
#### Summary

Hotfix: handle duplicates in same batch when performing incremental logic.

Note that merging this will require a full refresh in `+grp_performance_metrics`.