### PR TITLE
Chore: Mark models as deprecated

### DIFF
--- a/transform/snowflake-dbt/models/qa/events_mobile_telemetry.sql
+++ b/transform/snowflake-dbt/models/qa/events_mobile_telemetry.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "qa",
-    "tags":"hourly"
+    "tags": ["hourly", "deprecated"]
   })
 }}
 

--- a/transform/snowflake-dbt/models/qa/events_web_desktop_telemetry.sql
+++ b/transform/snowflake-dbt/models/qa/events_web_desktop_telemetry.sql
@@ -1,7 +1,7 @@
 {{config({
     "materialized": "incremental",
     "schema": "qa",
-    "tags":"hourly"
+    "tags": ["hourly", "deprecated"]
   })
 }}
 


### PR DESCRIPTION
#### Summary

Marks models no longer used as deprecated.
