### PR TITLE
Hotfix: use uppercase database name

### DIFF
--- a/transform/mattermost-analytics/models/staging/mattermost_nps/_mattermost_nps__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mattermost_nps/_mattermost_nps__sources.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: mattermost_nps
-    database: raw
+    database: 'RAW'
     schema: mattermost_nps
     loader: Segment
     description: |

--- a/transform/mattermost-analytics/models/staging/mm_plugin_prod/_mm_plugin_prod__sources.yml
+++ b/transform/mattermost-analytics/models/staging/mm_plugin_prod/_mm_plugin_prod__sources.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: mm_plugin_prod
-    database: raw
+    database: 'RAW'
     schema: mm_plugin_prod
     loader: Rudderstack
     description: |

--- a/transform/mattermost-analytics/models/staging/salesforce/_salesforce__sources.yml
+++ b/transform/mattermost-analytics/models/staging/salesforce/_salesforce__sources.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: salesforce
-    database: analytics
+    database: 'ANALYTICS'
     schema: orgm_raw
     loader: Stitch
     description: |


### PR DESCRIPTION
#### Summary

Some of the database names were lowercase. Using uppercase to align with snowflake naming conventions.